### PR TITLE
Set nodePort for Service

### DIFF
--- a/helm/prefect-orion/templates/api/service.yaml
+++ b/helm/prefect-orion/templates/api/service.yaml
@@ -9,5 +9,8 @@ spec:
   ports:
     - port: {{ .Values.api.service.port }}
       protocol: TCP
+{{ if (and (eq .Values.api.service.type "NodePort") (not (empty .Values.api.service.nodePort))) }}
+      nodePort: {{ .Values.api.service.nodePort }}
+{{ end }}
   selector:
     {{- include "orion.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Use `api.service.nodePort` to set `nodePort` for a NodePort Service.