### PR TITLE
fix: only search for prefect tag versions that are semver

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
           echo "PREFECT_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
-            https://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///' \
+            https://github.com/PrefectHQ/prefect.git '*.*.*' | tail -n1 | sed 's/.*\///' \
           )" >> $GITHUB_OUTPUT
 
       - name: Copy Artifact Hub metadata


### PR DESCRIPTION
```
$             git ls-remote --tags --refs --sort="v:refname" \
            https://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///'
2.82
```

vs

```
$             git ls-remote --tags --refs --sort="v:refname" \
            https://github.com/PrefectHQ/prefect.git '*.*.*' | tail -n1 | sed 's/.*\///'
2.14.15
```

if you see the full list, there's an old prefect version that is leaking out to the top of the sorted list, not entirely sure how or why

```
$ git ls-remote --tags --refs --sort="v:refname" https://github.com/PrefectHQ/prefect.git

...
e6d7d76d906301fb6771dce2ee896e2d5673341d	refs/tags/2.14.11
5a2482d058275f5042fe15129fb08bb6b1ae7a8d	refs/tags/2.14.12
9df5ba721c7ae216db092bb1dcf338a1cfdc0c98	refs/tags/2.14.13
cd74a035af1d9161c3593fdb80f25f3867ce21ee	refs/tags/2.14.14
e585e980078e5d997d40ce56da7dbb65f417ef20	refs/tags/2.14.15
afbed19d752b7057ccb2dc63ab806f56cc563fe1	refs/tags/2.82
```