### PR TITLE
chore: allow forked PRs to access necessary actions secret for status checks

### DIFF
--- a/.github/workflows/agent-lint-and-test.yaml
+++ b/.github/workflows/agent-lint-and-test.yaml
@@ -1,16 +1,23 @@
 name: Lint and Test Prefect Agent Chart
 
 "on":
-  pull_request:
+  pull_request_target:
     paths:
       - .github/workflows/agent-lint-and-test.yaml
       - .github/linters/agent-ct.yaml
       - charts/prefect-agent/**
 
+# Do not grant jobs any permissions by default
+permissions: {}
+
+
 jobs:
   lint_test:
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
     strategy:
       matrix:
         kubernetes:

--- a/.github/workflows/agent-lint-and-test.yaml
+++ b/.github/workflows/agent-lint-and-test.yaml
@@ -10,7 +10,6 @@ name: Lint and Test Prefect Agent Chart
 # Do not grant jobs any permissions by default
 permissions: {}
 
-
 jobs:
   lint_test:
     name: "lint-test (${{ matrix.kubernetes }})"

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -7,10 +7,16 @@ name: Lint and Test Prefect Server Chart
       - .github/linters/server-ct.yaml
       - charts/prefect-server/**
 
+# Do not grant jobs any permissions by default
+permissions: {}
+
 jobs:
   lint_test:
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
     strategy:
       matrix:
         kubernetes:

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -1,15 +1,22 @@
 name: Lint and Test Prefect Worker Chart
 
 "on":
-  pull_request:
+  pull_request_target:
     paths:
       - .github/workflows/worker-lint-and-test.yaml
       - .github/linters/worker-ct.yaml
       - charts/prefect-worker/**
+
+# Do not grant jobs any permissions by default
+permissions: {}
+
 jobs:
   lint_test:
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
     strategy:
       matrix:
         kubernetes:


### PR DESCRIPTION
by using pull_request_target [against the main branch] it tells GHA that the workflow is trusted, and therefore can access actions secrets

relevant docs:
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
