### PR TITLE
Update environment variables passed to the prefect `server` chart

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -137,13 +137,13 @@ postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
 | server.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set server containers' security context readOnlyRootFilesystem |
 | server.containerSecurityContext.runAsNonRoot | bool | `true` | set server containers' security context runAsNonRoot |
 | server.containerSecurityContext.runAsUser | int | `1001` | set server containers' security context runAsUser |
+| server.debug | bool | `false` | enable server debug mode |
 | server.env | list | `[]` | array with environment variables to add to server nodes |
 | server.extraContainers | list | `[]` | additional sidecar containers |
 | server.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to server nodes |
 | server.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to server nodes |
 | server.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the server pod |
 | server.extraVolumes | list | `[]` | array with extra volumes for the server pod |
-| server.image.debug | bool | `false` | enable server image debug mode |
 | server.image.prefectTag | string | `"2-latest"` | prefect image tag (immutable tags are recommended) |
 | server.image.pullPolicy | string | `"IfNotPresent"` | server image pull policy |
 | server.image.pullSecrets | list | `[]` | server image pull secrets |
@@ -154,15 +154,16 @@ postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
 | server.livenessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | server.livenessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
 | server.livenessProbe.enabled | bool | `false` |  |
+| server.loggingLevel | string | `"WARNING"` |  |
 | server.nodeSelector | object | `{}` | node labels for server pods assignment |
 | server.podAnnotations | object | `{}` | extra annotations for server pod |
 | server.podLabels | object | `{}` | extra labels for server pod |
 | server.podSecurityContext.fsGroup | int | `1001` | set server pod's security context fsGroup |
 | server.podSecurityContext.runAsNonRoot | bool | `true` | set server pod's security context runAsNonRoot |
 | server.podSecurityContext.runAsUser | int | `1001` | set server pod's security context runAsUser |
+| server.prefectApiHost | string | `"0.0.0.0"` | sets PREFECT_SERVER_API_HOST |
+| server.prefectApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_API_URL |
 | server.priorityClassName | string | `""` | priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class |
-| server.publicApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; should be publicly accessible API URL |
-| server.publicUiUrl | string | `"http://localhost:4200"` | sets PREFECT_UI_URL |
 | server.readinessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | server.readinessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |
 | server.readinessProbe.config.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |
@@ -173,12 +174,15 @@ postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
 | server.resources.limits | object | `{}` | the requested limits for the server container |
 | server.resources.requests | object | `{}` | the requested resources for the server container |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
+| server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
+| server.uiConfig.prefectUiApiUrl | string | `""` | sets PREFECT_UI_API_URL |
+| server.uiConfig.prefectUiUrl | string | `""` | sets PREFECT_UI_URL |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |
 | service.externalTrafficPolicy | string | `"Cluster"` | service external traffic policy |
 | service.nodePort | string | `""` | service port if defining service as type nodeport |
 | service.port | int | `4200` | service port |
-| service.targetPort | int | `4200` | target port of the server pod |
+| service.targetPort | int | `4200` | target port of the server pod; also sets PREFECT_SERVER_API_PORT |
 | service.type | string | `"ClusterIP"` | service type |
 | serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
 | serviceAccount.create | bool | `true` | specifies whether a ServiceAccount should be created |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -162,6 +162,7 @@ postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
 | server.podSecurityContext.runAsUser | int | `1001` | set server pod's security context runAsUser |
 | server.priorityClassName | string | `""` | priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class |
 | server.publicApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; should be publicly accessible API URL |
+| server.publicUiUrl | string | `"http://localhost:4200"` | sets PREFECT_UI_URL |
 | server.readinessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | server.readinessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |
 | server.readinessProbe.config.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |

--- a/charts/prefect-server/templates/NOTES.txt
+++ b/charts/prefect-server/templates/NOTES.txt
@@ -13,5 +13,5 @@ http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host.hostname }
 Run the following command to port-forward the UI to your localhost:
 $ kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ template "common.names.fullname" . }} {{ .Values.service.targetPort }}:{{ .Values.service.port }}
 
-Visit http://localhost:4200 to use Prefect!
+Visit {{ include "server.uiUrl" . }} to use Prefect!
 {{- end }}

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -53,3 +53,11 @@ Create the name of the service account to use
   {{- printf "%s-%s" $name "postgresql-connection" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "server.uiUrl" -}}
