### PR TITLE
feat: default to Chart AppVersion as tag

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -57,9 +57,6 @@ jobs:
       - name: Package Agent helm chart
         run: |
           mkdir -p /tmp/chart
-          cd charts
-          # Update the prefect version tag in values.yaml
-          sed -i "s/prefectTag:.*$/prefectTag: $PREFECT_VERSION-python3.10/g" prefect-agent/values.yaml
           helm package prefect-agent \
             --destination /tmp/chart \
             --dependency-update \
@@ -73,11 +70,11 @@ jobs:
           PREFECT_VERSION: ${{ steps.get_version.outputs.PREFECT_VERSION }}
           SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
           SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
+        working-directory: charts
 
       - name: Package Worker helm chart
         run: |
           mkdir -p /tmp/chart
-          cd charts
           helm package prefect-worker \
             --destination /tmp/chart \
             --dependency-update \
@@ -91,13 +88,11 @@ jobs:
           PREFECT_VERSION: ${{ steps.get_version.outputs.PREFECT_VERSION }}
           SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
           SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
+        working-directory: charts
 
       - name: Package Server helm chart
         run: |
           mkdir -p /tmp/chart
-          cd charts
-          # Update the prefect version tag in values.yaml
-          sed -i "s/prefectTag:.*$/prefectTag: $PREFECT_VERSION-python3.10/g" prefect-server/values.yaml
           helm package prefect-server \
             --destination /tmp/chart \
             --dependency-update \
@@ -111,6 +106,7 @@ jobs:
           PREFECT_VERSION: ${{ steps.get_version.outputs.PREFECT_VERSION }}
           SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
           SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
+        working-directory: charts
 
       - name: Update chart index
         run: |

--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -53,7 +53,7 @@ Prefect Agent application bundle
 | agent.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the agent pod |
 | agent.extraVolumes | list | `[]` | array with extra volumes for the agent pod |
 | agent.image.debug | bool | `false` | enable agent image debug mode |
-| agent.image.prefectTag | string | `"2-latest"` | prefect image tag (immutable tags are recommended) |
+| agent.image.prefectTag | string | `""` | as the tag, unless overridden here (immutable tags are recommended) |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | agent image pull policy |
 | agent.image.pullSecrets | list | `[]` | agent image pull secrets |
 | agent.image.repository | string | `"prefecthq/prefect"` | agent image repository |

--- a/charts/prefect-agent/templates/_helpers.tpl
+++ b/charts/prefect-agent/templates/_helpers.tpl
@@ -33,3 +33,11 @@ Create the name of the service account to use
 {{- (lookup "v1" "Namespace" "" "kube-system" | default $defaultDict).metadata.uid | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+  agent.imageTag:
+    Define image tag either from appVersion or imageTag value
+*/}}
+{{- define "agent.imageTag" }}
+{{- .Values.agent.image.prefectTag | default .Chart.AppVersion }}
+{{- end }}

--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Values.agent.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "agent.imageTag" . | quote }}
+    prefect-version: {{ include "agent.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -24,7 +25,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: agent
-        prefect-version: {{ .Values.agent.image.prefectTag }}
+        prefect-version: {{ include "agent.imageTag" . | quote }}
         {{- if .Values.agent.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.agent.podLabels "context" $) | nindent 8 }}
         {{- end }}
@@ -50,7 +51,7 @@ spec:
       {{- end }}
       containers:
         - name: prefect-agent
-          image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.prefectTag }}"
+          image: "{{ .Values.agent.image.repository }}:{{ template "agent.imageTag" . }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           command:
             - prefect

