### PR TITLE
chore: allow strings to be passed to `containerPorts` in addition to integers

### DIFF
--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -721,7 +721,7 @@
           "form": true,
           "properties": {
             "postgresql": {
-              "type": "integer",
+              "type": ["integer","string"],
               "title": "Postgres",
               "description": "PostgreSQL container port",
               "form": true


### PR DESCRIPTION
Resolves https://github.com/PrefectHQ/prefect-helm/issues/319