### PR TITLE
/opt/prefect needs to be writable for memo_store.toml

### DIFF
--- a/charts/prefect-orion/templates/deployment.yaml
+++ b/charts/prefect-orion/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           securityContext: {{- .Values.orion.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /opt/prefect/.prefect
+            - mountPath: /opt/prefect/
               name: orion-home
       volumes:
         - name: orion-home


### PR DESCRIPTION
Without this PR orion fails on startup:

```
ERROR:    Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 645, in lifespan
    async with self.lifespan_context(app):
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 540, in __aenter__
    await self._router.startup()
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 622, in startup
    await handler()
  File "/usr/local/lib/python3.10/site-packages/prefect/orion/api/server.py", line 288, in wrapper
    memo_store_path.write_text(
  File "/usr/local/lib/python3.10/pathlib.py", line 1154, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
  File "/usr/local/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
OSError: [Errno 30] Read-only file system: '/opt/prefect/memo_store.toml'
ERROR:    Application startup failed. Exiting.
Orion stopped!
```