### PR TITLE
chore: remove support for 1.22 HPA

### DIFF
--- a/charts/prefect-server/templates/hpa.yaml
+++ b/charts/prefect-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.server.autoscaling.enabled .Values.server.resources.requests }}
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -24,24 +24,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.server.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
In Kubernetes 1.23 (released on December 7, 2021 and end-of-life on February 28, 2023), HorizontalPodAutoscaler was promoted to General Availability. Given that the oldest Kubernetes release supported by the upstream maintainers is version 1.25, we are dropping support for the v2beta2 HPA.

Resolves: #148

---

See also:

* [Kubernetes 1.23: The Next Frontier Release Notes - HorizontalPodAutoscaler v2 graduates to GA](https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/#horizontalpodautoscaler-v2-graduates-to-ga)
* [Kubernetes Patch Release Schedule](https://kubernetes.io/releases/patch-releases/)
* [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/)