### PR TITLE
Add volume mounts to deployments in agent and orion

### DIFF
--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -44,6 +44,8 @@ Prefect Agent application bundle
 | agent.extraEnvVars | list | `[]` | array with extra environment variables to add to agent nodes |
 | agent.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to agent nodes |
 | agent.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to agent nodes |
+| agent.extraVolumeMounts | string | `[]` | array with extra volume mounts to add to agent nodes |
+| agent.extraVolumes | string | `[]` | array with extra volumes to add to agent nodes |
 | agent.image.debug | bool | `false` | enable agent image debug mode |
 | agent.image.prefectTag | string | `"2-latest"` | prefect image tag (immutable tags are recommended) |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | agent image pull policy |

--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
             - mountPath: /tmp
               name: scratch
               subPathExpr: tmp
+            {{- if .Values.agent.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.agent.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: scratch
           emptyDir: {}
+        {{- if .Values.agent.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.agent.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -128,6 +128,12 @@ agent:
   # -- name of existing Secret containing extra env vars to add to agent nodes
   extraEnvVarsSecret: ""
 
+  # -- array with extra volume mounts to add to agent nodes
+  extraVolumeMounts: []
+
+  # -- array with extra volumes to add to agent nodes
+  extraVolumes: []
+  
 ## ServiceAccount configuration
 serviceAccount:
   # -- specifies whether a ServiceAccount should be created

--- a/charts/prefect-orion/README.md
+++ b/charts/prefect-orion/README.md
@@ -57,6 +57,8 @@ Prefect orion application bundle
 | orion.env | list | `[]` | array with environment variables to add to orion nodes |
 | orion.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to orion nodes |
 | orion.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to orion nodes |
+| agent.extraVolumeMounts | string | `[]` | array with extra volume mounts to add to agent nodes |
+| agent.extraVolumes | string | `[]` | array with extra volumes to add to agent nodes |
 | orion.image.debug | bool | `false` | enable orion image debug mode |
 | orion.image.prefectTag | string | `"2-latest"` | prefect image tag (immutable tags are recommended) |
 | orion.image.pullPolicy | string | `"IfNotPresent"` | orion image pull policy |

--- a/charts/prefect-orion/templates/deployment.yaml
+++ b/charts/prefect-orion/templates/deployment.yaml
@@ -93,6 +93,12 @@ spec:
             - mountPath: /tmp
               name: scratch
               subPathExpr: tmp
+            {{- if .Values.agent.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.agent.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: scratch
           emptyDir: {}
+        {{- if .Values.agent.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.agent.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/prefect-orion/values.yaml
+++ b/charts/prefect-orion/values.yaml
@@ -108,6 +108,12 @@ orion:
   # -- name of existing Secret containing extra env vars to add to orion nodes
   extraEnvVarsSecret: ""
 
+  # -- array with extra volume mounts to add to agent nodes
+  extraVolumeMounts: []
+
+  # -- array with extra volumes to add to agent nodes
+  extraVolumes: []
+
 ## ServiceAccount configuration
 serviceAccount:
   # -- specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Previously the charts did not allow adding additional volumes to deployments. This would be useful if nodes needed access to additional files, such as configurations or credentials.