--- a/charts/prefect-agent/templates/role.yaml
+++ b/charts/prefect-agent/templates/role.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Values.agent.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "agent.imageTag" . | quote }}
+    prefect-version: {{ include "agent.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-agent/templates/rolebinding.yaml
+++ b/charts/prefect-agent/templates/rolebinding.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Values.agent.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "agent.imageTag" . | quote }}
+    prefect-version: {{ include "agent.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-agent/templates/serviceaccount.yaml
+++ b/charts/prefect-agent/templates/serviceaccount.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent
-    prefect-version: {{ .Values.agent.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "agent.imageTag" . | quote }}
+    prefect-version: {{ include "agent.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -18,10 +18,9 @@ agent:
   image:
     # -- agent image repository
     repository: prefecthq/prefect
-    ## prefect tag is pinned to the latest available image tag at packaging time.  Update the value here to
-    ## override pinned tag
-    # -- prefect image tag (immutable tags are recommended)
-    prefectTag: 2-latest
+    # -- by default, the chart will use the appVersion defined in the Chart.yaml
+    # -- as the tag, unless overridden here (immutable tags are recommended)
+    prefectTag: ""
     # -- agent image pull policy
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -77,7 +77,7 @@ Prefect server application bundle
 | server.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the server pod |
 | server.extraVolumes | list | `[]` | array with extra volumes for the server pod |
 | server.image.debug | bool | `false` | enable server image debug mode |
-| server.image.prefectTag | string | `"2-latest"` | prefect image tag (immutable tags are recommended) |
+| server.image.prefectTag | string | `""` | as the tag, unless overridden here (immutable tags are recommended) |
 | server.image.pullPolicy | string | `"IfNotPresent"` | server image pull policy |
 | server.image.pullSecrets | list | `[]` | server image pull secrets |
 | server.image.repository | string | `"prefecthq/prefect"` | server image repository |

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -53,3 +53,11 @@ Create the name of the service account to use
   {{- printf "%s-%s" $name "postgresql-connection" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  server.imageTag:
+    Define image tag either from appVersion or imageTag value
+*/}}
+{{- define "server.imageTag" }}
+{{- .Values.server.image.prefectTag | default .Chart.AppVersion }}
+{{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
-    prefect-version: {{ .Values.server.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "server.imageTag" . | quote }}
+    prefect-version: {{ include "server.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -24,7 +25,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: server
-        prefect-version: {{ .Values.server.image.prefectTag }}
+        prefect-version: {{ include "server.imageTag" . | quote }}
         {{- if .Values.server.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.server.podLabels "context" $) | nindent 8 }}
         {{- end }}
@@ -50,7 +51,7 @@ spec:
       {{- end }}
       containers:
         - name: prefect-server
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.prefectTag }}"
+          image: "{{ .Values.server.image.repository }}:{{ template "server.imageTag" . }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command: ["prefect", "server", "start", "--host", "0.0.0.0", "--log-level", "WARNING", "--port", {{ .Values.service.port | quote }}]
           workingDir: /home/prefect

--- a/charts/prefect-server/templates/hpa.yaml
+++ b/charts/prefect-server/templates/hpa.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    prefect-version: {{ .Values.server.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "server.imageTag" . | quote }}
+    prefect-version: {{ include "server.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-server/templates/ingress.yaml
+++ b/charts/prefect-server/templates/ingress.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
-    prefect-version: {{ .Values.server.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "server.imageTag" . | quote }}
+    prefect-version: {{ include "server.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-server/templates/secret.yaml
+++ b/charts/prefect-server/templates/secret.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
-    prefect-version: {{ .Values.server.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "server.imageTag" . | quote }}
+    prefect-version: {{ include "server.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-server/templates/service.yaml
+++ b/charts/prefect-server/templates/service.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
-    prefect-version: {{ .Values.server.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "server.imageTag" . | quote }}
+    prefect-version: {{ include "server.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-server/templates/serviceaccount.yaml
+++ b/charts/prefect-server/templates/serviceaccount.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
-    prefect-version: {{ .Values.server.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "server.imageTag" . | quote }}
+    prefect-version: {{ include "server.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -15,10 +15,9 @@ server:
   image:
     # -- server image repository
     repository: prefecthq/prefect
-    ## prefect tag is pinned to the latest available image tag at packaging time.  Update the value here to
-    ## override pinned tag
-    # -- prefect image tag (immutable tags are recommended)
-    prefectTag: 2-latest
+    # -- by default, the chart will use the appVersion defined in the Chart.yaml
+    # -- as the tag, unless overridden here (immutable tags are recommended)
+    prefectTag: ""
     # -- server image pull policy
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -61,7 +61,7 @@ Prefect Worker application bundle
 | worker.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the agent pod |
 | worker.extraVolumes | list | `[]` | array with extra volumes for the agent pod |
 | worker.image.debug | bool | `false` | enable agent image debug mode |
-| worker.image.prefectTag | string | `"2-python3.11-kubernetes"` | prefect image tag (immutable tags are recommended) |
+| worker.image.prefectTag | string | `""` | as the tag, unless overridden here (immutable tags are recommended) |
 | worker.image.pullPolicy | string | `"IfNotPresent"` | agent image pull policy |
 | worker.image.pullSecrets | list | `[]` | agent image pull secrets |
 | worker.image.repository | string | `"prefecthq/prefect"` | agent image repository |

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -33,3 +33,11 @@ Create the name of the service account to use
 {{- (lookup "v1" "Namespace" "" "kube-system" | default $defaultDict).metadata.uid | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+  worker.imageTag:
+    Define image tag either from appVersion or imageTag value
+*/}}
+{{- define "worker.imageTag" }}
+{{- .Values.worker.image.prefectTag | default .Chart.AppVersion }}
+{{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
-    prefect-version: {{ .Values.worker.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "worker.imageTag" . | quote }}
+    prefect-version: {{ include "worker.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -24,7 +25,8 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: worker
-        prefect-version: {{ .Values.worker.image.prefectTag }}
+        app.kubernetes.io/version: {{ include "worker.imageTag" . | quote }}
+        prefect-version: {{ include "worker.imageTag" . | quote }}
         {{- if .Values.worker.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.podLabels "context" $) | nindent 8 }}
         {{- end }}
@@ -50,7 +52,7 @@ spec:
       {{- end }}
       containers:
         - name: prefect-worker
-          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.prefectTag }}"
+          image: "{{ .Values.worker.image.repository }}:{{ template "worker.imageTag" . }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           command:
             - prefect

--- a/charts/prefect-worker/templates/role.yaml
+++ b/charts/prefect-worker/templates/role.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
-    prefect-version: {{ .Values.worker.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "worker.imageTag" . | quote }}
+    prefect-version: {{ include "worker.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-worker/templates/rolebinding.yaml
+++ b/charts/prefect-worker/templates/rolebinding.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
-    prefect-version: {{ .Values.worker.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "worker.imageTag" . | quote }}
+    prefect-version: {{ include "worker.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-worker/templates/serviceaccount.yaml
+++ b/charts/prefect-worker/templates/serviceaccount.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
-    prefect-version: {{ .Values.worker.image.prefectTag }}
+    app.kubernetes.io/version: {{ include "worker.imageTag" . | quote }}
+    prefect-version: {{ include "worker.imageTag" . | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -18,10 +18,9 @@ worker:
   image:
     # -- agent image repository
     repository: prefecthq/prefect
-    ## prefect tag is pinned to the latest available image tag at packaging time.  Update the value here to
-    ## override pinned tag
-    # -- prefect image tag (immutable tags are recommended)
-    prefectTag: 2-python3.11-kubernetes
+    # -- by default, the chart will use the appVersion defined in the Chart.yaml
+    # -- as the tag, unless overridden here (immutable tags are recommended)
+    prefectTag: ""
     # -- agent image pull policy
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
* Add standard app.kubernetes.io/version label
* Use the chart's appVersion as the image tag if prefectTag is not set, simplifying the chart packaging process