### PR TITLE
fix: avoid setting limit unless set in values

### DIFF
--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -38,7 +38,7 @@ Prefect Agent application bundle
 | agent.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | agent.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
 | agent.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
-| agent.config.limit | string | `"None"` | Maximum number of flow runs to start simultaneously (default: unlimited) |
+| agent.config.limit | string | `nil` | Maximum number of flow runs to start simultaneously (default: unlimited) |
 | agent.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | agent.config.queryInterval | int | `5` | how often the agent will query for runs |
 | agent.config.workPool | string | `""` | name of prefect workpool the agent will poll; if workpool or workqueues is not provided, we use the default queue |

--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -77,8 +77,10 @@ spec:
             - --work-queue
             - "default"
             {{- end }}
+            {{- if .Values.agent.config.limit }}
             - --limit
             - {{ .Values.agent.config.limit | quote }}
+            {{- end }}
           workingDir: /home/prefect
           env:
             - name: HOME

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -50,7 +50,7 @@ agent:
     # -- connect using HTTP/2 if the server supports it (experimental)
     http2: true
     # -- Maximum number of flow runs to start simultaneously (default: unlimited)
-    limit: None
+    limit: null
 
   ## connection settings
   # -- one of 'cloud' or 'server'

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -51,7 +51,7 @@ Prefect Worker application bundle
 | worker.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | worker.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
-| worker.config.limit | string | `"None"` | Maximum number of flow runs to start simultaneously (default: unlimited) |
+| worker.config.limit | string | `nil` | Maximum number of flow runs to start simultaneously (default: unlimited) |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | worker.config.queryInterval | int | `5` | how often the worker will query for runs |
 | worker.config.workPool | string | `""` | name of prefect work pool the worker will poll |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -68,8 +68,10 @@ spec:
             - kubernetes
             - --pool
             - {{ .Values.worker.config.workPool | quote }}
+            {{- if .Values.worker.config.limit }}
             - --limit
             - {{ .Values.worker.config.limit | quote }}
+            {{- end }}
             {{- if .Values.worker.livenessProbe.enabled }}
             - --with-healthcheck
             {{- end }}

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -46,7 +46,7 @@ worker:
     # -- connect using HTTP/2 if the server supports it (experimental)
     http2: true
     # -- Maximum number of flow runs to start simultaneously (default: unlimited)
-    limit: None
+    limit: null
 
   ## connection settings
   # -- one of 'cloud' or 'server'


### PR DESCRIPTION
The default value for --limit configured in our typer.Option is None; however, users cannot explicitly set the value to None: https://github.com/tiangolo/typer/issues/530

Closes: #192