### PR TITLE
fix(server): mounted fs path for static-ui-dir

### DIFF
--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
             - name: PREFECT_UI_URL
               value: {{ .Values.server.uiConfig.prefectUiUrl | quote }}
             {{- end }}
+            - name: PREFECT_UI_STATIC_DIRECTORY
+              value: {{ .Values.server.uiConfig.prefectUiStaticDirectory | quote }}
             {{- if .Values.postgresql.enabled }}
             - name: PREFECT_API_DATABASE_CONNECTION_URL
               valueFrom:
@@ -141,6 +143,9 @@ spec:
             - mountPath: /tmp
               name: scratch
               subPathExpr: tmp
+            - mountPath: {{ .Values.server.uiConfig.prefectUiStaticDirectory }}
+              name: scratch
+              subPathExpr: ui-build
           {{- if .Values.server.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.server.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -54,6 +54,8 @@ server:
     prefectUiApiUrl: ""
     # -- sets PREFECT_UI_URL
     prefectUiUrl: ""
+    # -- sets PREFECT_UI_STATIC_DIRECTORY
+    prefectUiStaticDirectory: "/ui_build"
 
   # see here for a full list of possible environment variables - https://docs.prefect.io/latest/api-ref/prefect/settings/
   # -- array with environment variables to add to server nodes


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/prefect-helm/issues/288

![image](https://github.com/PrefectHQ/prefect-helm/assets/19556538/9a4526c5-278d-4d21-b185-cc485a3dd845)

```
$ kl prefect-server-5dd4b5755-7b5k7

 ___ ___ ___ ___ ___ ___ _____
| _ \ _ \ __| __| __/ __|_   _|
|  _/   / _|| _|| _| (__  | |
|_| |_|_\___|_| |___\___| |_|

Configure Prefect to communicate with the server with:

    prefect config set PREFECT_API_URL=http://0.0.0.0:4200/api

View the API reference documentation at http://0.0.0.0:4200/docs

Check out the dashboard at http://0.0.0.0:4200
```