### PR TITLE
enhancement: support additional worker configuration options

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -192,7 +192,7 @@ serviceAccount:
 
 ### Configuring a Base Job Template on the Worker
 
-If you want to define the base job template of the worker and pass it as a value in this chart, you will need to do the following. **Note** if the `workPool` already exists, the base job template passed **will** be ignored.
+If you want to define the [base job template](https://docs.prefect.io/concepts/work-pools/#base-job-template) of the worker and pass it as a value in this chart, you will need to do the following. **Note** if the `workPool` already exists, the base job template passed **will** be ignored.
 
 1. Define the base job template in a local file. To get a formatted template, run the following command & store locally in `base-job-template.json`
 

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -190,6 +190,27 @@ serviceAccount:
   name: "prefect-worker"
 ```
 
+### Configuring a Base Job Template on the Worker
+
+If you want to define the base job template of the worker and pass it as a value in this chart, you will need to do the following. **Note** if the `workPool` already exists, the base job template passed **will** be ignored.
+
+1. Define the base job template in a local file. To get a formatted template, run the following command & store locally in `base-job-template.json`
+
+```bash
+# you may need to install `prefect-kubernetes` first
+pip install prefect-kubernetes
+
+prefect work-pool get-default-base-job-template --type kubernetes > base-job-template.json
+```
+
+2. Modify the base job template as needed
+
+3. Install the chart as you usually would, making sure to use the `--set-file` command to pass in the `base-job-template.json` file as a paramater:
+
+```bash
+helm install prefect-worker prefect/prefect-worker -f values.yaml --set-file worker.config.baseJobTemplate=base-job-template.json
+```
+
 ## Maintainers
 
 | Name | Email | Url |
@@ -225,6 +246,7 @@ serviceAccount:
 | worker.cloudApiConfig.cloudUrl | string | `"https://api.prefect.cloud/api"` | prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId |
 | worker.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | worker.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
+| worker.config.baseJobTemplate | string | `nil` | JSON formatted base job template. If unspecified, Prefect will use the default base job template for the given worker type. If the work pool already exists, this will be ignored. |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
 | worker.config.installPolicy | string | `"prompt"` | install policy to use workers from Prefect integration packages. |
 | worker.config.limit | string | `nil` | maximum number of flow runs to start simultaneously (default: unlimited) |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -226,7 +226,9 @@ serviceAccount:
 | worker.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | worker.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be infered at time of helm install |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
-| worker.config.limit | string | `nil` | Maximum number of flow runs to start simultaneously (default: unlimited) |
+| worker.config.installPolicy | string | `"prompt"` | install policy to use workers from Prefect integration packages. |
+| worker.config.limit | string | `nil` | maximum number of flow runs to start simultaneously (default: unlimited) |
+| worker.config.name | string | `nil` | the name to give to the started worker. If not provided, a unique name will be generated. |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
 | worker.config.queryInterval | int | `5` | how often the worker will query for runs |
 | worker.config.type | string | `"kubernetes"` | specify the worker type |

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -190,6 +190,27 @@ serviceAccount:
   name: "prefect-worker"
 ```
 
+### Configuring a Base Job Template on the Worker
+
+If you want to define the base job template of the worker and pass it as a value in this chart, you will need to do the following. **Note** if the `workPool` already exists, the base job template passed **will** be ignored.
+
+1. Define the base job template in a local file. To get a formatted template, run the following command & store locally in `base-job-template.json`
+
+```bash
+# you may need to install `prefect-kubernetes` first
+pip install prefect-kubernetes
+
+prefect work-pool get-default-base-job-template --type kubernetes > base-job-template.json
+```
+
+2. Modify the base job template as needed
+
+3. Install the chart as you usually would, making sure to use the `--set-file` command to pass in the `base-job-template.json` file as a paramater:
+
+```bash
+helm install prefect-worker prefect/prefect-worker -f values.yaml --set-file worker.config.baseJobTemplate=base-job-template.json
+```
+
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.requirementsSection" . }}

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -192,7 +192,7 @@ serviceAccount:
 
 ### Configuring a Base Job Template on the Worker
 
-If you want to define the base job template of the worker and pass it as a value in this chart, you will need to do the following. **Note** if the `workPool` already exists, the base job template passed **will** be ignored.
+If you want to define the [base job template](https://docs.prefect.io/concepts/work-pools/#base-job-template) of the worker and pass it as a value in this chart, you will need to do the following. **Note** if the `workPool` already exists, the base job template passed **will** be ignored.
 
 1. Define the base job template in a local file. To get a formatted template, run the following command & store locally in `base-job-template.json`
 

--- a/charts/prefect-worker/templates/configmap.yaml
+++ b/charts/prefect-worker/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prefect-worker-base-template
+  name: prefect-worker-base-job-template
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: worker

--- a/charts/prefect-worker/templates/configmap.yaml
+++ b/charts/prefect-worker/templates/configmap.yaml
@@ -10,5 +10,5 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  baseTemplate.json: {{ .Values.worker.config.baseJobTemplate | toJson }}
+  baseJobTemplate.json: {{ .Values.worker.config.baseJobTemplate | toJson }}
 {{- end }}

--- a/charts/prefect-worker/templates/configmap.yaml
+++ b/charts/prefect-worker/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.worker.config.baseJobTemplate }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prefect-worker-base-template
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: worker
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  baseTemplate.json: {{ .Values.worker.config.baseJobTemplate | toJson }}
+{{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -72,12 +72,18 @@ spec:
             - --work-queue
             - {{ . }}
             {{- end }}
+            - --install-policy
+            - {{ .Values.worker.config.installPolicy | quote }}
             {{- if .Values.worker.config.limit }}
             - --limit
             - {{ .Values.worker.config.limit | quote }}
             {{- end }}
             {{- if .Values.worker.livenessProbe.enabled }}
             - --with-healthcheck
+            {{- end }}
+            {{- if .Values.worker.config.name }}
+            - --name
+            - {{ .Values.worker.config.name | quote }}
             {{- end }}
           workingDir: /home/prefect
           env:

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
               subPathExpr: tmp
             {{- if .Values.worker.config.baseJobTemplate }}
             - mountPath: /home/prefect/baseJobTemplate.json
-              name: base-template-file
+              name: base-job-template-file
               subPath: baseJobTemplate.json
             {{- end }}
           {{- if .Values.worker.extraVolumeMounts }}
@@ -168,7 +168,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.worker.config.baseJobTemplate }}
-        - name: base-template-file
+        - name: base-job-template-file
           configMap:
             name: prefect-worker-base-job-template
         {{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -170,5 +170,5 @@ spec:
         {{- if .Values.worker.config.baseJobTemplate }}
         - name: base-template-file
           configMap:
-            name: prefect-worker-base-template
+            name: prefect-worker-base-job-template
         {{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
             - --name
             - {{ .Values.worker.config.name | quote }}
             {{- end }}
+            {{- if .Values.worker.config.baseJobTemplate }}
+            - --base-job-template
+            - baseTemplate.json
+            {{- end }}
           workingDir: /home/prefect
           env:
             - name: HOME
@@ -146,6 +150,11 @@ spec:
             - mountPath: /tmp
               name: scratch
               subPathExpr: tmp
+            {{- if .Values.worker.config.baseJobTemplate }}
+            - mountPath: /home/prefect/baseTemplate.json
+              name: base-template-file
+              subPath: baseTemplate.json
+            {{- end }}
           {{- if .Values.worker.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -157,4 +166,9 @@ spec:
           emptyDir: {}
         {{- if .Values.worker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.worker.config.baseJobTemplate }}
+        - name: base-template-file
+          configMap:
+            name: prefect-worker-base-template
         {{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             {{- end }}
             {{- if .Values.worker.config.baseJobTemplate }}
             - --base-job-template
-            - baseTemplate.json
+            - baseJobTemplate.json
             {{- end }}
           workingDir: /home/prefect
           env:
@@ -151,9 +151,9 @@ spec:
               name: scratch
               subPathExpr: tmp
             {{- if .Values.worker.config.baseJobTemplate }}
-            - mountPath: /home/prefect/baseTemplate.json
+            - mountPath: /home/prefect/baseJobTemplate.json
               name: base-template-file
-              subPath: baseTemplate.json
+              subPath: baseJobTemplate.json
             {{- end }}
           {{- if .Values.worker.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -141,7 +141,7 @@
               "form": true
             },
             "installPolicy": {
-              "type": ["string"],
+              "type": "string",
               "title": "Install Policy",
               "description": "Install policy to use workers from Prefect integration packages.",
               "form": true

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -151,6 +151,12 @@
               "title": "Type",
               "description": "the type of worker to start i.e kubernetes",
               "form": true
+            },
+            "baseJobTemplate": {
+              "type": ["string", "null"],
+              "title": "Base Job Template",
+              "description": "JSON formatted base job template. If unspecified, Prefect will use the default base job template for the given worker type. If the work pool already exists, this will be ignored.",
+              "form": true
             }
           }
         },

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -134,6 +134,18 @@
               "description": "Maximum number of flow runs to start simultaneously (default: unlimited)",
               "form": true
             },
+            "name": {
+              "type": ["string", "null"],
+              "title": "Name",
+              "description": "The name to give to the started worker. If not provided, a unique name will be generated.",
+              "form": true
+            },
+            "installPolicy": {
+              "type": ["string"],
+              "title": "Install Policy",
+              "description": "Install policy to use workers from Prefect integration packages.",
+              "form": true
+            },
             "type": {
               "type": "string",
               "title": "Type",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -60,6 +60,8 @@ worker:
     name: null
     # -- maximum number of flow runs to start simultaneously (default: unlimited)
     limit: null
+    # -- JSON formatted base job template. If unspecified, Prefect will use the default base job template for the given worker type. If the work pool already exists, this will be ignored.
+    baseJobTemplate: null
 
   ## connection settings
   # -- one of 'cloud', 'selfHosted', or 'server'

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -47,14 +47,19 @@ worker:
     prefetchSeconds: 10
     # -- connect using HTTP/2 if the server supports it (experimental)
     http2: true
-    # -- Maximum number of flow runs to start simultaneously (default: unlimited)
-    limit: null
     ## You can set the worker type here.
     ## The default image includes only the type "kubernetes".
     ## Custom workers must be properly registered with the prefect cli.
     ## See the guide here: https://docs.prefect.io/2.11.3/guides/deployment/developing-a-new-worker-type/
     # -- specify the worker type
     type: kubernetes
+    ## one of 'always', 'if-not-present', 'never', 'prompt'
+    # --  install policy to use workers from Prefect integration packages.
+    installPolicy: prompt
+    # -- the name to give to the started worker. If not provided, a unique name will be generated.
+    name: null
+    # -- maximum number of flow runs to start simultaneously (default: unlimited)
+    limit: null
 
   ## connection settings
   # -- one of 'cloud', 'selfHosted', or 'server'


### PR DESCRIPTION
This PR introduces `install-policy`, `name` and `base-job-template` as additional configuration options on the `prefect-worker`

Resolves https://github.com/PrefectHQ/prefect-helm/issues/267