### PR TITLE
feat: automate version bumps of dependent bitnami helm charts

### DIFF
--- a/.github/updatecli/manifest.yaml
+++ b/.github/updatecli/manifest.yaml
@@ -1,0 +1,39 @@
+---
+sources:
+  common:
+    kind: helmchart
+    spec:
+      url: "https://charts.bitnami.com/bitnami"
+      name: "common"
+      version: "2.*.*"
+    sourceid: common
+  postgresql:
+    kind: helmchart
+    spec:
+      url: "https://charts.bitnami.com/bitnami"
+      name: "postgresql"
+      version: "11.*.*"
+    sourceid: postgresql
+conditions: {}
+targets:
+  agent-common:
+    name: bump chart dependencies
+    kind: yaml
+    spec:
+      file: "charts/prefect-agent/Chart.yaml"
+      key: "dependencies[0].version"
+    sourceid: common
+  orion-common:
+    name: bump chart dependencies
+    kind: yaml
+    spec:
+      file: "charts/prefect-orion/Chart.yaml"
+      key: "dependencies[0].version"
+    sourceid: common
+  orion-postgresql:
+    name: bump chart dependencies
+    kind: yaml
+    spec:
+      file: "charts/prefect-orion/Chart.yaml"
+      key: "dependencies[1].version"
+    sourceid: postgresql

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -2,8 +2,6 @@
 name: "updatecli"
 
 on:
-  push:
-    branch: [bitnami-dependency-management]
   workflow_dispatch:
   schedule:
     - cron: "0 15 1 * *"

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -2,6 +2,8 @@
 name: "updatecli"
 
 on:
+  push:
+    branch: [bitnami-dependency-management]
   workflow_dispatch:
   schedule:
     - cron: "0 15 1 * *"

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -4,7 +4,7 @@ name: "updatecli"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 15 1 * *"
+    - cron: "0 15 1 * *" # The first of each month at 10am EST
 
 permissions:
   contents: write

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -1,0 +1,52 @@
+---
+name: "updatecli"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 15 1 * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: configure git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: create branch for helm version updates
+        run: |
+          git checkout -b "helm-version-${{ steps.date.outputs.date }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MARVIN_GITHUB_TOKEN }}
+
+      - name: install updatecli in the runner
+        uses: updatecli/updatecli-action@v2
+
+      - name: run updatecli in apply mode
+        run: |
+          updatecli apply --config .github/updatecli/manifest.yaml
+          git commit -am "helm-version-${{ steps.date.outputs.date }}"
+          git push --set-upstream origin "helm-version-${{ steps.date.outputs.date }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.MARVIN_GITHUB_TOKEN }}"
+
+      - name: create pr
+        run: |
+          git checkout "helm-version-${{ steps.date.outputs.date }}"
+          gh pr create --base main --title "helm-version-bump-${{ steps.date.outputs.date }}" -f
+        env:
+          GITHUB_TOKEN: ${{ secrets.MARVIN_GITHUB_TOKEN }}

--- a/charts/prefect-orion/Chart.yaml
+++ b/charts/prefect-orion/Chart.yaml
@@ -5,11 +5,11 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.0.2
+    version: 2.0.3
   - name: postgresql
     condition: postgresql.useSubChart
     repository: https://charts.bitnami.com/bitnami
-    version: "~11.6.2"
+    version: 11.9.6
 description: Prefect orion application bundle
 engine: gotpl
 home: https://github.com/PrefectHQ

--- a/charts/prefect-orion/README.md
+++ b/charts/prefect-orion/README.md
@@ -21,8 +21,8 @@ Prefect orion application bundle
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.0.2 |
-| https://charts.bitnami.com/bitnami | postgresql | ~11.6.2 |
+| https://charts.bitnami.com/bitnami | common | 2.0.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 11.9.6 |
 
 ## Values
 


### PR DESCRIPTION
also bumps prefect-orion dependent charts
- bitnami common from `2.0.2` to `2.0.3` 
- bitnami postgresql from `11.6.2` to `11.9.6`