### PR TITLE
Fix indentation error in yaml snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ If you are running flows on your agent’s pod (i.e. with Process infrastructure
 role:
   extraPermissions:
     - apiGroups: [""]
-    resources: ["pods", "services"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      resources: ["pods", "services"]
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
     - apiGroups: ["policy"]
-    resources: ["poddisruptionbudgets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      resources: ["poddisruptionbudgets"]
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ```
 
 ## Version Support Policy


### PR DESCRIPTION
Fixed format in YAML snippet in *security context* section of README.md.