### PR TITLE
Adapt env-unwrap function for orion

### DIFF
--- a/charts/prefect-orion/templates/_helpers.tpl
+++ b/charts/prefect-orion/templates/_helpers.tpl
@@ -85,7 +85,7 @@ Create the name of the service account to use
 {{- $key := upper $key -}}
 {{/* Create an environment variable if this is a leaf */}}
 {{- if ne (typeOf $val | toString) "map[string]interface {}" }}
-- name: {{ printf "%s__%s" $prefix $key }}
+- name: {{ printf "%s_%s" $prefix $key }}
   value: {{ $val | quote }}
 {{/* Otherwise, recurse into each child key with an updated prefix */}}
 {{- else -}}
@@ -166,6 +166,6 @@ secretKeyRef:
   valueFrom:
     {{- include "orion.postgres-secret-ref" . | nindent 4 }}
 {{- end }}    
-{{- $args := (dict "prefix" "PREFECT_SERVER" "map" .Values.prefectConfig) -}}
+{{- $args := (dict "prefix" "PREFECT_ORION" "map" .Values.prefectConfig) -}}
 {{- include "env-unwrap" $args -}}
 {{- end }}


### PR DESCRIPTION
Adapting the `env-unwrap` function to make sense for orion, i.e., setting `PREFECT_ORION_` env vars. I guess, this was a left-over from prefect-server?