### PR TITLE
chore(prometheus-prefect-exporter): make further use of common library chart

### DIFF
--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -62,12 +62,12 @@ Shoutout to @ialejandro for the original work on this chart!
 | affinity | object | `{}` | Affinity for pod assignment |
 | autoscaling | object | `{"enabled":false,"maxReplicas":100,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Autoscaling with CPU or memory utilization percentage |
 | env | object | `{}` | Environment variables to configure application |
-| fullnameOverride | string | `""` | String to fully override prometheus-prefect-exporter.fullname template |
+| fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.1.0"}` | Image registry |
 | imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | Ingress configuration to expose app |
 | livenessProbe | bool | `false` | Enable livenessProbe |
-| nameOverride | string | `""` | String to partially override prometheus-prefect-exporter.fullname template (will maintain the release name) |
+| nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Pod annotations |
 | podDisruptionBudget | object | `{}` | Limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions |

--- a/charts/prometheus-prefect-exporter/templates/NOTES.txt
+++ b/charts/prometheus-prefect-exporter/templates/NOTES.txt
@@ -15,7 +15,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-prefect-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prometheus-prefect-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/charts/prometheus-prefect-exporter/templates/NOTES.txt
+++ b/charts/prometheus-prefect-exporter/templates/NOTES.txt
@@ -6,13 +6,13 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-prefect-exporter.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "prometheus-prefect-exporter.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-prefect-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")

--- a/charts/prometheus-prefect-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-prefect-exporter/templates/_helpers.tpl
@@ -3,19 +3,11 @@ Common labels
 */}}
 {{- define "prometheus-prefect-exporter.labels" -}}
 helm.sh/chart: {{ include "common.names.chart" . }}
-{{ include "prometheus-prefect-exporter.selectorLabels" . }}
+{{ include "common.labels.matchLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "prometheus-prefect-exporter.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "common.names.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/prometheus-prefect-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-prefect-exporter/templates/_helpers.tpl
@@ -1,11 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "prometheus-prefect-exporter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -46,7 +39,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "prometheus-prefect-exporter.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "prometheus-prefect-exporter.name" . }}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/prometheus-prefect-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-prefect-exporter/templates/_helpers.tpl
@@ -1,15 +1,8 @@
 {{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "prometheus-prefect-exporter.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Common labels
 */}}
 {{- define "prometheus-prefect-exporter.labels" -}}
-helm.sh/chart: {{ include "prometheus-prefect-exporter.chart" . }}
+helm.sh/chart: {{ include "common.names.chart" . }}
 {{ include "prometheus-prefect-exporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/prometheus-prefect-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-prefect-exporter/templates/_helpers.tpl
@@ -1,16 +1,4 @@
 {{/*
-Common labels
-*/}}
-{{- define "prometheus-prefect-exporter.labels" -}}
-helm.sh/chart: {{ include "common.names.chart" . }}
-{{ include "common.labels.matchLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
 Create the name of the service account to use
 */}}
 {{- define "prometheus-prefect-exporter.serviceAccountName" -}}

--- a/charts/prometheus-prefect-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-prefect-exporter/templates/_helpers.tpl
@@ -1,22 +1,4 @@
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "prometheus-prefect-exporter.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "prometheus-prefect-exporter.chart" -}}
@@ -48,7 +30,7 @@ Create the name of the service account to use
 */}}
 {{- define "prometheus-prefect-exporter.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "prometheus-prefect-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "prometheus-prefect-exporter.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -19,7 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prometheus-prefect-exporter.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.matchLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.image)}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           {{- if .Values.containerArgs }}

--- a/charts/prometheus-prefect-exporter/templates/hpa.yaml
+++ b/charts/prometheus-prefect-exporter/templates/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "prometheus-prefect-exporter.fullname" . }}
+    name: {{ include "common.names.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/prometheus-prefect-exporter/templates/hpa.yaml
+++ b/charts/prometheus-prefect-exporter/templates/hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/prometheus-prefect-exporter/templates/pdb.yaml
+++ b/charts/prometheus-prefect-exporter/templates/pdb.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/prometheus-prefect-exporter/templates/pdb.yaml
+++ b/charts/prometheus-prefect-exporter/templates/pdb.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus-prefect-exporter.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end }}

