### PR TITLE
chore: replace MARVIN_GITHUB_PAT with local token

### DIFF
--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git checkout -b "helm-version-${{ steps.date.outputs.date }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.MARVIN_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: install updatecli in the runner
         uses: updatecli/updatecli-action@v2
@@ -42,11 +42,11 @@ jobs:
           git commit -am "helm-version-${{ steps.date.outputs.date }}"
           git push --set-upstream origin "helm-version-${{ steps.date.outputs.date }}"
         env:
-          GITHUB_TOKEN: "${{ secrets.MARVIN_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
 
       - name: create pr
         run: |
           git checkout "helm-version-${{ steps.date.outputs.date }}"
           gh pr create --base main --title "helm-version-bump-${{ steps.date.outputs.date }}" -b "please run helm-docs locally to update chart readmes"
         env:
-          GITHUB_TOKEN: ${{ secrets.MARVIN_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/automatic-token-authentication

the workflow, which autogenerates a temp token to be used during the jobs, has these permissions scoped:

```
permissions:
  contents: write
  pull-requests: write
```