### PR TITLE
correct condition for tls spec in ingress resource

### DIFF
--- a/charts/prefect-server/templates/ingress.yaml
+++ b/charts/prefect-server/templates/ingress.yaml
@@ -52,7 +52,7 @@ spec:
     {{- end }}
   {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:
-    {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+    {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) }}
     - hosts:
         - {{ .Values.ingress.host.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.host.hostname }}


### PR DESCRIPTION
Rollback of a last minute change in the PR #79. See my last comments.

@jamiezieziula has changed the condition in ingress.yaml which breaks the logic. With the current values:

```
ingress:
  enabled: true
  className: "nginx"
  host:
    hostname: myhost.mydomain
  tls: true
  extraTls:
    - hosts:
      - myhost.mydomain
      secretName: ingress-tls-myhost
```

Both conditions line 55 and line 60 would match, resulting in:

```
- hosts:
    - "myhost.mydomain"
  secretName: myhost.mydomain-tls
- hosts:
    - myhost.mydomain
  secretName: ingress-tls-myhost
```

Which does not make sense. Onemay want to define `.Values.ingress.extraTls` in order to set a specific `secretName` . 
