### PR TITLE
checkout head branch, update workflow reds

### DIFF
--- a/.github/workflows/agent-lint-and-test.yaml
+++ b/.github/workflows/agent-lint-and-test.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5
@@ -46,4 +48,5 @@ jobs:
           kubectl create secret generic prefect-api-key  --from-literal=key=${{ secrets.PREFECT_CLOUD_API_KEY }} -n prefect
 
       - name: Run chart-testing (install)
-        run: ct install --config .github/linters/agent-ct.yaml --helm-extra-set-args "--set=agent.config.workQueueName=agent --set=agent.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=agent.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }}"
+        run: |
+          ct install --config .github/linters/agent-ct.yaml --helm-extra-set-args "--set=agent.config.workQueueName=agent --set=agent.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=agent.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }}" --set=agent.cloudApiConfig.cloudUrl=${{ secrets.PREFECT_CLOUD_API_URL }}"

--- a/.github/workflows/agent-lint-and-test.yaml
+++ b/.github/workflows/agent-lint-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5
@@ -40,10 +42,11 @@ jobs:
         with:
           node_image: "kindest/node:v${{ matrix.kubernetes }}"
 
-      - name: Create API Secret for Agent Chart
+      - name: Create API Secret for Worker Chart
         run: |
           kubectl create ns prefect
           kubectl create secret generic prefect-api-key  --from-literal=key=${{ secrets.PREFECT_CLOUD_API_KEY }} -n prefect
 
       - name: Run chart-testing (install)
-        run: ct install --config .github/linters/worker-ct.yaml --helm-extra-set-args "--set=worker.config.workPool=repo-prefect-helm-gha-workflow-tests --set=worker.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=worker.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }}"
+        run: |
+          ct install --config .github/linters/worker-ct.yaml --helm-extra-set-args "--set=worker.config.workPool=repo-prefect-helm-gha-workflow-tests --set=worker.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=worker.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }}" --set=worker.cloudApiConfig.cloudUrl=${{ secrets.PREFECT_CLOUD_API_URL }}"

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5


### PR DESCRIPTION
Updates the agent/worker validation workflows to:
- checkout and execute against the `head` branch, rather than the `base` (main)
- run against a defined api url

Depends on https://github.com/PrefectHQ/platform/pull/5981