### PR TITLE
fix: show clickable url on install

### DIFF
--- a/charts/prefect-worker/templates/NOTES.txt
+++ b/charts/prefect-worker/templates/NOTES.txt
@@ -1,1 +1,1 @@
-1. Check Prefect worker connections in the prefect UI at {{ template "worker.apiUrl" . }}
+1. Check Prefect worker connections in the prefect UI at {{ template "worker.appUrl" . }}

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -22,6 +22,16 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+  worker.appUrl:
+    Define APP URL for cloud worker install
+*/}}
+{{- define "worker.appUrl" -}}
+{{- if eq .Values.worker.apiConfig "cloud" }}
+{{- printf "https://app.prefect.cloud/account/%s/workspace/%s" .Values.worker.cloudApiConfig.accountId .Values.worker.cloudApiConfig.workspaceId | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
   worker.clusterUUID:
     Define cluster UID either from user-defined UID or by doing a lookup at helm install time
 */}}

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -28,8 +28,11 @@ Create the name of the service account to use
 {{- define "worker.appUrl" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
 {{- printf "https://app.prefect.cloud/account/%s/workspace/%s" .Values.worker.cloudApiConfig.accountId .Values.worker.cloudApiConfig.workspaceId | quote }}
+{{- else }}
+{{- .Values.worker.serverApiConfig.apiUrl | quote }}
 {{- end }}
 {{- end }}
+
 
 {{/*
   worker.clusterUUID:


### PR DESCRIPTION
closes #183 

```python
❯ cat prefect-worker/values.yaml | rg testval
    accountId: "testval"
    workspaceId: "testval"
❯ helm install my-local-worker ./prefect-worker

NAME: my-local-worker
LAST DEPLOYED: Wed Jun 28 10:35:04 2023
NAMESPACE: test
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Check Prefect worker connections in the prefect UI at "https://app.prefect.cloud/account/testval/workspace/testval"
```