### PR TITLE
fix: appUrl for `NOTES.txt` shown on install

### DIFF
--- a/charts/prefect-worker/templates/NOTES.txt
+++ b/charts/prefect-worker/templates/NOTES.txt
@@ -1,1 +1,1 @@
-1. Check Prefect worker connections in the prefect UI at {{ template "worker.apiUrl" . }}
+1. Check Prefect worker connections in the prefect UI at {{ template "worker.appUrl" . }}

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -22,6 +22,16 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+  worker.appUrl:
+    Define APP URL for cloud worker install
+*/}}
+{{- define "worker.appUrl" -}}
+{{- if eq .Values.worker.apiConfig "cloud" }}
+{{- printf "https://app.prefect.cloud/account/%s/workspace/%s" .Values.worker.cloudApiConfig.accountId .Values.worker.cloudApiConfig.workspaceId | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
   worker.clusterUUID:
     Define cluster UID either from user-defined UID or by doing a lookup at helm install time
 */}}


### PR DESCRIPTION
previously the api url was shown on install via `NOTES.txt`, where you cannot click to see the status of your worker

Resolves #177 