### PR TITLE
fix: use prefect agent start -q

### DIFF
--- a/charts/prefect-agent/templates/agent/deployment.yaml
+++ b/charts/prefect-agent/templates/agent/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["prefect", "agent", "start", {{ .Values.config.workQueueName }}]
+          command: ["prefect", "agent", "start", "-q", {{ .Values.config.workQueueName }}]
           env:
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.config.debugEnabled | quote }}


### PR DESCRIPTION
to silence this startup message:
```
Agents now support multiple work queues. Instead of passing a single argument, 
provide work queue names with the `-q` or `--work-queue` flag: `prefect agent 
start -q kubernetes`
```