### PR TITLE
Start orion server on specified port

### DIFF
--- a/charts/prefect-orion/templates/NOTES.txt
+++ b/charts/prefect-orion/templates/NOTES.txt
@@ -13,7 +13,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "orion.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "orion.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:{{ .Values.api.service.port }}
 {{- else if contains "ClusterIP" .Values.api.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "orion.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/charts/prefect-orion/templates/api/deployment.yaml
+++ b/charts/prefect-orion/templates/api/deployment.yaml
@@ -34,9 +34,9 @@ spec:
             {{- toYaml .Values.api.securityContext | nindent 12 }}
           image: "{{ .Values.api.image.name }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          command: ["prefect", "orion", "start", "--host", "0.0.0.0", "--log-level", "WARNING"]
+          command: ["prefect", "orion", "start", "--host", "0.0.0.0", "--log-level", "WARNING", "--port", {{ .Values.api.service.port | quote }}]
           ports:
-          - containerPort: {{ .Values.api.service.port }}
+          - containerPort: {{ int .Values.api.service.port }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Actually use specified port when starting server. I assume, this is what `api.service.port` is intended for?

Fix display of port in NOTES, as well.