### PR TITLE
chore(prometheus-prefect-exporter): Add additionalLabels for serviceMonitor

### DIFF
--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -85,7 +85,7 @@ Shoutout to @ialejandro for the original work on this chart!
 | service.targetPort | int | `8000` | Pod expose port |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type. Allowed values: NodePort, LoadBalancer or ClusterIP |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Enable creation of ServiceAccount |
-| serviceMonitor | object | `{"enabled":false,"interval":"30s","metricRelabelings":[],"relabelings":[],"scrapeTimeout":"10s"}` | Enable ServiceMonitor to get metrics ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor |
+| serviceMonitor | object | `{"additionalLabels":{},"enabled":false,"interval":"30s","metricRelabelings":[],"relabelings":[],"scrapeTimeout":"10s"}` | Enable ServiceMonitor to get metrics ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor |
 | serviceMonitor.enabled | bool | `false` | Enable or disable |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
 spec:
   jobLabel: "{{ .Release.Name }}"
   selector:

--- a/charts/prometheus-prefect-exporter/values.schema.json
+++ b/charts/prometheus-prefect-exporter/values.schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "replicaCount" : {
+    "replicaCount": {
       "type": "integer",
       "title": "Replica Count",
       "description": "Number of replicas to deploy",
@@ -154,6 +154,12 @@
           "description": "Enable service monitor",
           "form": true
         },
+        "additionalLabels": {
+          "type": "object",
+          "title": "Additional Labels",
+          "description": "Prometheus rule additional labels",
+          "form": true
+        },
         "interval": {
           "type": "string",
           "title": "Interval",
@@ -166,13 +172,13 @@
           "description": "Service monitor timeout",
           "form": true
         },
-        "metricRelabelings" : {
+        "metricRelabelings": {
           "type": "array",
           "title": "Metric Relabelings",
           "description": "Service monitor metric relabelings",
           "form": true
         },
-        "relabelings" : {
+        "relabelings": {
           "type": "array",
           "title": "Relabelings",
           "description": "Service monitor relabelings",

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -69,6 +69,7 @@ service:
 serviceMonitor:
   # -- Enable or disable
   enabled: false
+  additionalLabels: {}
   interval: 30s
   scrapeTimeout: 10s
   metricRelabelings: []


### PR DESCRIPTION
**Context:**
This PR aims to enhance the ServiceMonitor configuration for the prometheus-prefect-exporter by introducing the ability to add custom labels through the additionalLabels field. This change is crucial for ensuring that the ServiceMonitor can be properly managed and identified by Prometheus, particularly in environments where specific labeling is required for integration or management purposes.

**Key Changes:**
Introduction of `additionalLabels`: The updated ServiceMonitor configuration now includes an option to add custom labels specified by `.Values.serviceMonitor.additionalLabels`. This allows users to define additional labels in their Helm values, which will be incorporated into the ServiceMonitor metadata.

**Issue Addressed:**
The previous configuration did not support the addition of custom labels, which limited the ability to manage the ServiceMonitor effectively within Prometheus environments that require specific labeling conventions. This update resolves that issue by providing the necessary flexibility for label customization.

This change ensures that users can now easily add the necessary custom labels to their ServiceMonitor, facilitating better integration and management with Prometheus.