+{{- if .Values.server.uiConfig.prefectUiUrl -}}
+  {{- .Values.server.uiConfig.prefectUiUrl -}}
+{{- else -}}
+  {{- printf "%s" (replace "/api" "" .Values.server.prefectApiUrl) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -64,10 +64,6 @@ spec:
             - prefect
             - server
             - start
-            - --host
-            - 0.0.0.0
-            - --log-level
-            - WARNING
             - --port
             - {{ .Values.service.targetPort | quote }}
           workingDir: /home/prefect
@@ -76,12 +72,26 @@ spec:
           env:
             - name: HOME
               value: /home/prefect
+            - name: PREFECT_API_URL
+              value: {{ .Values.server.prefectApiUrl | quote }}
             - name: PREFECT_DEBUG_MODE
-              value: {{ .Values.server.image.debug | quote }}
+              value: {{ .Values.server.debug | quote }}
+            - name: PREFECT_LOGGING_SERVER_LEVEL
+              value: {{ .Values.server.loggingLevel | quote }}
+            - name: PREFECT_SERVER_API_HOST
+              value: {{ .Values.server.prefectApiHost | quote }}
+            - name: PREFECT_SERVER_API_PORT
+              value: {{ .Values.service.targetPort  | quote }}
+            - name: PREFECT_UI_ENABLED
+              value: {{ .Values.server.uiConfig.enabled | quote }}
+            {{- if .Values.server.uiConfig.prefectUiApiUrl }}
             - name: PREFECT_UI_API_URL
-              value: {{ .Values.server.publicApiUrl | quote }}
+              value: {{ .Values.server.uiConfig.prefectUiApiUrl | quote }}
+            {{- end }}
+            {{- if .Values.server.uiConfig.prefectUiUrl }}
             - name: PREFECT_UI_URL
-              value: {{ .Values.server.publicUiUrl | quote }}
+              value: {{ .Values.server.uiConfig.prefectUiUrl | quote }}
+            {{- end }}
             {{- if .Values.postgresql.enabled }}
             - name: PREFECT_API_DATABASE_CONNECTION_URL
               valueFrom:

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -78,10 +78,10 @@ spec:
               value: /home/prefect
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.server.image.debug | quote }}
-            {{- if .Values.server.publicApiUrl }}
             - name: PREFECT_UI_API_URL
               value: {{ .Values.server.publicApiUrl | quote }}
-            {{- end }}
+            - name: PREFECT_UI_URL
+              value: {{ .Values.server.publicUiUrl | quote }}
             {{- if .Values.postgresql.enabled }}
             - name: PREFECT_API_DATABASE_CONNECTION_URL
               valueFrom:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -72,12 +72,6 @@
               "items": {
                 "type": "string"
               }
-            },
-            "debug": {
-              "type": "boolean",
-              "title": "Debug",
-              "description": "server image debug mode",
-              "form": true
             }
           }
         },
@@ -87,17 +81,55 @@
           "description": "priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class",
           "form": true
         },
-        "publicApiUrl": {
-          "type": "string",
-          "title": "Public API URL",
-          "description": "sets PREFECT_UI_API_URL; should be publicly accessible API URL",
+        "debug": {
+          "type": "boolean",
+          "title": "Debug",
+          "description": "server debug mode",
           "form": true
         },
-        "publicUiUrl": {
+        "loggingLevel": {
           "type": "string",
-          "title": "Public UI URL",
-          "description": "sets PREFECT_UI_URL",
+          "title": "Logging Level",
+          "description": "sets PREFECT_LOGGING_SERVER_LEVEL",
           "form": true
+        },
+        "prefectApiUrl": {
+          "type": "string",
+          "title": "Prefect API URL",
+          "description": "sets PREFECT_API_URL",
+          "form": true
+        },
+        "prefectApiHost": {
+          "type": "string",
+          "title": "Prefect API Host",
+          "description": "sets PREFECT_SERVER_API_HOST",
+          "form": true
+        },
+        "uiConfig": {
+          "type": "object",
+          "title": "UI Config",
+          "description": "Prefect UI Config",
+          "form": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable Prefect UI",
+              "description": "set PREFECT_UI_ENABLED; enable the UI on the server",
+              "form": true
+            },
+            "prefectUiApiUrl": {
+              "type": "string",
+              "title": "Prefect API URL",
+              "description": "sets PREFECT_UI_API_URL",
+              "form": true
+            },
+            "prefectUiUrl": {
+              "type": "string",
+              "title": "Prefect UI URL",
+              "description": "sets PREFECT_UI_URL",
+              "form": true
+            }
+          }
         },
         "env": {
           "type": "array",

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -93,6 +93,12 @@
           "description": "sets PREFECT_UI_API_URL; should be publicly accessible API URL",
           "form": true
         },
