### PR TITLE
Change postgresql.useSubChart to .enabled

### DIFF
--- a/charts/prefect-server/Chart.yaml
+++ b/charts/prefect-server/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
       - bitnami-common
     version: 2.19.1
   - name: postgresql
-    condition: postgresql.useSubChart
+    condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami
     version: 12.12.10
 description: Prefect server application bundle

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -31,14 +31,12 @@ Note: If you choose to make modifications to either the `server.prefectApiUrl` o
 If you are installing the chart as-is (and therefore installing PostgreSQL) - you'll need to update one of two fields:
 1. `postgresql.auth.password`: a password you want to set for the prefect user
 
-2. `postgresql.auth.existingSecret`: name of an existing secret in your cluster with the following fields:
+2. `postgresql.auth.existingSecret`: name of an existing secret in your cluster with the following field:
 
-    1. `connection-string`: fully-quallified connection string in the format of `postgresql+asyncpg://{username}:{password}@{hostname}/{database}`
+    - `connection-string`: fully-quallified connection string in the format of `postgresql+asyncpg://{username}:{password}@{hostname}/{database}`
         - username = `postgresql.auth.username`
         - hostname = `<release-name>-postgresql.<release-namespace>:<postgresql.containerPorts.postgresql>`
         - database = `postgresql.auth.database`
-
-    2. `password`: the same password defined in the `connection-string` above
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -63,7 +63,7 @@ No secrets are created when providing an existing secret.
             mountPath: "/home/prefect/.postgresql"
             readOnly: true
       postgresql:
-        useSubChart: false
+        enabled: false
         auth:
           existingSecret: external-db-connection-string
     ```
@@ -127,13 +127,12 @@ No secrets are created when providing an existing secret.
 | postgresql.auth.password | string | `"prefect-rocks"` | password for the custom user. Ignored if `auth.existingSecret` with key `password` is provided |
 | postgresql.auth.username | string | `"prefect"` | name for a custom user |
 | postgresql.containerPorts | object | `{"postgresql":5432}` | PostgreSQL container port |
-| postgresql.enabled | bool | `true` |  |
+| postgresql.enabled | bool | `true` | enable use of bitnami/postgresql subchart |
 | postgresql.externalHostname | string | `""` |  |
 | postgresql.image.tag | string | `"14.3.0"` | Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/ |
 | postgresql.primary.initdb.user | string | `"postgres"` | specify the PostgreSQL username to execute the initdb scripts |
 | postgresql.primary.persistence.enabled | bool | `false` | enable PostgreSQL Primary data persistence using PVC |
 | postgresql.primary.persistence.size | string | `"8Gi"` | PVC Storage Request for PostgreSQL volume |
-| postgresql.useSubChart | bool | `true` | enable use of bitnami/postgresql subchart |
 | server.affinity | object | `{}` | affinity for server pods assignment |
 | server.autoscaling.enabled | bool | `false` | enable autoscaling for server |
 | server.autoscaling.maxReplicas | int | `100` | maximum number of server replicas |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -40,6 +40,18 @@ If you are installing the chart as-is (and therefore installing PostgreSQL) - yo
 
     2. `password`: the same password defined in the `connection-string` above
 
+If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
+
+```yaml
+prefect-server:
+  postgresql:
+    # Disable the objects from the bundled PostgreSQL chart
+    enabled: false
+    auth:
+      # Provide the name of an existing secret following the instructions above.
+      existingSecret: <existing secret name>
+```
+
 Two secrets are created when not providing an existing secret name:
 1. `prefect-server-postgresql-connection`: used by the prefect-server deployment to connect to the postgresql database.
 

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -30,14 +30,12 @@ Note: If you choose to make modifications to either the `server.prefectApiUrl` o
 If you are installing the chart as-is (and therefore installing PostgreSQL) - you'll need to update one of two fields:
 1. `postgresql.auth.password`: a password you want to set for the prefect user
 
-2. `postgresql.auth.existingSecret`: name of an existing secret in your cluster with the following fields:
+2. `postgresql.auth.existingSecret`: name of an existing secret in your cluster with the following field:
 
-    1. `connection-string`: fully-quallified connection string in the format of `postgresql+asyncpg://{username}:{password}@{hostname}/{database}`
+    - `connection-string`: fully-quallified connection string in the format of `postgresql+asyncpg://{username}:{password}@{hostname}/{database}`
         - username = `postgresql.auth.username`
         - hostname = `<release-name>-postgresql.<release-namespace>:<postgresql.containerPorts.postgresql>`
         - database = `postgresql.auth.database`
-
-    2. `password`: the same password defined in the `connection-string` above
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -39,6 +39,17 @@ If you are installing the chart as-is (and therefore installing PostgreSQL) - yo
 
     2. `password`: the same password defined in the `connection-string` above
 
