### PR TITLE
feat(prefect-worker): update Base Job Template with user-provided JSON

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -215,7 +215,7 @@ helm install prefect-worker prefect/prefect-worker -f values.yaml --set-file wor
 
 #### Updating the Base Job Template
 
-If a base job template is set via Helm (via either `.Values.worker.config.baseJobTemplate.configuration` or `.Values.worker.config.baseJobTemplate.existingConfigMapName`), we'll run an optional `initContainer` that will sync the template configuration to the work pool named in `.Values.worker.config.workPool`.
+If a base job template is set through Helm (via either `.Values.worker.config.baseJobTemplate.configuration` or `.Values.worker.config.baseJobTemplate.existingConfigMapName`), we'll run an optional `initContainer` that will sync the template configuration to the work pool named in `.Values.worker.config.workPool`.
 
 Any time the base job template is updated, the subsequent `initContainer` run will run `prefect work-pool update <work-pool-name> --base-job-template <template-json>` and sync this template to the API.
 

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -213,13 +213,22 @@ prefect work-pool get-default-base-job-template --type kubernetes > base-job-tem
 helm install prefect-worker prefect/prefect-worker -f values.yaml --set-file worker.config.baseJobTemplate=base-job-template.json
 ```
 
+#### Updating the Base Job Template
+
+If a base job template is set via Helm (via either `.Values.worker.config.baseJobTemplate.configuration` or `.Values.worker.config.baseJobTemplate.existingConfigMapName`), we'll run an optional `initContainer` that will sync the template configuration to the work pool named in `.Values.worker.config.workPool`.
+
+Any time the base job template is updated, the subsequent `initContainer` run will run `prefect work-pool update <work-pool-name> --base-job-template <template-json>` and sync this template to the API.
+
+Please note that updating JSON inside of a `baseJobTemplate.existingConfigMapName` will require a manual restart of the `prefect-worker` Deployment in order to kick off the `initContainer`.  However, updating the `baseJobTemplate.configuration` value will automatically roll the Deployment.
+
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| jamiezieziula | <jamie@prefect.io> |  |
-| jimid27 | <jimi@prefect.io> |  |
-| parkedwards | <edward@prefect.io> |  |
+| Name          | Email                 | Url |
+|---------------|-----------------------|-----|
+| jamiezieziula | <jamie@prefect.io>    |     |
+| jimid27       | <jimi@prefect.io>     |     |
+| parkedwards   | <edward@prefect.io>   |     |
+| mitchnielsen  | <mitchell@prefect.io> |     |
 
 ## Requirements
 

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -19,9 +19,11 @@ spec:
       app.kubernetes.io/component: worker
   template:
     metadata:
-      {{- if .Values.worker.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
-      {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.worker.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: worker
         prefect-version: {{ .Chart.AppVersion }}
@@ -50,6 +52,72 @@ spec:
       {{- end }}
       {{- if .Values.worker.priorityClassName }}
       priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
+      {{- if include "worker.baseJobTemplateName" . }}
+      initContainers:
+        - name: sync-base-job-template
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.prefectTag }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              work_pool_name={{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool | quote }}
+
+              # suppress work-pool inspect output, as we're just
+              # calling it to check the existence of the work-pool.
+
+              if ! prefect work-pool inspect $work_pool_name > /dev/null; then
+                echo ""
+                echo "Work pool $work_pool_name does not yet exist, meaning this is the initial run."
+                echo "The prefect-worker container will create the work pool on the initial run."
+                echo ""
+                echo "Exiting now!"
+                exit 0
+              fi
+
+              echo ""
+              echo "Work pool $work_pool_name exists; syncing the base job template now..."
+
+              echo ""
+              echo "Work pool $work_pool_name now updating with the following Base Job Template:"
+              echo ""
+              cat ./baseJobTemplate.json
+              echo ""
+
+              prefect work-pool update $work_pool_name --base-job-template ./baseJobTemplate.json
+          workingDir: /home/prefect
+          volumeMounts:
+            - mountPath: /home/prefect
+              name: scratch
+              subPathExpr: home
+            - mountPath: /tmp
+              name: scratch
+              subPathExpr: tmp
+            - mountPath: /home/prefect/baseJobTemplate.json
+              name: base-job-template-file
+              subPath: baseJobTemplate.json
+          env:
+            - name: HOME
+              value: /home/prefect
+            - name: PREFECT_API_URL
+              value: {{ template "worker.apiUrl" . }}
+            - name: PREFECT_KUBERNETES_CLUSTER_UID
+              value: {{ template "worker.clusterUUID" . }}
+            {{- if eq .Values.worker.apiConfig "cloud" }}
+            - name: PREFECT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.worker.cloudApiConfig.apiKeySecret.name }}
+                  key:  {{ .Values.worker.cloudApiConfig.apiKeySecret.key }}
+            {{- else if eq .Values.worker.apiConfig "selfHosted" }}
+            - name: PREFECT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.worker.selfHostedCloudApiConfig.apiKeySecret.name }}
+                  key:  {{ .Values.worker.selfHostedCloudApiConfig.apiKeySecret.key }}
+            {{- end }}
       {{- end }}
       containers:
         - name: prefect-worker


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/prefect-helm/issues/346

## Solution
We'll load an `initContainer` in the prefect-worker pod that uses a `prefect` image (with the CLI). 

The initContainer will check for the presence of an existing `work-pool` by the provided name - if it doesn't exist, then we can assume that the `work-pool` has not yet been initialized and we'll allow the primary container to do so (current behavior)

If it does exist, we'll invoke the `prefect work-pool update <name> --base-job-template <.json>` command - this ensures that any `baseJobTemplate` configuration used by the helm chart will be the source of truth

## Testing

Testing OSS:
https://www.loom.com/share/54da46ed513f482d8ea23ec3ad7cf273

Testing Prefect Cloud:
https://www.loom.com/share/55e5a33179ce4d0e810273adc15de273