### PR TITLE
chore: add default resource request/limits

### DIFF
--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -59,8 +59,8 @@ Prefect Agent application bundle
 | agent.podSecurityContext.runAsNonRoot | bool | `true` | set agent pod's security context runAsNonRoot |
 | agent.podSecurityContext.runAsUser | int | `1001` | set agent pod's security context runAsUser |
 | agent.replicaCount | int | `1` | number of agent replicas to deploy |
-| agent.resources.limits | object | `{}` | the requested limits for the agent container |
-| agent.resources.requests | object | `{}` | the requested resources for the agent container |
+| agent.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the agent container |
+| agent.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the agent container |
 | agent.tolerations | list | `[]` | tolerations for agent pods assignment |
 | commonAnnotations | object | `{}` | annotations to add to all deployed objects |
 | commonLabels | object | `{}` | labels to add to all deployed objects |

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -70,9 +70,13 @@ agent:
 
   resources:
     # -- the requested resources for the agent container
-    requests: {}
+    requests:
+      memory: 256Mi
+      cpu: 100m
     # -- the requested limits for the agent container
-    limits: {}
+    limits:
+      memory: 1Gi
+      cpu: 1000m
 
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext:


### PR DESCRIPTION
Add resource requests and limits using figures from our internal data warehouse. Our agents use about 128 MiB, and a very small amount of CPU, so this should provide a reasonable starting point.

Closes: #85