### PR TITLE
Provide writable directories by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,6 +132,41 @@ Development versions of the Helm chart will always be available directly from th
 
 See comments in `values.yaml`.
 
+### Security Context
+
+By default, the agent and server run as an unprivileged user with a read-only root filesystem. You can customize the security context settings for both the agent and server in the `values.yaml` file for your use case.
+
+If you need to install system packages or configure other settings at runtime, you can configure a writable filesystem and run as root by configuring the pod and container security context accordingly:
+
+```yaml
+  podSecurityContext:
+    runAsUser: 0
+    runAsNonRoot: false
+    fsGroup: 0
+
+  containerSecurityContext:
+    runAsUser: 0
+    # this must be false, since we are running as root
+    runAsNonRoot: false
+    # make the filesystem writable
+    readOnlyRootFilesystem: false
+    # this must be false, since we are running as root
+    allowPrivilegeEscalation: false
+```
+
+If you are running in OpenShift, the default `restricted` security context constraint will prevent customization of the user. In this case, explicitly configure the `runAsUser` settings to `null` to use OpenShift-assigned settings:
+
+```yaml
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+
+  containerSecurityContext:
+    runAsUser: null
+```
+
+The other default settings, such as a read-only root filesystem, are suitable for an OpenShift environment.
+
 ## Troubleshooting
 
 ### The database deploys correctly but other services fail with "bad password"

--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -53,7 +53,10 @@ spec:
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.prefectTag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           command: ["prefect", "agent", "start", "-q", '{{ join "," .Values.agent.config.workQueues }}']
+          workingDir: /home/prefect
           env:
+            - name: HOME
+              value: /home/prefect
             - name: PREFECT_AGENT_PREFETCH_SECONDS
               value: {{ .Values.agent.config.prefetchSeconds | quote }}
             - name: PREFECT_AGENT_QUERY_INTERVAL
@@ -69,8 +72,6 @@ spec:
             {{- end }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.agent.image.debug | quote }}
-            - name: PREFECT_HOME
-              value: /opt/prefect
             {{- if .Values.agent.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.agent.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -90,8 +91,12 @@ spec:
           securityContext: {{- .Values.agent.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /opt/prefect/.prefect
-              name: agent-home
+            - mountPath: /home/prefect
+              name: scratch
+              subPathExpr: home
+            - mountPath: /tmp
+              name: scratch
+              subPathExpr: tmp
       volumes:
-        - name: agent-home
+        - name: scratch
           emptyDir: {}

--- a/charts/prefect-orion/templates/deployment.yaml
+++ b/charts/prefect-orion/templates/deployment.yaml
@@ -53,13 +53,14 @@ spec:
           image: "{{ .Values.orion.image.repository }}:{{ .Values.orion.image.prefectTag }}"
           imagePullPolicy: {{ .Values.orion.image.pullPolicy }}
           command: ["prefect", "orion", "start", "--host", "0.0.0.0", "--log-level", "WARNING", "--port", {{ .Values.service.port | quote }}]
+          workingDir: /home/prefect
           ports:
             - containerPort: {{ int .Values.service.port }}
           env:
+            - name: HOME
+              value: /home/prefect
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.orion.image.debug | quote }}
-            - name: PREFECT_HOME
-              value: /opt/prefect
             {{- if .Values.postgresql.enabled }}
             - name: PREFECT_ORION_DATABASE_CONNECTION_URL
               valueFrom:
@@ -86,8 +87,12 @@ spec:
           securityContext: {{- .Values.orion.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /opt/prefect/.prefect
-              name: orion-home
+            - mountPath: /home/prefect
+              name: scratch
+              subPathExpr: home
+            - mountPath: /tmp
+              name: scratch
+              subPathExpr: tmp
       volumes:
-        - name: orion-home
+        - name: scratch
           emptyDir: {}


### PR DESCRIPTION
Closes: #54 

---

## Orion

I've installed orion using the following command, to disable PostgreSQL:

`helm upgrade prefect-orion ./charts/prefect-orion --install --set=postgresql.enabled=false`

I then verified that orion starts successfully using SQLite:

```
$ kubectl exec -it deployment/prefect-orion -- ls -alR
.:
total 16
drwxrwsrwx 3 root 1001 4096 Oct  4 23:33 .
drwxr-xr-x 1 root root 4096 Oct  4 23:28 ..
-rw------- 1 1001 1001   34 Oct  4 23:33 .bash_history
drwxr-sr-x 2 1001 1001 4096 Oct  4 23:36 .prefect

./.prefect:
total 584
drwxr-sr-x 2 1001 1001   4096 Oct  4 23:36 .
drwxrwsrwx 3 root 1001   4096 Oct  4 23:33 ..
-rw-r--r-- 1 1001 1001     93 Oct  4 23:29 memo_store.toml
-rw-r--r-- 1 1001 1001 585728 Oct  4 23:29 orion.db
```

From filesystem mounts, both the home directory and tmp directory are available and writable:

```
$ kubectl exec -it deployment/prefect-orion -- findmnt | grep -E '(/tmp|home)'
├─/tmp /dev/sda1[/var/lib/kubelet/pods/8ed9efee-1f96-4c6b-a920-03f382656089/volumes/kubernetes.io~empty-dir/scratch/tmp]
├─/home/prefect
│      /dev/sda1[/var/lib/kubelet/pods/8ed9efee-1f96-4c6b-a920-03f382656089/volumes/kubernetes.io~empty-dir/scratch/home]
```

## Agent

I've installed the agent using the following command:

`helm upgrade prefect-agent ./charts/prefect-agent --install --set=agent.cloudApiConfig.accountId=aa44c164-ecc4-4c76-9c85-4a2f1835f36b --set=agent.cloudApiConfig.workspaceId=b97ece4a-c5a2-4430-95ff-b6e6eb20d7ea`

I verified that I can install packages:

```
$ kubectl exec -it deployment/prefect-agent -- pip install pytest
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: pytest in ./.local/lib/python3.10/site-packages (7.1.3)
Requirement already satisfied: attrs>=19.2.0 in /usr/local/lib/python3.10/site-packages (from pytest) (22.1.0)
Requirement already satisfied: iniconfig in ./.local/lib/python3.10/site-packages (from pytest) (1.1.1)
Requirement already satisfied: packaging in /usr/local/lib/python3.10/site-packages (from pytest) (21.3)
Requirement already satisfied: py>=1.8.2 in ./.local/lib/python3.10/site-packages (from pytest) (1.11.0)
Requirement already satisfied: pluggy<2.0,>=0.12 in ./.local/lib/python3.10/site-packages (from pytest) (1.0.0)
Requirement already satisfied: tomli>=1.0.0 in ./.local/lib/python3.10/site-packages (from pytest) (2.0.1)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.10/site-packages (from packaging->pytest) (3.0.9)
WARNING: You are using pip version 21.3.1; however, version 22.2.2 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```