### PR TITLE
chore: update readme to use `prefectApiUrl` instead of `publicApiUrl`

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -22,7 +22,7 @@ Without making any modifications to the `values.yaml` file, you can access the P
 kubectl port-forward svc/prefect-server 4200:4200
 ```
 
-Note: If you choose to make modifications to either the `server.publicApiUrl` or `service.port`, make sure to update the other value with the updated port!
+Note: If you choose to make modifications to either the `server.prefectApiUrl` or `service.port`, make sure to update the other value with the updated port!
 
 ## PostgreSQL Configuration
 

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -21,7 +21,7 @@ Without making any modifications to the `values.yaml` file, you can access the P
 kubectl port-forward svc/prefect-server 4200:4200
 ```
 
-Note: If you choose to make modifications to either the `server.publicApiUrl` or `service.port`, make sure to update the other value with the updated port!
+Note: If you choose to make modifications to either the `server.prefectApiUrl` or `service.port`, make sure to update the other value with the updated port!
 
 ## PostgreSQL Configuration
 


### PR DESCRIPTION
Resolves #261 