### PR TITLE
enhancement: Add required functions to worker template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ Chart.lock
 # IDEs
 .vscode/
 .idea/
+
+# macs
+.DS_Store

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -189,8 +189,8 @@ Workers each have a type corresponding to the execution environment to which the
 | worker.replicaCount | int | `1` | number of worker replicas to deploy |
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
-| worker.serverConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
-| worker.serverConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url |
+| worker.serverApiConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
+| worker.serverApiConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url |
 | worker.tolerations | list | `[]` | tolerations for worker pods assignment |
 
 ----------------------------------------------

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -189,12 +189,8 @@ Workers each have a type corresponding to the execution environment to which the
 | worker.replicaCount | int | `1` | number of worker replicas to deploy |
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
-| worker.serverConfig.apiUrl.fullyQualifiedEndpoint | string | `""` | The fully qualified Prefect API url (PREFECT_API_URL), external to the cluster |
-| worker.serverConfig.apiUrl.prefectServer | object | `{"namespace":"prefect","serviceName":"prefect-server","servicePort":"4200"}` | The prefect API url (PREFECT_API_URL); the full URL is constructed as http://serviceName.namespace.svc.cluster.local:4200/api |
-| worker.serverConfig.apiUrl.prefectServer.namespace | string | `"prefect"` | The namespace where the prefect server pod is deployed |
-| worker.serverConfig.apiUrl.prefectServer.serviceName | string | `"prefect-server"` | The name of the prefect server service |
-| worker.serverConfig.apiUrl.prefectServer.servicePort | string | `"4200"` | The service port of the prefect server service |
-| worker.serverConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url; defaults to localhost |
+| worker.serverConfig.apiUrl | string | `nil` | prefect API url (PREFECT_API_URL) |
+| worker.serverConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url |
 | worker.tolerations | list | `[]` | tolerations for worker pods assignment |
 
 ----------------------------------------------

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -88,7 +88,12 @@ Prefect Worker application bundle
 | worker.replicaCount | int | `1` | number of worker replicas to deploy |
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
-| worker.serverApiConfig.apiUrl | string | `"http://127.0.0.1:4200/api"` | prefect API url (PREFECT_API_URL); should be in-cluster URL if the worker is deployed in the same cluster as the API |
+| worker.serverConfig.apiUrl.fullyQualifiedEndpoint | string | `""` | The fully qualified Prefect API url (PREFECT_API_URL), external to the cluster |
+| worker.serverConfig.apiUrl.prefectServer | object | `{"namespace":"prefect","serviceName":"prefect-server","servicePort":"4200"}` | The prefect API url (PREFECT_API_URL); the full URL is constructed as http://serviceName.namespace.svc.cluster.local:4200/api |
+| worker.serverConfig.apiUrl.prefectServer.namespace | string | `"prefect"` | The namespace where the prefect server pod is deployed |
+| worker.serverConfig.apiUrl.prefectServer.serviceName | string | `"prefect-server"` | The name of the prefect server service |
+| worker.serverConfig.apiUrl.prefectServer.servicePort | string | `"4200"` | The service port of the prefect server service |
+| worker.serverConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url; defaults to localhost |
 | worker.tolerations | list | `[]` | tolerations for worker pods assignment |
 
 ----------------------------------------------

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -189,7 +189,7 @@ Workers each have a type corresponding to the execution environment to which the
 | worker.replicaCount | int | `1` | number of worker replicas to deploy |
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
-| worker.serverConfig.apiUrl | string | `nil` | prefect API url (PREFECT_API_URL) |
+| worker.serverConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
 | worker.serverConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url |
 | worker.tolerations | list | `[]` | tolerations for worker pods assignment |
 

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -14,7 +14,7 @@ Require Prefect Cloud Account ID
 */}}
 {{- define "cloud.requiredConfig.accountId" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
-    {{- required "A Prefect Cloud Account ID is required (worker.cloudApiConfig.accountId)" .Values.worker.cloudApiConfig.accountId | printf "%s"  -}}
+    {{- required "A Prefect Cloud Account ID is required (worker.cloudApiConfig.accountId)" .Values.worker.cloudApiConfig.accountId -}}
 {{- end -}}
 {{- end -}}
 
@@ -23,7 +23,7 @@ Require Prefect Cloud Workspace ID
 */}}
 {{- define "cloud.requiredConfig.workspaceId" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
-    {{- required "A Prefect Cloud Workspace ID is required (worker.cloudApiConfig.workspaceId)" .Values.worker.cloudApiConfig.workspaceId | printf "%s"  -}}
+    {{- required "A Prefect Cloud Workspace ID is required (worker.cloudApiConfig.workspaceId)" .Values.worker.cloudApiConfig.workspaceId -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -34,8 +34,10 @@ Require Prefect Cloud Workspace ID
 {{- define "worker.apiUrl" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
     {{- printf "%s/accounts/%s/workspaces/%s" .Values.worker.cloudApiConfig.cloudUrl (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
+{{- else if and (eq .Values.worker.apiConfig "server") .Values.worker.serverConfig.apiUrl.fullyQualifiedEndpoint }}
+    {{- printf .Values.worker.serverConfig.apiUrl.fullyQualifiedEndpoint | quote }}
 {{- else }}
-    {{- .Values.worker.serverApiConfig.apiUrl | quote }}
+    {{- printf "http://%s.%s.svc.cluster.local:%s/api" .Values.worker.serverConfig.apiUrl.prefectServer.serviceName .Values.worker.serverConfig.apiUrl.prefectServer.namespace .Values.worker.serverConfig.apiUrl.prefectServer.servicePort | quote}}
 {{- end }}
 {{- end }}
 
@@ -47,7 +49,7 @@ Require Prefect Cloud Workspace ID
 {{- if eq .Values.worker.apiConfig "cloud" }}
     {{- printf "https://app.prefect.cloud/account/%s/workspace/%s" (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
 {{- else }}
-    {{- .Values.worker.serverApiConfig.apiUrl | quote }}
+    {{- .Values.worker.serverConfig.uiUrl | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -34,10 +34,8 @@ Require Prefect Cloud Workspace ID
 {{- define "worker.apiUrl" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
     {{- printf "%s/accounts/%s/workspaces/%s" .Values.worker.cloudApiConfig.cloudUrl (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
-{{- else if and (eq .Values.worker.apiConfig "server") .Values.worker.serverConfig.apiUrl.fullyQualifiedEndpoint }}
-    {{- printf .Values.worker.serverConfig.apiUrl.fullyQualifiedEndpoint | quote }}
 {{- else }}
-    {{- printf "http://%s.%s.svc.cluster.local:%s/api" .Values.worker.serverConfig.apiUrl.prefectServer.serviceName .Values.worker.serverConfig.apiUrl.prefectServer.namespace .Values.worker.serverConfig.apiUrl.prefectServer.servicePort | quote}}
+    {{- .Values.worker.serverConfig.apiUrl | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -28,6 +28,15 @@ Require Prefect Cloud Workspace ID
 {{- end -}}
 
 {{/*
+Require Prefect Server API URL
+*/}}
+{{- define "server.requiredConfig.apiUrl" -}}
+{{- if eq .Values.worker.apiConfig "server" }}
+    {{- required "The Prefect Server API URL is required (worker.serverConfig.apiUrl)" .Values.worker.serverConfig.apiUrl -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
   worker.apiUrl:
     Define API URL for cloud or server worker install
 */}}
@@ -35,7 +44,7 @@ Require Prefect Cloud Workspace ID
 {{- if eq .Values.worker.apiConfig "cloud" }}
     {{- printf "%s/accounts/%s/workspaces/%s" .Values.worker.cloudApiConfig.cloudUrl (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
 {{- else }}
-    {{- .Values.worker.serverConfig.apiUrl | quote }}
+    {{- include "server.requiredConfig.apiUrl" . | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -10,14 +10,32 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Require Prefect Cloud Account ID
+*/}}
+{{- define "cloud.requiredConfig.accountId" -}}
+{{- if eq .Values.worker.apiConfig "cloud" }}
+    {{- required "A Prefect Cloud Account ID is required (worker.cloudApiConfig.accountId)" .Values.worker.cloudApiConfig.accountId | printf "%s"  -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Require Prefect Cloud Workspace ID
+*/}}
+{{- define "cloud.requiredConfig.workspaceId" -}}
+{{- if eq .Values.worker.apiConfig "cloud" }}
+    {{- required "A Prefect Cloud Workspace ID is required (worker.cloudApiConfig.workspaceId)" .Values.worker.cloudApiConfig.workspaceId | printf "%s"  -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
   worker.apiUrl:
     Define API URL for cloud or server worker install
 */}}
 {{- define "worker.apiUrl" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
-{{- printf "%s/accounts/%s/workspaces/%s" .Values.worker.cloudApiConfig.cloudUrl .Values.worker.cloudApiConfig.accountId .Values.worker.cloudApiConfig.workspaceId | quote }}
+    {{- printf "%s/accounts/%s/workspaces/%s" .Values.worker.cloudApiConfig.cloudUrl (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
 {{- else }}
-{{- .Values.worker.serverApiConfig.apiUrl | quote }}
+    {{- .Values.worker.serverApiConfig.apiUrl | quote }}
 {{- end }}
 {{- end }}
 
@@ -27,9 +45,9 @@ Create the name of the service account to use
 */}}
 {{- define "worker.appUrl" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
-{{- printf "https://app.prefect.cloud/account/%s/workspace/%s" .Values.worker.cloudApiConfig.accountId .Values.worker.cloudApiConfig.workspaceId | quote }}
+    {{- printf "https://app.prefect.cloud/account/%s/workspace/%s" (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
 {{- else }}
-{{- .Values.worker.serverApiConfig.apiUrl | quote }}
+    {{- .Values.worker.serverApiConfig.apiUrl | quote }}
 {{- end }}
 {{- end }}
 
@@ -40,8 +58,8 @@ Create the name of the service account to use
 {{- define "worker.clusterUUID" -}}
 {{- $defaultDict := dict "metadata" (dict "uid" "") -}}
 {{- if .Values.worker.clusterUid }}
-{{- .Values.worker.clusterUid | quote }}
+    {{- .Values.worker.clusterUid | quote }}
 {{- else }}
-{{- (lookup "v1" "Namespace" "" "kube-system" | default $defaultDict).metadata.uid | quote }}
+    {{- (lookup "v1" "Namespace" "" "kube-system" | default $defaultDict).metadata.uid | quote }}
 {{- end }}
 {{- end }}

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -32,7 +32,7 @@ Require Prefect Server API URL
 */}}
 {{- define "server.requiredConfig.apiUrl" -}}
 {{- if eq .Values.worker.apiConfig "server" }}
-    {{- required "The Prefect Server API URL is required (worker.serverConfig.apiUrl)" .Values.worker.serverConfig.apiUrl -}}
+    {{- required "The Prefect Server API URL is required (worker.serverApiConfig.apiUrl)" .Values.worker.serverApiConfig.apiUrl -}}
 {{- end -}}
 {{- end -}}
 
@@ -56,7 +56,7 @@ Require Prefect Server API URL
 {{- if eq .Values.worker.apiConfig "cloud" }}
     {{- printf "https://app.prefect.cloud/account/%s/workspace/%s" (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
 {{- else }}
-    {{- .Values.worker.serverConfig.uiUrl | quote }}
+    {{- .Values.worker.serverApiConfig.uiUrl | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - --type
             - {{ .Values.worker.config.type | quote }}
             - --pool
-            -  {{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool | quote }}
+            - {{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool | quote }}
             {{- range .Values.worker.config.workQueues }}
             - --work-queue
             - {{ . }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - --type
             - {{ .Values.worker.config.type | quote }}
             - --pool
-            - {{ .Values.worker.config.workPool | quote }}
+            -  {{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool | quote }}
             {{- range .Values.worker.config.workQueues }}
             - --work-queue
             - {{ . }}

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -76,22 +76,11 @@ worker:
     cloudUrl: https://api.prefect.cloud/api
 
   serverConfig:
-    # If the API server does not reside in the same cluster as the worker provide the fully qualified endpoint of the server,
-    # otherwise, provide the values nested under prefectServer below
+    # If the prefect server is located external to this cluster, set a fully qualified domain name as the apiUrl
+    # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local/api
+    # -- prefect API url (PREFECT_API_URL)
     apiUrl:
-      # -- The fully qualified Prefect API url (PREFECT_API_URL), external to the cluster
-      fullyQualifiedEndpoint: ""
-      # -- The prefect API url (PREFECT_API_URL); the full URL is constructed as http://serviceName.namespace.svc.cluster.local:4200/api
-      prefectServer:
-        # -- The namespace where the prefect server pod is deployed
-        namespace: prefect
-        # -- The name of the prefect server service
-        serviceName: prefect-server
-        # --The service port of the prefect server service
-        servicePort: "4200"
-
-
-    # -- prefect UI url; defaults to localhost
+    # -- prefect UI url
     uiUrl: http://localhost:4200
 
   # -- number of worker replicas to deploy

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -75,7 +75,7 @@ worker:
     # -- prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId
     cloudUrl: https://api.prefect.cloud/api
 
-  serverConfig:
+  serverApiConfig:
     # If the prefect server is located external to this cluster, set a fully qualified domain name as the apiUrl
     # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local/api
     # -- prefect API url (PREFECT_API_URL)

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -79,7 +79,7 @@ worker:
     # If the prefect server is located external to this cluster, set a fully qualified domain name as the apiUrl
     # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local/api
     # -- prefect API url (PREFECT_API_URL)
-    apiUrl:
+    apiUrl: ""
     # -- prefect UI url
     uiUrl: http://localhost:4200
 

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -75,9 +75,23 @@ worker:
     # -- prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId
     cloudUrl: https://api.prefect.cloud/api
 
-  serverApiConfig:
-    # -- prefect API url (PREFECT_API_URL); should be in-cluster URL if the worker is deployed in the same cluster as the API
-    apiUrl: http://127.0.0.1:4200/api
+  serverConfig:
+    # If the API server does not live in the same cluster as the worker provide the fully qualified endpoint,
+    # otherwise, provide the prefect server values
+    apiUrl:
+      # -- The prefect API url (PREFECT_API_URL); the full URL is constructed as http://serviceName.namespace.svc.cluster.local:4200/api
+      prefectServer:
+        # -- The namespace where the prefect server pod is deployed
+        namespace: prefect
+        # -- The name of the prefect server service
+        serviceName: prefect-server
+        # --The service port of the prefect server service
+        servicePort: "4200"
+      # -- The fully qualified Prefect API url (PREFECT_API_URL), external to the cluster
+      fullyQualifiedEndpoint: ""
+
+    # -- prefect UI url; defaults to localhost
+    uiUrl: http://localhost:4200
 
   # -- number of worker replicas to deploy
   replicaCount: 1

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -76,9 +76,11 @@ worker:
     cloudUrl: https://api.prefect.cloud/api
 
   serverConfig:
-    # If the API server does not live in the same cluster as the worker provide the fully qualified endpoint,
-    # otherwise, provide the prefect server values
+    # If the API server does not reside in the same cluster as the worker provide the fully qualified endpoint of the server,
+    # otherwise, provide the values nested under prefectServer below
     apiUrl:
+      # -- The fully qualified Prefect API url (PREFECT_API_URL), external to the cluster
+      fullyQualifiedEndpoint: ""
       # -- The prefect API url (PREFECT_API_URL); the full URL is constructed as http://serviceName.namespace.svc.cluster.local:4200/api
       prefectServer:
         # -- The namespace where the prefect server pod is deployed
@@ -87,8 +89,7 @@ worker:
         serviceName: prefect-server
         # --The service port of the prefect server service
         servicePort: "4200"
-      # -- The fully qualified Prefect API url (PREFECT_API_URL), external to the cluster
-      fullyQualifiedEndpoint: ""
+
 
     # -- prefect UI url; defaults to localhost
     uiUrl: http://localhost:4200


### PR DESCRIPTION
With the use of `{{ required }}`, we know enforce at the helm level the 3 necessary values needed in order for a worker to be deployed successfully.

This also fixes the printed UI url when using the `server` configuration which previously just displayed the `api url` endpoint. 

Resolves https://github.com/PrefectHQ/prefect-helm/issues/223