+        "publicUiUrl": {
+          "type": "string",
+          "title": "Public UI URL",
+          "description": "sets PREFECT_UI_URL",
+          "form": true
+        },
         "env": {
           "type": "array",
           "title": "Environment Variables",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -39,6 +39,9 @@ server:
   # -- sets PREFECT_UI_API_URL; should be publicly accessible API URL
   publicApiUrl: http://localhost:4200/api
 
+  # -- sets PREFECT_UI_URL
+  publicUiUrl: "http://localhost:4200"
+
   # -- array with environment variables to add to server nodes
   env: []
   ## env:

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -29,24 +29,38 @@ server:
     ##   - myRegistryKeySecretName
     # -- server image pull secrets
     pullSecrets: []
-    # -- enable server image debug mode
-    debug: false
 
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   # -- priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class
   priorityClassName: ""
 
-  # -- sets PREFECT_UI_API_URL; should be publicly accessible API URL
-  publicApiUrl: http://localhost:4200/api
+  # -- enable server debug mode
+  debug: false
 
-  # -- sets PREFECT_UI_URL
-  publicUiUrl: "http://localhost:4200"
+  # sets PREFECT_LOGGING_SERVER_LEVEL
+  loggingLevel: WARNING
 
+  # -- sets PREFECT_API_URL
+  prefectApiUrl: http://localhost:4200/api
+
+  # -- sets PREFECT_SERVER_API_HOST
+  prefectApiHost: 0.0.0.0
+
+  ## If you want to run the UI seperately from the server, you will need to set the UI-specific URLs below
+  uiConfig:
+    # -- set PREFECT_UI_ENABLED; enable the UI on the server
+    enabled: true
+    # -- sets PREFECT_UI_API_URL
+    prefectUiApiUrl: ""
+    # -- sets PREFECT_UI_URL
+    prefectUiUrl: ""
+
+  # see here for a full list of possible environment variables - https://docs.prefect.io/latest/api-ref/prefect/settings/
   # -- array with environment variables to add to server nodes
   env: []
   ## env:
-  ##   - name: PREFECT_LOGGING_SERVER_LEVEL
-  ##     value: WARNING
+  ##   - name: PREFECT_API_ENABLE_HTTP2
+  ##     value: false
 
   # Autoscaling configuration
   # requests MUST be specified if using an HPA, otherwise the HPA will not know when to trigger a scale event
@@ -170,7 +184,7 @@ service:
   type: ClusterIP
   # -- service port
   port: 4200
-  # -- target port of the server pod
+  # -- target port of the server pod; also sets PREFECT_SERVER_API_PORT
   targetPort: 4200
   # -- service Cluster IP
   clusterIP: ""


### PR DESCRIPTION
This PR will implement a **breaking change**. The following will need to be updated in the end users environment when upgrading:

### Prefect API URL (server.prefectApiUrl)
This value was previously not exposed. It is set to default value that was previously set at`server.publicApiUrl`. If the URL of your server installation is not `http://localhost:4200`, you **will** need to override that value here.

### Prefect UI Configuration
Unless you have a different endpoint for your UI server, you can ignore this change. If your UI endpoint is unique from the API endpoint, you will need to set both `server.uiConfig.prefectUiApiUrl` and `server.uiConfig.prefectUiUrl`.

### Debug Level
If you previously had `server.image.debug` set to `true`, you will need to remove that setting and instead set `server.debug` to be `true`

See [here](https://docs.prefect.io/2.13.7/api-ref/prefect/settings/) for any questions around the possible server environment variables