### PR TITLE
chore: fix typos in worker test

### DIFF
--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -45,4 +45,4 @@ jobs:
           kubectl create secret generic prefect-api-key  --from-literal=key=${{ secrets.PREFECT_CLOUD_API_KEY }} -n prefect
 
       - name: Run chart-testing (install)
-        run: ct install --config .github/linters/worker-ct.yaml --helm-extra-set-args "--set=worker.config.workPool=test-helm --set=agent.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=agent.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }}"
+        run: ct install --config .github/linters/worker-ct.yaml --helm-extra-set-args "--set=worker.config.workPool=test-helm --set=worker.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=worker.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }}"


### PR DESCRIPTION
The values provided when installing the worker chart were for the agent, not the worker.