### PR TITLE
Allow prometheus-prefect-exporter to be used as a sub-chart

### DIFF
--- a/charts/prometheus-prefect-exporter/values.schema.json
+++ b/charts/prometheus-prefect-exporter/values.schema.json
@@ -317,6 +317,12 @@
       "title": "Common",
       "description": "common configuration.  Not set by user but required as common vars are passed to all manifests.",
       "form": true
+    },
+    "global": {
+      "type": "object",
+      "title": "Global",
+      "description": "global configuration.  Not set by user but required when prefect is referenced as a downstream Chart",
+      "form": true
     }
   }
 }


### PR DESCRIPTION
Helm adds a property called "global" when a chart is being used as a sub-chart. This must be allowed for in the schema or validation will fail.

The prefect-server and prefect-worker charts already have this defined but it's missing from prometheus-prefect-exporter.