+If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
+
+```yaml
+prefect-server:
+  postgresql:
+    # Disable the objects from the bundled PostgreSQL chart
+    enabled: false
+    auth:
+      # Provide the name of an existing secret following the instructions above.
+      existingSecret: <existing secret name>
+```
 
 Two secrets are created when not providing an existing secret name:
 1. `prefect-server-postgresql-connection`: used by the prefect-server deployment to connect to the postgresql database.

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -63,7 +63,7 @@ No secrets are created when providing an existing secret.
             mountPath: "/home/prefect/.postgresql"
             readOnly: true
       postgresql:
-        useSubChart: false
+        enabled: false
         auth:
           existingSecret: external-db-connection-string
     ```

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -17,7 +17,7 @@ Create the name of the service account to use
     Otherwise, the configured external hostname will be returned
 */}}
 {{- define "server.postgres-hostname" -}}
-{{- if .Values.postgresql.useSubChart -}}
+{{- if .Values.postgresql.enabled -}}
   {{- $subchart_overrides := .Values.postgresql -}}
   {{- $name := include "postgresql.v1.primary.fullname" (dict "Values" $subchart_overrides "Chart" (dict "Name" "postgresql") "Release" .Release) -}}
   {{- printf "%s.%s" $name .Release.Namespace -}}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -97,13 +97,11 @@ spec:
             {{- end }}
             - name: PREFECT_UI_STATIC_DIRECTORY
               value: {{ .Values.server.uiConfig.prefectUiStaticDirectory | quote }}
-            {{- if .Values.postgresql.enabled }}
             - name: PREFECT_API_DATABASE_CONNECTION_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "server.postgres-string-secret-name" . }}
                   key: connection-string
-            {{- end }}
             {{- if .Values.server.env }}
             {{- include "common.tplvalues.render" (dict "value" .Values.server.env "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -660,12 +660,6 @@
           "description": "external hostname for the postgresql service",
           "form": true
         },
-        "enabled": {
-          "type": "boolean",
-          "title": "Enabled",
-          "description": "enable use of bitnami/postgresql subchart",
-          "form": true
-        },
         "primary": {
           "type": "object",
           "title": "Primary",

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -660,9 +660,9 @@
           "description": "external hostname for the postgresql service",
           "form": true
         },
-        "useSubChart": {
+        "enabled": {
           "type": "boolean",
-          "title": "Use Sub Chart",
+          "title": "Enabled",
           "description": "enable use of bitnami/postgresql subchart",
           "form": true
         },

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -594,49 +594,41 @@
       "type": "object",
       "title": "PostgreSQL",
       "description": "Postgresql configuration",
-      "form": true,
       "properties": {
         "enabled": {
           "type": "boolean",
           "title": "Enabled",
-          "description": "enable postgresql",
-          "form": true
+          "description": "enable postgresql"
         },
         "auth": {
           "type": "object",
           "title": "Auth",
           "description": "postgresql authentication configuration",
-          "form": true,
           "properties": {
             "enablePostgresUser": {
               "type": "boolean",
               "title": "Enable Postgres User",
-              "description": "determines whether an admin user is created within postgres",
-              "form": true
+              "description": "determines whether an admin user is created within postgres"
             },
             "database": {
               "type": "string",
               "title": "Database",
-              "description": "name for a custom database",
-              "form": true
+              "description": "name for a custom database"
             },
             "username": {
               "type": "string",
               "title": "Username",
-              "description": "name for a custom user",
-              "form": true
+              "description": "name for a custom user"
             },
             "password": {
               "type": "string",
               "title": "Password",
-              "description": "password for the custom user",
-              "form": true
+              "description": "password for the custom user"
             },
             "existingSecret": {
               "type": "string",
               "title": "Existing Secret",
-              "description": "name of an existing secret containing the postgresql password",
-              "form": true
+              "description": "name of an existing secret containing the postgresql password"
             }
           }
         },
@@ -644,39 +636,33 @@
           "type": "object",
           "title": "Container Ports",
           "description": "PostgreSQL container port",
-          "form": true,
           "properties": {
             "postgresql": {
               "type": ["integer","string"],
               "title": "Postgres",
-              "description": "PostgreSQL container port",
-              "form": true
+              "description": "PostgreSQL container port"
             }
           }
         },
         "externalHostname": {
           "type": "string",
           "title": "External Hostname",
-          "description": "external hostname for the postgresql service",
-          "form": true
+          "description": "external hostname for the postgresql service"
         },
         "primary": {
           "type": "object",
           "title": "Primary",
           "description": "Initdb configuration",
-          "form": true,
           "properties": {
             "initdb": {
               "type": "object",
               "title": "Initdb",
               "description": "Initdb configuration",
-              "form": true,
               "properties": {
                 "user": {
                   "type": "string",
                   "title": "User",
-                  "description": "specify the PostgreSQL username to execute the initdb scripts",
-                  "form": true
+                  "description": "specify the PostgreSQL username to execute the initdb scripts"
                 }
               }
             },
@@ -684,19 +670,16 @@
               "type": "object",
               "title": "Persistence",
               "description": "Primary persistence configuration",
-              "form": true,
               "properties": {
                 "enabled": {
                   "type": "boolean",
                   "title": "Enabled",
-                  "description": "enable PostgreSQL Primary data persistence using PVC",
-                  "form": true
+                  "description": "enable PostgreSQL Primary data persistence using PVC"
                 },
                 "size": {
                   "type": "string",
                   "title": "Size",
-                  "description": "PVC Storage Request for PostgreSQL volume",
-                  "form": true
+                  "description": "PVC Storage Request for PostgreSQL volume"
                 }
               }
             },
@@ -704,13 +687,11 @@
               "type": "object",
               "title": "Image",
               "description": "Postgres image configuration",
-              "form": true,
               "properties": {
                 "tag": {
                   "type": "string",
                   "title": "Tag",
-                  "description": " Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/",
-                  "form": true
+                  "description": " Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/"
                 }
               }
             }
@@ -721,14 +702,12 @@
     "common": {
       "type": "object",
       "title": "Common",
-      "description": "common configuration.  Not set by user but required as common vars are passed to all manifests.",
-      "form": true
+      "description": "common configuration.  Not set by user but required as common vars are passed to all manifests."
     },
     "global": {
       "type": "object",
       "title": "Global",
-      "description": "global configuration.  Not set by user but required when prefect is referenced as a downstream Chart",
-      "form": true
+      "description": "global configuration.  Not set by user but required when prefect is referenced as a downstream Chart"
     }
   }
 }

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -293,6 +293,7 @@ ingress:
 
 # Postgresql configuration
 postgresql:
+  # -- enable use of bitnami/postgresql subchart
   enabled: true
   auth:
     # -- determines whether an admin user is created within postgres
@@ -321,9 +322,6 @@ postgresql:
   # managed postgres database instance at. This is not required if
   # `internalPostgres` is `true`
   externalHostname: ""
-
-  # -- enable use of bitnami/postgresql subchart
-  useSubChart: true
 
   ## postgresql configuration below here is only used if using the subchart
 


### PR DESCRIPTION
## Summary

Changes `postgresql.useSubChart` to `postgresql.enabled`, following the common convention mentioned in https://helm.sh/docs/topics/charts/https://helm.sh/docs/topics/charts/.

This should hopefully make it clearer what that key does - and this key already existed, so by removing `useSubChart`, there's only one key to manipulate.

Other commits in this PR have commit messages explaining what and why.

Closes https://github.com/PrefectHQ/prefect-helm/issues/336

## Testing

### Internal PostgreSQL enabled (default)

(Default values used)

```
$ helm template test . -f test.values.yaml --show-only charts/postgresql/templates/primary/statefulset.yaml | yq '.metadata.name'
test-postgresql
```

### Internal PostgreSQL disabled

```yaml
postgresql:
  enabled: false