--- a/charts/prometheus-prefect-exporter/templates/pdb.yaml
+++ b/charts/prometheus-prefect-exporter/templates/pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "prometheus-prefect-exporter.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "prometheus-prefect-exporter.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     {{- with .Values.prometheusRule.additionalLabels -}}
 {{- toYaml . | nindent 4 -}}
     {{- end }}

--- a/charts/prometheus-prefect-exporter/templates/service.yaml
+++ b/charts/prometheus-prefect-exporter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/service.yaml
+++ b/charts/prometheus-prefect-exporter/templates/service.yaml
@@ -13,4 +13,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "prometheus-prefect-exporter.selectorLabels" . | nindent 4 }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/service.yaml
+++ b/charts/prometheus-prefect-exporter/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/prometheus-prefect-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-prefect-exporter/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "prometheus-prefect-exporter.serviceAccountName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "prometheus-prefect-exporter.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:
-      {{- include "prometheus-prefect-exporter.selectorLabels" . | nindent 8 }}
+      {{- include "common.labels.matchLabels" . | nindent 8 }}
   endpoints:
   - port: http
     interval: {{ .Values.serviceMonitor.interval | quote }}

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/prometheus-prefect-exporter/templates/tests/test-connection.yaml
+++ b/charts/prometheus-prefect-exporter/templates/tests/test-connection.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: "{{ include "common.names.fullname" . }}-test-connection"
   labels:
-    {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/charts/prometheus-prefect-exporter/templates/tests/test-connection.yaml
+++ b/charts/prometheus-prefect-exporter/templates/tests/test-connection.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "prometheus-prefect-exporter.fullname" . }}-test-connection"
+  name: "{{ include "common.names.fullname" . }}-test-connection"
   labels:
     {{- include "prometheus-prefect-exporter.labels" . | nindent 4 }}
   annotations:
@@ -12,6 +12,6 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "prometheus-prefect-exporter.fullname" . }}:{{ .Values.service.targetPort | default .Values.service.port }}']
+      args: ['{{ include "common.names.fullname" . }}:{{ .Values.service.targetPort | default .Values.service.port }}']
   restartPolicy: Never
 {{- end }}

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -8,10 +8,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 1.1.0
 
-# -- String to partially override prometheus-prefect-exporter.fullname template (will maintain the release name)
+# -- String to partially override common.names.fullname template (will maintain the release name)
 nameOverride: ""
 
-# -- String to fully override prometheus-prefect-exporter.fullname template
+# -- String to fully override common.names.fullname template
 fullnameOverride: ""
 
 # -- Global Docker registry secret names as an array


### PR DESCRIPTION
## Summary

Makes further use of Bitnami's `common` library chart.

Closes https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/32

## Testing

### Defaults

A very rudimentary test is just to compare the default chart output on `main` and on this branch and confirm that there are no differences:

```
$ helm template test ../main/charts/prometheus-prefect-exporter > output.main.yaml

$ helm template test charts/prometheus-prefect-exporter > output.branch.yaml

$ dyff between output.{main,branch}.yaml
     _        __  __
   _| |_   _ / _|/ _|  between output.main.yaml, three documents
 / _' | | | | |_| |_       and output.branch.yaml, three documents
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned no differences
        |___/
```

### Specific overrides

Setting the image:

```
$ helm template test charts/prometheus-prefect-exporter --set image.repository=prometheus-test --show-only templates/deployment.yaml | yq '.spec.template.spec.containers[0].image'
prometheus-test:1.1.0
```

Setting the name override:

```
$ helm template test charts/prometheus-prefect-exporter --set nameOverride=prometheusv2 --show-only templates/deployment.yaml | yq '.metadata.name'
test-prometheusv2
```