### PR TITLE
set http2 to default false

### DIFF
--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -45,7 +45,7 @@ worker:
     # -- when querying for runs, how many seconds in the future can they be scheduled
     prefetchSeconds: 10
     # -- connect using HTTP/2 if the server supports it (experimental)
-    http2: true
+    http2: false
 
   ## connection settings
   # -- one of 'cloud' or 'server'


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/issues/7442
https://github.com/encode/httpx/discussions/2112

considering that the above two issues mean that using `http2: true` leads consistently to irrecoverable worker failures, I think the default should be false