### PR TITLE
Add Namespace to Prometheus-Prefect-Exporter Chart

### DIFF
--- a/.github/linters/prometheus-prefect-exporter-ct.yaml
+++ b/.github/linters/prometheus-prefect-exporter-ct.yaml
@@ -1,6 +1,8 @@
 # See https://github.com/helm/chart-testing#configuration
 charts:
   - charts/prometheus-prefect-exporter
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s
 namespace: default
 release-label: prefect

--- a/charts/prometheus-prefect-exporter/Chart.yaml
+++ b/charts/prometheus-prefect-exporter/Chart.yaml
@@ -2,6 +2,12 @@ apiVersion: v2
 appVersion: "latest"
 description: A Helm chart to deploy Prometheus Prefect Exporter
 home: https://github.com/PrefectHQ
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 2.16.1
 keywords:
   - prometheus-prefect-exporter
 maintainers:

--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -49,6 +49,12 @@ Shoutout to @ialejandro for the original work on this chart!
 | jimid27 | <jimi@prefect.io> |  |
 | parkedwards | <edward@prefect.io> |  |
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 2.16.1 |
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus-prefect-exporter/templates/hpa.yaml
+++ b/charts/prometheus-prefect-exporter/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus-prefect-exporter/templates/pdb.yaml
+++ b/charts/prometheus-prefect-exporter/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-prefect-exporter.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "prometheus-prefect-exporter.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
     {{- with .Values.prometheusRule.additionalLabels -}}

--- a/charts/prometheus-prefect-exporter/templates/service.yaml
+++ b/charts/prometheus-prefect-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus-prefect-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-prefect-exporter/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "prometheus-prefect-exporter.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus-prefect-exporter/values.schema.json
+++ b/charts/prometheus-prefect-exporter/values.schema.json
@@ -311,6 +311,12 @@
       "title": "Affinity",
       "description": "Affinity",
       "form": true
+    },
+    "common": {
+      "type": "object",
+      "title": "Common",
+      "description": "common configuration.  Not set by user but required as common vars are passed to all manifests.",
+      "form": true
     }
   }
 }


### PR DESCRIPTION
This adds a namespace parameter to the `prometheus-prefect-exporter` chart in alignment with the other charts in this repo.