### PR TITLE
Complete extraTls support

### DIFF
--- a/charts/prefect-orion/README.md
+++ b/charts/prefect-orion/README.md
@@ -37,6 +37,7 @@ Prefect orion application bundle
 | ingress.extraHosts | list | `[]` | an array with additional hostname(s) to be covered with the ingress record |
 | ingress.extraPaths | list | `[]` | an array with additional arbitrary paths that may need to be added to the ingress under the main host |
 | ingress.extraRules | list | `[]` | additional rules to be covered with this ingress record |
+| ingress.extraTls | list | `[]` | an array with additional tls configuration to be added to the ingress record |
 | ingress.host.hostname | string | `"prefect.local"` | default host for the ingress record |
 | ingress.host.path | string | `"/"` | default path for the ingress record |
 | ingress.host.pathType | string | `"ImplementationSpecific"` | ingress path type |

--- a/charts/prefect-orion/templates/_helpers.tpl
+++ b/charts/prefect-orion/templates/_helpers.tpl
@@ -42,7 +42,7 @@ Create the name of the service account to use
 {{/*
   orion.postgres-string-secret-name:
     Get the name of the secret to be used for the postgresql
-    user password. Generates {release-name}-postgresql if
+    user password. Generates {release-name}-postgresql-connection if
     an existing secret is not set.
 */}}
 {{- define "orion.postgres-string-secret-name" -}}

--- a/charts/prefect-orion/templates/ingress.yaml
+++ b/charts/prefect-orion/templates/ingress.yaml
@@ -52,13 +52,13 @@ spec:
     {{- end }}
   {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:
-    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
     - hosts:
         - {{ .Values.ingress.host.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.host.hostname }}
     {{- end }}
-    {{- if .Values.ingress.extraTls -}}
-      {{ toYaml .Values.ingress.extraTls  | nindent 4 }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/prefect-orion/templates/ingress.yaml
+++ b/charts/prefect-orion/templates/ingress.yaml
@@ -57,5 +57,8 @@ spec:
         - {{ .Values.ingress.host.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.host.hostname }}
     {{- end }}
+    {{- if .Values.ingress.extraTls -}}
+      {{ toYaml .Values.ingress.extraTls  | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/prefect-orion/values.yaml
+++ b/charts/prefect-orion/values.yaml
@@ -188,6 +188,14 @@ ingress:
   ##     serviceName: ssl-redirect
   ##     servicePort: use-annotation
 
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  # -- an array with additional tls configuration to be added to the ingress record
+  extraTls: []
+  ## extraTls:
+  ## - hosts:
+  ##     - orion.local
+  ##   secretName: orion.local-tls
+
   ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
   # -- additional rules to be covered with this ingress record
   extraRules: []
@@ -201,8 +209,6 @@ ingress:
   ##           port:
   ##             name: http
 
-  # -- an array with additional tls configuration to be added to the ingress record
-  extraTls: []
 
 # Postgresql configuration
 postgresql:

--- a/charts/prefect-orion/values.yaml
+++ b/charts/prefect-orion/values.yaml
@@ -201,6 +201,9 @@ ingress:
   ##           port:
   ##             name: http
 
+  # -- an array with additional tls configuration to be added to the ingress record
+  extraTls: []
+
 # Postgresql configuration
 postgresql:
   enabled: true
@@ -209,9 +212,9 @@ postgresql:
     database: orion
     # -- name for a custom user to create
     username: prefect
-    ## This is the password for `username` and will be set within the secret at the key `{fullnameOverride}-postgresql-password`.
+    ## This is the password for `username` and will be set within the secret `{fullnameOverride}-postgresql` at the key `password`.
     ## This argument is only relevant when using the Postgres database included in the chart.
-    ## For an external postgres connection, you must create and use `existingSecret` instead of `postgresqlPassword`.
+    ## For an external postgres connection, you must create and use `existingSecret` instead.
     # -- password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided
     password: ""
 


### PR DESCRIPTION
Complete the support of the extraTls value which appears in the ingress.yaml. This is for example required to specify a custom secretName for the Tls certificate. For instance:
```
  tls: true
  extraTls:
    - hosts:
      - myhost.mydomain
      secretName: ingress-tls-myhost
```

Also clarify or correct some comments.