### PR TITLE
Fixing base helm chart

### DIFF
--- a/charts/prefect-orion/README.md
+++ b/charts/prefect-orion/README.md
@@ -81,7 +81,7 @@ Prefect orion application bundle
 | postgresql.auth.database | string | `"orion"` | name for a custom database to create |
 | postgresql.auth.enablePostgresUser | bool | `false` | determines whether an admin user is created within postgres |
 | postgresql.auth.existingSecret | string | `nil` | Name of existing secret to use for PostgreSQL credentials. |
-| postgresql.auth.password | string | `""` | password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided |
+| postgresql.auth.password | string | `"password"` | password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided |
 | postgresql.auth.username | string | `"prefect"` | name for a custom user to create |
 | postgresql.containerPorts | object | `{"postgresql":5432}` | PostgreSQL container port |
 | postgresql.enabled | bool | `true` |  |

--- a/charts/prefect-orion/values.yaml
+++ b/charts/prefect-orion/values.yaml
@@ -227,7 +227,7 @@ postgresql:
     ## This argument is only relevant when using the Postgres database included in the chart.
     ## For an external postgres connection, you must create and use `existingSecret` instead.
     # -- password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided
-    password: ""
+    password: password
 
     ## This secret must contain two key-value pairs where the first key is `connection-string` and the value is the
     ## connection string containing your password (e.g. postgresql+asyncpg://{username}:{password}@{hostname}/{database}).


### PR DESCRIPTION
The base instructions for installing the helm chart are not working: 

```
(prefect) ➜  prefect-helm helm install prefect/prefect-orion --generate-name --debug
install.go:193: [debug] Original chart version: ""
install.go:210: [debug] CHART PATH: /Users/alee/Library/Caches/helm/repository/prefect-orion-2023.2.14.tgz

Error: INSTALLATION FAILED: execution error at (prefect-orion/templates/secret.yaml:18:24): .Values.postgresql.auth.password is required.
helm.go:84: [debug] execution error at (prefect-orion/templates/secret.yaml:18:24): .Values.postgresql.auth.password is required.
INSTALLATION FAILED
main.newInstallCmd.func2
	helm.sh/helm/v3/cmd/helm/install.go:141
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.6.1/command.go:916
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.6.1/command.go:1044
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.6.1/command.go:968
main.main
	helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
	runtime/proc.go:250
runtime.goexit
	runtime/asm_arm64.s:1172
```

This can be fixed by running something like:

```
(prefect) ➜  prefect-helm helm install prefect/prefect-orion --generate-name -f test.yaml
NAME: prefect-orion-1676574953
LAST DEPLOYED: Thu Feb 16 14:15:55 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=prefect-orion,app.kubernetes.io/instance=prefect-orion-1676574953" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace default $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace default port-forward $POD_NAME 8080:$CONTAINER_PORT
```

where `test.yaml` looks like: 

```
(prefect) ➜  prefect-helm more test.yaml
postgresql:
  auth:
    password: "password"
```

This PR attempts to fix this by adding a default string value of `password`.  Now the `prefect-orion` agent can be created:

```
(prefect) ➜  prefect-helm git:(westford14/helm_chart_postgres) kubectl create ns prefect-orion
namespace/prefect-orion created
(prefect) ➜  prefect-helm git:(westford14/helm_chart_postgres) helm install -n prefect-orion ./charts/prefect-orion -f charts/prefect-orion/values.yaml --generate-name
NAME: prefect-orion-1676576183
LAST DEPLOYED: Thu Feb 16 14:36:23 2023
NAMESPACE: prefect-orion
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace prefect-orion -l "app.kubernetes.io/name=prefect-orion,app.kubernetes.io/instance=prefect-orion-1676576183" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace prefect-orion $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace prefect-orion port-forward $POD_NAME 8080:$CONTAINER_PORT
```