### PR TITLE
Look for agent.clusterUID instead of agent.clusterUUID in the deployment spec

### DIFF
--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: PREFECT_API_URL
               value: {{ template "agent.apiUrl" . }}
             - name: PREFECT_KUBERNETES_CLUSTER_UID
-              value: {{ template "agent.clusterUUID" . }}
+              value: {{ template "agent.clusterUID" . }}
             {{- if eq .Values.agent.apiConfig "cloud" }}
             - name: PREFECT_API_KEY
               valueFrom:

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -13,7 +13,7 @@ commonAnnotations: {}
 ## Deployment Configuration
 agent:
   # -- unique cluster identifier, if none is provided this value will be infered at time of helm install
-  clusterUid: ""
+  clusterUUID: ""
 
   image:
     # -- agent image repository

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -13,7 +13,7 @@ commonAnnotations: {}
 ## Deployment Configuration
 agent:
   # -- unique cluster identifier, if none is provided this value will be infered at time of helm install
-  clusterUUID: ""
+  clusterUid: ""
 
   image:
     # -- agent image repository


### PR DESCRIPTION
I think this is a typo.

Ref: https://github.com/PrefectHQ/prefect-helm/blob/98f7de9fdaeb09418782cf5864f564ffe9ad788e/charts/prefect-agent/templates/deployment.yaml#L83