### PR TITLE
feat(charts): support securityContext.capabilities

### DIFF
--- a/charts/prefect-agent/README.md
+++ b/charts/prefect-agent/README.md
@@ -43,6 +43,7 @@ Prefect Agent application bundle
 | agent.config.workPool | string | `""` | name of prefect workpool the agent will poll; if workpool or workqueues is not provided, we use the default queue |
 | agent.config.workQueues | list | `[]` | names of prefect workqueues the agent will poll; if workpool or workqueues is not provided, we use the default queue |
 | agent.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set agent containers' security context allowPrivilegeEscalation |
+| agent.containerSecurityContext.capabilities | object | `{}` | set agent containers' security context capabilities |
 | agent.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set agent containers' security context readOnlyRootFilesystem |
 | agent.containerSecurityContext.runAsNonRoot | bool | `true` | set agent containers' security context runAsNonRoot |
 | agent.containerSecurityContext.runAsUser | int | `1001` | set agent containers' security context runAsUser |

--- a/charts/prefect-agent/templates/deployment.yaml
+++ b/charts/prefect-agent/templates/deployment.yaml
@@ -122,8 +122,8 @@ spec:
           {{- if .Values.agent.resources }}
           resources: {{- toYaml .Values.agent.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.agent.containerSecurityContext }}
