### PR TITLE
fix: update bitnami/common dependency chart to support helm 3.2+

### DIFF
--- a/charts/prefect-agent/Chart.yaml
+++ b/charts/prefect-agent/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.9.2
+    version: 2.10.1
 description: Prefect Agent application bundle
 engine: gotpl
 home: https://github.com/PrefectHQ

--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -23,7 +23,7 @@ Prefect Agent application bundle
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.9.2 |
+| https://charts.bitnami.com/bitnami | common | 2.10.1 |
 
 ## Values
 

--- a/charts/prefect-server/Chart.yaml
+++ b/charts/prefect-server/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.9.2
+    version: 2.10.1
   - name: postgresql
     condition: postgresql.useSubChart
     repository: https://charts.bitnami.com/bitnami

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -91,7 +91,7 @@ postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.9.2 |
+| https://charts.bitnami.com/bitnami | common | 2.10.1 |
 | https://charts.bitnami.com/bitnami | postgresql | 12.10.0 |
 
 ## Values

--- a/charts/prefect-worker/Chart.yaml
+++ b/charts/prefect-worker/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.9.2
+    version: 2.10.1
 description: Prefect Worker application bundle
 engine: gotpl
 home: https://github.com/PrefectHQ

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -128,7 +128,7 @@ Workers each have a type corresponding to the execution environment to which the
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.9.2 |
+| https://charts.bitnami.com/bitnami | common | 2.10.1 |
 
 ## Values
 


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/prefect-helm/issues/235
applies https://github.com/bitnami/charts/pull/19177

we received a community report where a user attempted to update their prefect-helm chart from `2023.09.01` -> `2023.09.07`, and seeing this error:

```
Error: parse error at (prefect-worker/charts/common/templates/_labels.tpl:14): unclosed action
```

this exception comes from the helper templates we pull in from the bitnami/common chart, specifically the `_labels.tpl` module.  it turns out that the bitnami folks added a template expression with newlines in the `bitnami/common@2.9.2` chart, which isn't compatible with older versions of gotpl + helm <= 3.5.x.  they've since pushed a fix for `2.10.1`, and i've verified this fix locally with an older version of helm

this impacts users who are on an older version of helm, but can resolve it without changing their prefect chart version if they update their helm client.  for those who cannot, this PR bumps the `bitnami/common` version to apply this backwards compatible fix