### PR TITLE
Added the ability to specify the worker type

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -54,6 +54,7 @@ Prefect Worker application bundle
 | worker.config.limit | string | `nil` | Maximum number of flow runs to start simultaneously (default: unlimited) |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | worker.config.queryInterval | int | `5` | how often the worker will query for runs |
+| worker.config.type | string | `"kubernetes"` | specify the worker type |
 | worker.config.workPool | string | `""` | the work pool that your started worker will poll. |
 | worker.config.workQueues | list | `[]` | one or more work queue names for the worker to pull from. if not provided, the worker will pull from all work queues in the work pool |
 | worker.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set worker containers' security context allowPrivilegeEscalation |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - worker
             - start
             - --type
-            - kubernetes
+            - {{ .Values.worker.config.type | quote }}
             - --pool
             - {{ .Values.worker.config.workPool | quote }}
             {{- range .Values.worker.config.workQueues }}

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -49,6 +49,10 @@ worker:
     http2: true
     # -- Maximum number of flow runs to start simultaneously (default: unlimited)
     limit: null
+    ## You can set the worker type here. Custom workers must be properly registered with the prefect cli.
+    ## See the guide here: https://docs.prefect.io/2.11.3/guides/deployment/developing-a-new-worker-type/
+    # -- specify the worker type
+    type: kubernetes
 
   ## connection settings
   # -- one of 'cloud' or 'server'

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -49,7 +49,9 @@ worker:
     http2: true
     # -- Maximum number of flow runs to start simultaneously (default: unlimited)
     limit: null
-    ## You can set the worker type here. Custom workers must be properly registered with the prefect cli.
+    ## You can set the worker type here.
+    ## The default image includes only the type "kubernetes".
+    ## Custom workers must be properly registered with the prefect cli.
     ## See the guide here: https://docs.prefect.io/2.11.3/guides/deployment/developing-a-new-worker-type/
     # -- specify the worker type
     type: kubernetes


### PR DESCRIPTION
I need the ability to specify the worker type since we implemented our own custom worker. We use our own custom image which ships this custom worker. I want to start the worker now but unfortunately this is not possible since "kubernetes" worker type is hardcoded. Right now, I have simply copy&pasted this chart and adjusted it the way i see fit. However, I think this should be included here. This PR does exactly this. Happy to hear feedback