### PR TITLE
fix: preserve default entrypoint

### DIFF
--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.prefectTag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           command:
+            - /usr/bin/tini
+            - -g
+            - --
+            - /opt/prefect/entrypoint.sh
+          args:
             - prefect
             - agent
             - start

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -55,7 +55,21 @@ spec:
         - name: prefect-server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.prefectTag }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-          command: ["prefect", "server", "start", "--host", "0.0.0.0", "--log-level", "WARNING", "--port", {{ .Values.service.port | quote }}]
+          command:
+            - /usr/bin/tini
+            - -g
+            - --
+            - /opt/prefect/entrypoint.sh
+          args:
+            - prefect
+            - server
+            - start
+            - --host
+            - 0.0.0.0
+            - --log-level
+            - WARNING
+            - --port
+            - {{ .Values.service.port | quote }}
           workingDir: /home/prefect
           ports:
             - containerPort: {{ int .Values.service.port }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.prefectTag }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           command:
+            - /usr/bin/tini
+            - -g
+            - --
+            - /opt/prefect/entrypoint.sh
+          args:
             - prefect
             - worker
             - start


### PR DESCRIPTION
* Use the default entrypoint script, so that we install packages correctly (Closes: #182)
* Define the default entrypoint as command, and pass Prefect server/agent/worker commands via args, consistent with running the container image via Docker/Podman (Closes: #170)