### PR TITLE
Enable exposing prefect-server with Loadbalancer

### DIFF
--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
             - name: PREFECT_UI_API_URL
               value: {{ .Values.server.publicApiUrl | quote }}
             {{- end }}
+            {{- if .Values.server.apiHost }}
+            - name: PREFECT_SERVER_API_HOST
+              value: {{ .Values.server.apiHost | quote }}
+            {{- end }}
             {{- if .Values.postgresql.enabled }}
             - name: PREFECT_API_DATABASE_CONNECTION_URL
               valueFrom:

--- a/charts/prefect-server/templates/service.yaml
+++ b/charts/prefect-server/templates/service.yaml
@@ -26,6 +26,9 @@ spec:
   {{- if eq .Values.service.type "NodePort" }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
   ports:
     - name: server-svc-port
       port: {{ .Values.service.port }}
@@ -34,6 +37,8 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
+      {{- else if eq .Values.service.type "LoadBalancer" }}
+      targetPort: {{ .Values.service.targetPort }}
       {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -38,6 +38,8 @@ server:
 
   # -- sets PREFECT_UI_API_URL; should be publicly accessible API URL; UI will not work unless set
   publicApiUrl: ""
+  # -- set PREFECT_API_HOST to something other than 127.0.0.1
+  apiHost: ""
 
   # -- array with environment variables to add to server nodes
   env: []
@@ -171,10 +173,13 @@ service:
   clusterIP: ""
   # -- service port if defining service as type nodeport
   nodePort: ""
+  # -- Loadbalancer IP if defining service using type LoadBalancer
+  loadBalancerIP: ""
+  targetPort: 4200
 
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # -- service external traffic policy
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: default Cluster
   ## -- additional custom annotations for server service
   annotations: {}
 
@@ -275,8 +280,7 @@ postgresql:
     postgresql: 5432
 
   # externalHostname defines the address to contact an externally
-  # managed postgres database instance at. This is not required if
-  # `internalPostgres` is `true`
+  # managed postgres database instance at.
   externalHostname: ""
 
   # -- enable use of bitnami/postgresql subchart

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -179,7 +179,7 @@ service:
 
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # -- service external traffic policy
-  externalTrafficPolicy: default Cluster
+  externalTrafficPolicy: Cluster
   ## -- additional custom annotations for server service
   annotations: {}
 


### PR DESCRIPTION
Also enable setting prefect's `APIHost` value and k8s service `targetPort` value. 

Example values.yaml to install with this (using a MetalLB LoadBalancer, and an existing, in-cluster Postgres db):
```
fullnameOverride: "prefect-server"
namespaceOverride: "prefect-server"

postgresql:
  enabled: true
  useSubChart: false
  auth:
    existingSecret: prefect-postgres-auth
  externalHostname: postgresql

service:
  type: LoadBalancer
  loadBalancerIP: 192.168.1.11
  annotations:
    metallb.universe.tf/address-pool: exposed-pool

server:
  publicApiUrl: "http://prefect-server.example.com:4200/api"
  apiHost: "prefect-server.example.com"
  image:
    prefectTag: 2.8-python3.11
``` 