### PR TITLE
Introduce automation for releases

### DIFF
--- a/.github/workflows/deploy-latest-helm-version.yaml
+++ b/.github/workflows/deploy-latest-helm-version.yaml
@@ -2,9 +2,6 @@ name: Deploy latest helm releases to internal cluster
 
 "on":
   workflow_dispatch:
-    inputs:
-      helm_version:
-        description: Release Tag
 
 jobs:
   update_helm_releases:

--- a/.github/workflows/deploy-latest-helm-version.yaml
+++ b/.github/workflows/deploy-latest-helm-version.yaml
@@ -19,6 +19,6 @@ jobs:
           gh workflow run updatecli-helm-integration-tests.yaml \
             --repo prefecthq/ops-cluster-deployment \
             --ref main \
-            -f release_version=${{ github.release_version }}
+            -f release_version=${{ github.event.inputs.release_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.OPS_CLUSTER_DEPLOYMENT_ACTIONS_RW }}

--- a/.github/workflows/deploy-latest-helm-version.yaml
+++ b/.github/workflows/deploy-latest-helm-version.yaml
@@ -19,6 +19,6 @@ jobs:
           gh workflow run updatecli-helm-integration-tests.yaml \
             --repo prefecthq/ops-cluster-deployment \
             --ref main \
-            -f helm_version=${{ github.release_version }}
+            -f release_version=${{ github.release_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.OPS_CLUSTER_DEPLOYMENT_ACTIONS_RW }}

--- a/.github/workflows/deploy-latest-helm-version.yaml
+++ b/.github/workflows/deploy-latest-helm-version.yaml
@@ -2,6 +2,9 @@ name: Deploy latest helm releases to internal cluster
 
 "on":
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: Release tag
 
 jobs:
   update_helm_releases:
@@ -16,6 +19,6 @@ jobs:
           gh workflow run updatecli-helm-integration-tests.yaml \
             --repo prefecthq/ops-cluster-deployment \
             --ref main \
-            -f helm_version=${{ github.ref_name }}
+            -f helm_version=${{ github.release_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.OPS_CLUSTER_DEPLOYMENT_ACTIONS_RW }}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -141,7 +141,8 @@ jobs:
       - name: Trigger deploy-latest-helm-version workflow
         run: |
           gh workflow run deploy-latest-helm-version.yaml \
-            --ref main -f release_version=$RELEASE_VERSION
+            --ref main \
+            -f release_version=$RELEASE_VERSION
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -141,8 +141,7 @@ jobs:
       - name: Trigger deploy-latest-helm-version workflow
         run: |
           gh workflow run deploy-latest-helm-version.yaml \
-            --ref main \
-            -f helm_version=$RELEASE_VERSION
+            --ref main
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Trigger deploy-latest-helm-version workflow
         run: |
           gh workflow run deploy-latest-helm-version.yaml \
-            --ref main
+            --ref main -f release_version=$RELEASE_VERSION
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/prometheus-exporter-helm-release.yaml
+++ b/.github/workflows/prometheus-exporter-helm-release.yaml
@@ -23,7 +23,7 @@ jobs:
           set -x
 
           echo "CHART_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_OUTPUT
-          echo "RELEASE_VERSION=prefect-prometheus-exporter-$CHART_VERSION" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=prometheus-prefect-exporter-$CHART_VERSION" >> $GITHUB_OUTPUT
           echo "PROMETHEUS_PREFECT_EXPORTER_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/PrefectHQ/prometheus-prefect-exporter | tail -n1 | sed 's/.*\///' \

--- a/.github/workflows/prometheus-exporter-helm-release.yaml
+++ b/.github/workflows/prometheus-exporter-helm-release.yaml
@@ -1,12 +1,7 @@
 name: Release Prometheus Prefect Exporter Helm Chart
 
 "on":
-  push:
-    tags:
-      # prefect-prometheus-exporter-2023.9.1, but not prefect-prometheus-exporter-2023.09.01
-      # prefect-prometheus-exporter-2023.11.5, but not prefect-prometheus-exporter-2023.11.05
-      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      - 'prefect-prometheus-exporter-2[0-9][2-9][3-9].1?[0-9].[1-3]?[0-9]'
+  workflow_dispatch:
 
 jobs:
   release:
