### PR TITLE
fix: use prefectTag for prefect version annotation

### DIFF
--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.agent.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: agent
-        prefect-version: {{ .Chart.AppVersion }}
+        prefect-version: {{ .Values.agent.image.prefectTag }}
         {{- if .Values.agent.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.agent.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/prefect-agent/templates/role.yaml
+++ b/charts/prefect-agent/templates/role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.agent.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-agent/templates/rolebinding.yaml
+++ b/charts/prefect-agent/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.agent.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-agent/templates/serviceaccount.yaml
+++ b/charts/prefect-agent/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.agent.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-orion/templates/deployment.yaml
+++ b/charts/prefect-orion/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: orion
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.orion.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: orion
-        prefect-version: {{ .Chart.AppVersion }}
+        prefect-version: {{ .Values.orion.image.prefectTag }}
         {{- if .Values.orion.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.orion.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/prefect-orion/templates/hpa.yaml
+++ b/charts/prefect-orion/templates/hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.orion.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-orion/templates/ingress.yaml
+++ b/charts/prefect-orion/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: orion
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.orion.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-orion/templates/secret.yaml
+++ b/charts/prefect-orion/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: orion
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.orion.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-orion/templates/service.yaml
+++ b/charts/prefect-orion/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: orion
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.orion.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-orion/templates/serviceaccount.yaml
+++ b/charts/prefect-orion/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: orion
-    prefect-version: {{ .Chart.AppVersion }}
+    prefect-version: {{ .Values.orion.image.prefectTag }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Closes #81 

Previously, at package time we supply the latest prefect version as the `prefectTag` value as well as the Chart `appVersion`.  The `appVersion` is then referenced by the downstream templates to create an annotation of the `prefect-version` on all resources.  This works fine, as long as the end user doesn't overwrite the `prefectTag` in the `values.yaml`.

However, it is reasonable to expect that an end user will want to overwrite the `prefectTag`, and therefore we should use that value as `prefect-version` annotation.