### PR TITLE
fix: add chart version timestamp in the patch slot, without hyphen

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -21,7 +21,7 @@ jobs:
           # Enable pipefail so git command failures do not result in null versions downstream
           set -x
 
-          echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d-%H%M%S')" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_OUTPUT
           echo "PREFECT_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/PrefectHQ/prefect.git '*.*.*' | tail -n1 | sed 's/.*\///' \


### PR DESCRIPTION
so it will be:
```
2024.2.9125019

# instead of

2024.2.9-125019
```

as the [pre-release append](https://semver.org/#spec-item-9) is NOT treated as part of the normal versioning sequence:

> Pre-release versions have a **lower precedence than the associated normal version**. A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements