### PR TITLE
fix: use semver-compatible calver versions

### DIFF
--- a/.github/workflows/update-helm-major-versions.yaml
+++ b/.github/workflows/update-helm-major-versions.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%-m-%-d')" >> $GITHUB_OUTPUT
 
       - name: install updatecli in the runner
         uses: updatecli/updatecli-action@v2

--- a/.github/workflows/update-helm-minor-versions.yaml
+++ b/.github/workflows/update-helm-minor-versions.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%-m-%-d')" >> $GITHUB_OUTPUT
 
       - name: create branch for helm version updates
         run: |


### PR DESCRIPTION
With this change, datestamps are generated without leading zeroes, therefore making
the format SemVer compatible.

This is needed to ensure that the helm chart versions are compatible with the helm specification,
which enforces SemVer for chart versions.

Resolves #233.
