### PR TITLE
fix: typo in prefect-server chart

### DIFF
--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.server.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.server.extraContainers }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.agent.extraContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.server.extraContainers "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         - name: scratch


### PR DESCRIPTION
Include extracontainers from server and not agent