@@ -17,13 +12,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # We set the chart release version here - the version schema
+      # is a SemVer adherent date-based versioning scheme that looks like:
+      # 2024.2.9125019
+      # which equates to a release on 2/9/24 at 12:50:19
       - name: Get the version tags
         id: get_version
         run: |
           # Enable pipefail so git command failures do not result in null versions downstream
           set -x
-          export "FULL_RELEASE=$(echo $GITHUB_REF | cut -d / -f 3)"
-          echo "RELEASE_VERSION=$(echo $FULL_RELEASE | cut -d - -f 4)" >> $GITHUB_OUTPUT
+
+          echo "CHART_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=prefect-prometheus-exporter-$CHART_VERSION" >> $GITHUB_OUTPUT
           echo "PROMETHEUS_PREFECT_EXPORTER_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/PrefectHQ/prometheus-prefect-exporter | tail -n1 | sed 's/.*\///' \
@@ -65,13 +65,13 @@ jobs:
           helm package prometheus-prefect-exporter \
             --destination /tmp/chart \
             --dependency-update \
-            --version $RELEASE_VERSION \
+            --version $CHART_VERSION \
             --app-version $PROMETHEUS_PREFECT_EXPORTER_VERSION \
             --sign --key 'jamie@prefect.io' \
             --keyring $SIGN_KEYRING \
             --passphrase-file $SIGN_PASSPHRASE_FILE
         env:
-          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          CHART_VERSION: ${{ steps.get_version.outputs.CHART_VERSION }}
           PROMETHEUS_PREFECT_EXPORTER_VERSION: ${{ steps.get_version.outputs.PROMETHEUS_PREFECT_EXPORTER_VERSION }}
           SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
           SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
@@ -86,9 +86,29 @@ jobs:
         run: |
           cp /tmp/chart/artifacthub-repo.yml .
           cp /tmp/chart/index.yaml .
-          cp /tmp/chart/prometheus-prefect-exporter-$RELEASE_VERSION.* ./charts
-          git add ./artifacthub-repo.yml ./index.yaml ./charts/prometheus-prefect-exporter-$RELEASE_VERSION.*
-          git commit -m "Release $RELEASE_VERSION"
+          cp /tmp/chart/prometheus-prefect-exporter-$CHART_VERSION.* ./charts
+          git add ./artifacthub-repo.yml ./index.yaml ./charts/prometheus-prefect-exporter-$CHART_VERSION.*
+          git commit -m "Release $CHART_VERSION"
           git push origin gh-pages
         env:
+          CHART_VERSION: ${{ steps.get_version.outputs.CHART_VERSION }}
+
+      - name: Trigger deploy-latest-helm-version workflow
+        run: |
+          gh workflow run deploy-latest-helm-version.yaml \
+            --ref main \
+            -f chart=prometheus-prefect-exporter
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CHART_VERSION: ${{ steps.get_version.outputs.CHART_VERSION }}
+
+      - name: Create Github Release + Tag
+        run: |
+          gh release create $RELEASE_VERSION \
+            --generate-notes \
+            --notes "Packaged with Prometheus Prefect Exporter version \
+            [$PROMETHEUS_PREFECT_EXPORTER_VERSION](https://github.com/PrefectHQ/prometheus-prefect-exporter/releases/tag/$PROMETHEUS_PREFECT_EXPORTER_VERSION)"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          PROMETHEUS_PREFECT_EXPORTER_VERSION: ${{ steps.get_version.outputs.PROMETHEUS_PREFECT_EXPORTER_VERSION }}

--- a/.github/workflows/prometheus-exporter-helm-release.yaml
+++ b/.github/workflows/prometheus-exporter-helm-release.yaml
@@ -100,7 +100,7 @@ jobs:
             -f chart=prometheus-prefect-exporter
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          CHART_VERSION: ${{ steps.get_version.outputs.CHART_VERSION }}
+          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
 
       - name: Create Github Release + Tag
         run: |

--- a/.github/workflows/prometheus-exporter-helm-release.yaml
+++ b/.github/workflows/prometheus-exporter-helm-release.yaml
@@ -97,7 +97,7 @@ jobs:
         run: |
           gh workflow run deploy-latest-helm-version.yaml \
             --ref main \
-            -f chart=prometheus-prefect-exporter
+            -f release_version=$RELEASE_VERSION
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
This PR changes the release structure for the `prometheus-prefect-exporter` chart to be triggered on `workflow_dispatch`, auto-generating its tag, release & chart version

Relates to https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/26