### PR TITLE
Fix git ls-remote pattern for latest prefect release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -25,7 +25,7 @@ jobs:
           echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_OUTPUT
           echo "PREFECT_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
-            https://github.com/PrefectHQ/prefect.git '*.*.*' | tail -n1 | sed 's/.*\///' \
+            https://github.com/PrefectHQ/prefect.git '[!prefect-]*.*.*' | tail -n1 | sed 's/.*\///' \
           )" >> $GITHUB_OUTPUT
 
       - name: Copy Artifact Hub metadata


### PR DESCRIPTION
While deploying the [`2024.4.25194423` release](https://github.com/PrefectHQ/prefect-helm/releases/tag/2024.4.25194423) of the prefect-worker Helm chart, I noticed it is selecting an incorrect git tag for the latest `PREFECT_VERSION`.

<img width="1174" alt="Screenshot 2024-04-26 at 11 23 44 AM" src="https://github.com/PrefectHQ/prefect-helm/assets/409842/67d7099f-199c-49c4-bf66-9a17c1db53b2">


Here are the relevant lines from [Release Helm Chart](https://github.com/PrefectHQ/prefect-helm/actions/runs/8838453598/job/24269623153#step:3:17) GHA run
<img width="1143" alt="Screenshot 2024-04-26 at 11 38 16 AM" src="https://github.com/PrefectHQ/prefect-helm/assets/409842/e00e1e59-80b9-4013-a87b-38e9803b4ba6">



I believe this is due to the recent migration of some of the Prefect maintained collections into the core `prefecthq/prefect` repo, e.g.
* https://github.com/PrefectHQ/prefect/pull/12898


---

The proposed change to the git `ls-remote` pattern may need to be adjusted to align with the Prefect team's plans moving forward, but this appears to address the current issue.

<img width="649" alt="Screenshot 2024-04-26 at 10 50 13 AM" src="https://github.com/PrefectHQ/prefect-helm/assets/409842/cb59c4c8-c9d5-491e-adda-680a28159935">

