### PR TITLE
Fix/Add global param

### DIFF
--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -797,6 +797,12 @@
       "title": "Common",
       "description": "common configuration.  Not set by user but required as common vars are passed to all manifests.",
       "form": true
+    },
+    "global": {
+      "type": "object",
+      "title": "Global",
+      "description": "global configuration.  Not set by user but required when prefect is referenced as a downstream Chart",
+      "form": true
     }
   }
 }

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -573,6 +573,12 @@
       "title": "Common",
       "description": "common configuration.  Not set by user but required as common vars are passed to all manifests.",
       "form": true
+    },
+    "global": {
+      "type": "object",
+      "title": "Global",
+      "description": "global configuration.  Not set by user but required when prefect is referenced as a downstream Chart",
+      "form": true
     }
   }
 }


### PR DESCRIPTION
- All subcharts and charts can access a "global" values type (info [here](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/)) so adding this addition to fix the failures that have been reported when using subcharts.
Verified functionality locally. 
- Resolves: https://github.com/PrefectHQ/prefect-helm/issues/258