### PR TITLE
chore: switch release workflow to manual, dispatch-based trigger

### DIFF
--- a/.github/workflows/agent-lint-and-test.yaml
+++ b/.github/workflows/agent-lint-and-test.yaml
@@ -2,10 +2,6 @@ name: Lint and Test Prefect Agent Chart
 
 "on":
   pull_request_target:
-    paths:
-      - .github/workflows/agent-lint-and-test.yaml
-      - .github/linters/agent-ct.yaml
-      - charts/prefect-agent/**
 
 # Do not grant jobs any permissions by default
 permissions: {}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,12 +1,7 @@
 name: Release Helm Chart
 
 "on":
-  push:
-    tags:
-      # 2023.9.1, but not 2023.09.01
-      # 2023.11.5, but not 2023.11.05
-      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      - '2[0-9][2-9][3-9].1?[0-9].[1-3]?[0-9]'
+  workflow_dispatch:
 
 jobs:
   release:
@@ -17,13 +12,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # We set the chart release version here - the version schema
+      # is a SemVer adherent date-based versioning scheme that looks like:
+      # 2024.1.1-123456
       - name: Get the version tags
         id: get_version
         run: |
           # Enable pipefail so git command failures do not result in null versions downstream
           set -x
 
-          echo "RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d-%H%M%S')" >> $GITHUB_OUTPUT
           echo "PREFECT_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/PrefectHQ/prefect.git '*.*.*' | tail -n1 | sed 's/.*\///' \
@@ -147,3 +145,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+
+      - name: Create Github Release + Tag
+        run: |
+          gh release create $RELEASE_VERSION \
+            --generate-notes \
+            --notes "Packaged with Prefect version \
+            [$PREFECT_VERSION](https://github.com/PrefectHQ/prefect/releases/tag/$PREFECT_VERSION)"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          PREFECT_VERSION: ${{ steps.get_version.outputs.PREFECT_VERSION }}

--- a/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
+++ b/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
@@ -2,10 +2,6 @@ name: Lint and Test Prometheus Prefect Exporter Chart
 
 "on":
   pull_request:
-    paths:
-      - .github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
-      - .github/linters/prometheus-prefect-exporter-ct.yaml
-      - charts/prometheus-prefect-exporter/**
 
 jobs:
   lint_test:

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -2,10 +2,6 @@ name: Lint and Test Prefect Server Chart
 
 "on":
   pull_request:
-    paths:
-      - .github/workflows/server-lint-and-test.yaml
-      - .github/linters/server-ct.yaml
-      - charts/prefect-server/**
 
 # Do not grant jobs any permissions by default
 permissions: {}

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -2,10 +2,6 @@ name: Lint and Test Prefect Worker Chart
 
 "on":
   pull_request_target:
-    paths:
-      - .github/workflows/worker-lint-and-test.yaml
-      - .github/linters/worker-ct.yaml
-      - charts/prefect-worker/**
 
 # Do not grant jobs any permissions by default
 permissions: {}


### PR DESCRIPTION
Update 2/9/24 - we're also going to _**always**_ run the lint-and-test jobs, as they are required status checks in this repo

--
relates to https://github.com/PrefectHQ/prefect-helm/issues/297

currently, our chart release workflow looks like this:
1. a chart version is set according to the date `2024.2.8`
2. a release/tag in this repo triggers the helm build

a new chart release is triggered by one of the following:
1. [anytime our upstream OSS library has a new update](https://github.com/PrefectHQ/prefect/blob/main/.github/workflows/helm-chart-release.yaml)
2. a manual release/tag is created in this repo

this poses an issue whenever we need to cut multiple OSS releases on the same day, as this results in a release/tag conflict in this repo

in order to solve this, we will:
1. modify the chart versioning schema to include the numerical hour + minute + seconds via [pre-release append](https://semver.org/#spec-item-9) (at the time the release workflow is executed).  This allows us to create multiple releases on the same day, without fear of conflict, as the version schema will now be something like `2024.2.8-204348`
3. only run the release workflow on `workflow_dispatch`, which is reflects the current manual trigger for ad-hoc releases.  additionally, the upstream OSS repo will call `gh workflow run` on the `helm-release.yaml` workflow in this repo -- this ensures that both release triggers operate on the same logic

additionally, we'll avoid the pitfall revealed in [this issue](https://github.com/PrefectHQ/prefect-helm/pull/234) around semver-based ordering not honoring our versioning schema, as this pre-release append ascends numerically + honors the overall schema

https://jubianchi.github.io/semver-check/#/version/2024.2.8-204348