### PR TITLE
fix: servicemonitor additionalLabels

### DIFF
--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   jobLabel: "{{ .Release.Name }}"

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
-    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | indent 4 }}
+    {{- end }}
 spec:
   jobLabel: "{{ .Release.Name }}"
   selector:


### PR DESCRIPTION
In `prometheus-prefect-exporter` helm chart, if you enable `serviceMonitor` and leave `serviceMonitor.additionalLabels` empty, the error occurs `"Error: YAML parse error on prometheus-prefect-exporter/templates/servicemonitor.yaml: error converting YAML to JSON: yaml: line 11: did not find expected key"`. Fixed this problem.