### PR TITLE
add namespace to role binding

### DIFF
--- a/charts/prefect-agent/templates/rolebinding.yaml
+++ b/charts/prefect-agent/templates/rolebinding.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
     prefect-version: {{ .Values.agent.image.prefectTag }}


### PR DESCRIPTION
The rolebinding resource in the chart was missing the namespace in it's metadata.