### PR TITLE
Fix display the prefect API URL in agents notes

### DIFF
--- a/charts/prefect-agent/templates/NOTES.txt
+++ b/charts/prefect-agent/templates/NOTES.txt
@@ -1,1 +1,1 @@
-1. Check Prefect agent connections in the prefect UI at {{ .Values.agent.apiUrl }}
+1. Check Prefect agent connections in the prefect UI at {{ .Values.agent.prefectApiUrl }}


### PR DESCRIPTION
Previously a non-existing key was referenced. I suppose `agent.prefectApiUrl` is the correct key.