### PR TITLE
patch: Update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Workers each have a type corresponding to the execution environment to which the
 
 ### Note: Workers are recommended
 
-Agents are part of the block-based deployment model. [Work Pools and Workers](/concepts/work-pools/) simplify the specification of a flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
+Agents are part of the block-based deployment model. [Work Pools and Workers](https://docs.prefect.io/latest/concepts/work-pools/) simplify the specification of a flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
 
 [Agent](https://docs.prefect.io/latest/concepts/agents/) processes are lightweight polling services that get scheduled work from a work pool and deploy the corresponding flow runs.
 


### PR DESCRIPTION
-Some of the links in the `README.md` were broken and pointing to stale docs that no longer exist
-Move links to official prefect doc links on the same concepts