```

```
$ helm template test . -f test.values.yaml --show-only charts/postgresql/templates/primary/statefulset.yaml | yq '.metadata.name'
Error: could not find template charts/postgresql/templates/primary/statefulset.yaml in chart
null
```

### Internal PostgreSQL + default Secret

(Default values used)

```
$ helm template test . -f test.values.yaml --show-only templates/deployment.yaml| yq '.spec.template.spec.containers[0].env[] | select(.name == "PREFECT_API_DATABASE_CONNECTION_URL") | .valueFrom.secretKeyRef.name'
prefect-server-postgresql-connection
```

### Internal PostgreSQL + existing Secret

```yaml
postgresql:
  enabled: true
  auth:
    existingSecret: my-external-pg-secret

```

```
$ helm template test . -f test.values.yaml --show-only templates/deployment.yaml| yq '.spec.template.spec.containers[0].env[] | select(.name == "PREFECT_API_DATABASE_CONNECTION_URL") | .valueFrom.secretKeyRef.name'
my-external-pg-secret
```

### External PostgreSQL + existing Secret

```yaml
postgresql:
  enabled: false
  auth:
    existingSecret: my-external-pg-secret
```

```
$ helm template test . -f test.values.yaml --show-only templates/deployment.yaml| yq '.spec.template.spec.containers[0].env[] | select(.name == "PREFECT_API_DATABASE_CONNECTION_URL") | .valueFrom.secretKeyRef.name'
my-external-pg-secret
```