-          securityContext: {{- .Values.agent.containerSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.agent.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /home/prefect

--- a/charts/prefect-agent/values.schema.json
+++ b/charts/prefect-agent/values.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "title": "Name Override",
+      "description": "partially overrides common.names.name"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "title": "Fullname Override",
+      "description": "fully override common.names.fullname"
+    },
+    "namespaceOverride": {
+      "type": "string",
+      "title": "Namespace Override",
+      "description": "fully override common.names.namespace"
+    },
+    "commonLabels": {
+      "type": "object",
+      "title": "Common Labels",
+      "description": "labels to add to all deployed objects"
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "title": "Common Annotations",
+      "description": "annotations to add to all deployed objects"
+    },
+    "server": {
+      "type": "object",
+      "title": "Server",
+      "description": "server configuration",
+      "additionalProperties": false,
+      "properties": {
+        "containerSecurityContext": {
+          "type": "object",
+          "title": "Container Security Context",
+          "description": "server container security context",
+          "additionalProperties": false,
+          "properties": {
+            "runAsUser": {
+              "type": "integer",
+              "title": "Run As User",
+              "description": "set agent container's security context runAsUser"
+            },
+            "runAsNonRoot": {
+              "type": "boolean",
+              "title": "Run As Non Root",
+              "description": "set agent container's security context runAsNonRoot"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean",
+              "title": "Read Only Root Filesystem",
+              "description": "set agent container's security context readOnlyRootFilesystem"
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "title": "Allow Privilege Escalation",
+              "description": "set agent container's security context allowPrivilegeEscalation"
+            },
+            "capabilities": {
+              "type": "object",
+              "title": "Configure Linux capabilities",
+              "description": "set agent container's security context capabilities",
+              "properties": {
+                "add": {
+                  "type": "array",
+                  "title": "Added capabilities",
+                  "description": "set agent container's security context capabilities to add",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "drop": {
+                  "type": "array",
+                  "title": "Removed capabilities",
+                  "description": "set agent container's security context capabilities to remove",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/prefect-agent/values.yaml
+++ b/charts/prefect-agent/values.yaml
@@ -111,6 +111,8 @@ agent:
     readOnlyRootFilesystem: true
     # -- set agent containers' security context allowPrivilegeEscalation
     allowPrivilegeEscalation: false
+    # -- set agent containers' security context capabilities
+    capabilities: {}
 
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for agent pod

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -150,6 +150,7 @@ No secrets are created when providing an existing secret.
 | server.autoscaling.targetCPU | int | `80` | target CPU utilization percentage |
 | server.autoscaling.targetMemory | int | `80` | target Memory utilization percentage |
 | server.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set server containers' security context allowPrivilegeEscalation |
+| server.containerSecurityContext.capabilities | object | `{}` | set server container's security context capabilities |
 | server.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set server containers' security context readOnlyRootFilesystem |
 | server.containerSecurityContext.runAsNonRoot | bool | `true` | set server containers' security context runAsNonRoot |
 | server.containerSecurityContext.runAsUser | int | `1001` | set server containers' security context runAsUser |

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -117,8 +117,8 @@ spec:
           {{- if .Values.server.resources }}
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext }}
-          securityContext: {{- .Values.server.containerSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.server.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -341,6 +341,29 @@
               "type": "boolean",
               "title": "Allow Privilege Escalation",
               "description": "set server container's security context allowPrivilegeEscalation"
+            },
+            "capabilities": {
+              "type": "object",
+              "title": "Configure Linux capabilities",
+              "description": "set server container's security context capabilities",
+              "properties": {
+                "add": {
+                  "type": "array",
+                  "title": "Added capabilities",
+                  "description": "set server container's security context capabilities to add",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "drop": {
+                  "type": "array",
+                  "title": "Removed capabilities",
+                  "description": "set server container's security context capabilities to remove",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         },

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -139,6 +139,8 @@ server:
     readOnlyRootFilesystem: true
     # -- set server containers' security context allowPrivilegeEscalation
     allowPrivilegeEscalation: false
+    # -- set server container's security context capabilities
+    capabilities: {}
 
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for server pod

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -267,6 +267,7 @@ helm install prefect-worker prefect/prefect-worker -f values.yaml --set-file wor
 | worker.config.workPool | string | `""` | the work pool that your started worker will poll. |
 | worker.config.workQueues | list | `[]` | one or more work queue names for the worker to pull from. if not provided, the worker will pull from all work queues in the work pool |
 | worker.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set worker containers' security context allowPrivilegeEscalation |
+| worker.containerSecurityContext.capabilities | object | `{}` | set worker container's security context capabilities |
 | worker.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set worker containers' security context readOnlyRootFilesystem |
 | worker.containerSecurityContext.runAsNonRoot | bool | `true` | set worker containers' security context runAsNonRoot |
 | worker.containerSecurityContext.runAsUser | int | `1001` | set worker containers' security context runAsUser |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -136,8 +136,8 @@ spec:
           {{- if .Values.worker.resources }}
           resources: {{- toYaml .Values.worker.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.worker.containerSecurityContext }}
-          securityContext: {{- .Values.worker.containerSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.worker.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.worker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -443,6 +443,29 @@
               "type": "integer",
               "title": "Run As User",
               "description": "set worker containers' security context runAsUser"
+            },
+            "capabilities": {
+              "type": "object",
+              "title": "Configure Linux capabilities",
+              "description": "set worker container's security context capabilities",
+              "properties": {
+                "add": {
+                  "type": "array",
+                  "title": "Added capabilities",
+                  "description": "set worker container's security context capabilities to add",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "drop": {
+                  "type": "array",
+                  "title": "Removed capabilities",
+                  "description": "set worker container's security context capabilities to remove",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -190,6 +190,8 @@ worker:
     readOnlyRootFilesystem: true
     # -- set worker containers' security context allowPrivilegeEscalation
     allowPrivilegeEscalation: false
+    # -- set worker container's security context capabilities
+    capabilities: {}
 
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for worker pod


### PR DESCRIPTION
## Summary

Adds support for setting `securityContext.capabilities on the server and worker charts.

Closes https://github.com/PrefectHQ/prefect-helm/issues/352

## Testing

### prefect-server chart

Set up values to test:

```yaml
server:
  containerSecurityContext:
    capabilities:
      drop:
        - ALL

worker:
  containerSecurityContext:
    capabilities:
      drop:
        - ALL
  config:
    workPool: foo
  cloudApiConfig:
    accountId: bar
    workspaceId: baz

agent:
  containerSecurityContext:
    capabilities:
      drop:
        - ALL
```

Test the output:

```
$ for chart in $(ls charts | grep '^prefect-'); do helm template test charts/$chart -f test.values.yaml | yq '.spec.template.spec.containers[].securityContext.capabilities'; done

drop:
  - ALL
drop:
  - ALL
---
drop:
  - ALL
drop:
  - ALL
```