### PR TITLE
feat: allow configuration of http2 connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### TL;DR
 
-``` bash
+```shell-session
 $ helm repo add prefect https://prefecthq.github.io/prefect-helm
 $ helm search repo prefect
 $ helm install my-release prefect/<chart>
@@ -12,58 +12,51 @@ $ helm install my-release prefect/<chart>
 
 ### Installing released versions
 
-Charts are automatically versioned and released together. The appVersion & `prefectTag` version are pinned at package time to the latest release of prefect 2.0.
+Charts are automatically versioned and released together. The `appVersion` and `prefectTag` version are pinned at package time to the current release of Prefect 2.
 
 The charts are hosted in a [Helm repository](https://helm.sh/docs/chart_repository/) deployed to the web courtesy of Github Pages.
 
-1. Let you local Helm manager know about the repository.
+1. Add the Prefect repository to Helm and list available charts and versions:
 
-    ```
-    $ helm repo add prefect https://prefecthq.github.io/prefect-helm/
-    ```
+   ```shell-session
+   $ helm repo add prefect https://prefecthq.github.io/prefect-helm/
+   $ helm repo update
+   $ helm search repo prefect
+   ```
 
-2. Sync versions available in the repo to your local cache.
+   **Note**: The repository includes a legacy `prefect-orion` chart, which no longer receives updates and will be removed in June 2023. Please use `prefect-server` instead.
 
-    ```
-    $ helm repo update
-    ```
+1. Install the Helm chart
 
-3. Search for available charts and versions
+   Using default options
 
-    ```
-    $ helm search repo prefect
-    ```
+   ```shell-session
+   $ helm install prefect/prefect-server --generate-name
+   ```
 
-4. Install the Helm chart
+   Setting some typical flags for customization
 
-    Using default options
-    ```
-    $ helm install prefect/prefect-server --generate-name
-    ```
+   ```bash
+   # The kubernetes namespace to install into, can be anything or excluded to install in the default namespace
+   NAMESPACE=prefect-server
+   # The Helm "release" name, can be anything but we recommend matching the chart name
+   NAME=prefect-server
+   # The path to your config that overrides values in `values.yaml`
+   CONFIG_PATH=path/to/your/config.yaml
+   # The chart version to install
+   VERSION=2023.03.30
 
-    Setting some typical flags for customization
+   helm install \
+     --namespace $NAMESPACE \
+     --version $VERSION \
+     --values $CONFIG_PATH \
+     $NAME \
+   prefect/prefect-server
+   ```
 
-    ```shell
-    # The kubernetes namespace to install into, can be anything or excluded to install in the default namespace
-    NAMESPACE=prefect-server
-    # The Helm "release" name, can be anything but we recommend matching the chart name
-    NAME=prefect-server
-    # The path to your config that overrides values in `values.yaml`
-    CONFIG_PATH=path/to/your/config.yaml
-    # The chart version to install
-    VERSION=2022.09.21
+If chart installation fails, run the same command with `--debug` to see additional diagnostic information.
 
-    helm install \
-        --namespace $NAMESPACE \
-        --version $VERSION \
-        --values $CONFIG_PATH \
-        $NAME \
-        prefect/prefect-server
-    ```
-
- If chart installation fails, `--debug` can provide more information_
-
- See [Helm install docs](https://helm.sh/docs/helm/helm_install/) for all options.
+Refer to the [Helm `install` documentation](https://helm.sh/docs/helm/helm_install/) for all options.
 
 ### Installing development versions
 
@@ -71,53 +64,54 @@ Development versions of the Helm chart will always be available directly from th
 
 1. Clone repository
 
-2. Change to this directory
+1. Change to this directory
 
-3. Download the chart dependencies
+1. Download the chart dependencies
 
-    ```
-    $ helm dependency update
-    ```
+   ```shell-session
+   $ helm dependency update
+   ```
 
-4. Install the chart
+1. Install the chart
 
-    ```
-    $ helm install . --generate-name
-    ```
+   ```shell-session
+   $ helm install . --generate-name
+   ```
 
 ### Upgrading
 
 1. Look up the name of the last release
 
-    ```
-    $ helm list
-    ```
+   ```shell-session
+   $ helm list
+   ```
 
-2. Run the upgrade
+1. Run the upgrade
 
-    ```shell
-    # Set this name to the name of your last Helm release
-    NAME=prefect-server
-    # Choose a version to upgrade to or omit the flag to use the latest version
-    VERSION=2022.09.21
+   ```bash
+   # Set this name to the name of your last Helm release
+   NAME=prefect-server
+   # Choose a version to upgrade to or omit the flag to use the latest version
+   VERSION=2023.03.30
 
-    helm upgrade $NAME prefect/prefect-server --version $VERSION
-    ```
+   helm upgrade $NAME prefect/prefect-server --version $VERSION
+   ```
 
-    For development versions, make sure your cloned repository is updated (`git pull`) and reference the local chart
-    ```
-    $ helm upgrade $NAME .
-    ```
+   For development versions, make sure your cloned repository is updated (`git pull`) and reference the local chart
 
-3. Upgrades can also be used enable features or change options
+   ```shell-session
+   $ helm upgrade $NAME .
+   ```
 
-    ```shell
-    NAME=prefect-server
+1. Upgrades can also be used enable features or change options
 
-    helm upgrade \
-        $NAME \
-        prefect/prefect-server
-    ```
+   ```bash
+   NAME=prefect-server
+
+   helm upgrade \
+     $NAME \
+     prefect/prefect-server
+   ```
 
 #### Important notes about upgrading
 
@@ -125,9 +119,9 @@ Development versions of the Helm chart will always be available directly from th
 - You will need to continue to set any values that you set during the original install (e.g. `--set agent.enabled=true` or `--values path/to/config.yaml`).
 - If you are using the postgresql subchart with an autogenerated password, it will complain that you have not provided that password for the upgrade.
   Export the password as the error asks then set it within the subchart using
-    ```
-    $ helm upgrade ... --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD
-    ```
+  ```shell-session
+  $ helm upgrade ... --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD
+  ```
 
 ## Options:
 

--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -37,7 +37,7 @@ Prefect Agent application bundle
 | agent.cloudApiConfig.cloudUrl | string | `"https://api.prefect.cloud/api"` | prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId |
 | agent.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | agent.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
-| agent.config.http2 | bool | `false` | connect using HTTP/2 if the server supports it (experimental) |
+| agent.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
 | agent.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | agent.config.queryInterval | int | `5` | how often the agent will query for runs |
 | agent.config.workPool | string | `""` | name of prefect workpool the agent will poll; if workpool or workqueues is not provided, we use the default queue |

--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -37,6 +37,7 @@ Prefect Agent application bundle
 | agent.cloudApiConfig.cloudUrl | string | `"https://api.prefect.cloud/api"` | prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId |
 | agent.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | agent.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
+| agent.config.http2 | bool | `false` | connect using HTTP/2 if the server supports it (experimental) |
 | agent.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | agent.config.queryInterval | int | `5` | how often the agent will query for runs |
 | agent.config.workPool | string | `""` | name of prefect workpool the agent will poll; if workpool or workqueues is not provided, we use the default queue |

--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{ .Values.agent.config.prefetchSeconds | quote }}
             - name: PREFECT_AGENT_QUERY_INTERVAL
               value: {{ .Values.agent.config.queryInterval | quote }}
+            - name: PREFECT_API_ENABLE_HTTP2
+              value: {{ .Values.agent.config.http2 | quote }}
             - name: PREFECT_API_URL
               value: {{ template "agent.apiUrl" . }}
             - name: PREFECT_KUBERNETES_CLUSTER_UID

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -48,7 +48,7 @@ agent:
     # -- when querying for runs, how many seconds in the future can they be scheduled
     prefetchSeconds: 10
     # -- connect using HTTP/2 if the server supports it (experimental)
-    http2: false
+    http2: true
 
   ## connection settings
   # -- one of 'cloud' or 'server'

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -47,6 +47,8 @@ agent:
     queryInterval: 5
     # -- when querying for runs, how many seconds in the future can they be scheduled
     prefetchSeconds: 10
+    # -- connect using HTTP/2 if the server supports it (experimental)
+    http2: false
 
   ## connection settings
   # -- one of 'cloud' or 'server'

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -46,7 +46,7 @@ Prefect Worker application bundle
 | worker.cloudApiConfig.cloudUrl | string | `"https://api.prefect.cloud/api"` | prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId |
 | worker.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | worker.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
-| worker.config.http2 | bool | `false` | connect using HTTP/2 if the server supports it (experimental) |
+| worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | worker.config.queryInterval | int | `5` | how often the agent will query for runs |
 | worker.config.workPool | string | `""` | name of prefect workpool the agent will poll; if workpool or workqueues is not provided, we use the default queue |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -46,6 +46,7 @@ Prefect Worker application bundle
 | worker.cloudApiConfig.cloudUrl | string | `"https://api.prefect.cloud/api"` | prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId |
 | worker.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | worker.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
+| worker.config.http2 | bool | `false` | connect using HTTP/2 if the server supports it (experimental) |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | worker.config.queryInterval | int | `5` | how often the agent will query for runs |
 | worker.config.workPool | string | `""` | name of prefect workpool the agent will poll; if workpool or workqueues is not provided, we use the default queue |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: {{ .Values.worker.config.prefetchSeconds | quote }}
             - name: PREFECT_AGENT_QUERY_INTERVAL
               value: {{ .Values.worker.config.queryInterval | quote }}
+            - name: PREFECT_API_ENABLE_HTTP2
+              value: {{ .Values.worker.config.http2 | quote }}
             - name: PREFECT_API_URL
               value: {{ template "worker.apiUrl" . }}
             - name: PREFECT_KUBERNETES_CLUSTER_UID

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -45,7 +45,7 @@ worker:
     # -- when querying for runs, how many seconds in the future can they be scheduled
     prefetchSeconds: 10
     # -- connect using HTTP/2 if the server supports it (experimental)
-    http2: false
+    http2: true
 
   ## connection settings
   # -- one of 'cloud' or 'server'

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -44,6 +44,8 @@ worker:
     queryInterval: 5
     # -- when querying for runs, how many seconds in the future can they be scheduled
     prefetchSeconds: 10
+    # -- connect using HTTP/2 if the server supports it (experimental)
+    http2: false
 
   ## connection settings
   # -- one of 'cloud' or 'server'


### PR DESCRIPTION
Add a value to configure the use of HTTP/2 if supported by the server, and disable it by default, as there are outstanding issues with httpx's support of HTTP/2.