### PR TITLE
Fix oversights regarding namespace and ports in templates

### DIFF
--- a/charts/prefect-agent/templates/agent/rbac.yaml
+++ b/charts/prefect-agent/templates/agent/rbac.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flow-runner-role-binding
-  namespace: default
+  namespace: {{ .Release.Namespace | quote }}
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: default
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: Role
   name: flow-runner

--- a/charts/prefect-agent/templates/agent/role.yaml
+++ b/charts/prefect-agent/templates/agent/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: default
+  namespace: {{ .Release.Namespace | quote }}
   name: flow-runner
 rules:
 - apiGroups: [""]

--- a/charts/prefect-orion/templates/api/deployment.yaml
+++ b/charts/prefect-orion/templates/api/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command: ["prefect", "orion", "start", "--host", "0.0.0.0", "--log-level", "WARNING"]
           ports:
-          - containerPort: 4200
+          - containerPort: {{ .Values.api.service.port }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           env:


### PR DESCRIPTION
I've fixes some minor oversights when setting the namespace and the port in the chart templates. Parameterised them - I hope I've done it correctly.