### PR TITLE
feat(prefect-worker): configure resources on initContainer

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -292,6 +292,7 @@ Please note that updating JSON inside of a `baseJobTemplate.existingConfigMapNam
 | worker.image.pullPolicy | string | `"IfNotPresent"` | worker image pull policy |
 | worker.image.pullSecrets | list | `[]` | worker image pull secrets |
 | worker.image.repository | string | `"prefecthq/prefect"` | worker image repository |
+| worker.initContainer.resources | object | `{}` | the resource specifications for the sync-base-job-template initContainer Defaults to the resources defined for the worker container |
 | worker.livenessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | worker.livenessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |
 | worker.livenessProbe.config.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -118,6 +118,9 @@ spec:
                   name: {{ .Values.worker.selfHostedCloudApiConfig.apiKeySecret.name }}
                   key:  {{ .Values.worker.selfHostedCloudApiConfig.apiKeySecret.key }}
             {{- end }}
+          {{- with .Values.worker }}
+          resources: {{ coalesce .initContainer.resources .resources | toYaml | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         - name: prefect-worker

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -72,6 +72,58 @@
           "title": "Cluster UID",
           "description": "unique cluster identifier, if none is provided this value will be infered at time of helm install"
         },
+        "initContainer": {
+          "type": "object",
+          "title": "initContainer",
+          "description": "sync-base-job-template initContainer configuration",
+          "additionalProperties": false,
+          "properties": {
+            "resources": {
+              "type": "object",
+              "title": "Resources",
+              "description": "initContainer resource configuration",
+              "additionalProperties": false,
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "title": "Requests",
+                  "description": "the requested resources for the worker container",
+                  "additionalProperties": false,
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "title": "CPU",
+                      "description": "worker resource request cpu"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "title": "Memory",
+                      "description": "worker resource request memory"
+                    }
+                  }
+                },
+                "limits": {
+                  "type": "object",
+                  "title": "Limits",
+                  "description": "the requested limits for the worker container",
+                  "additionalProperties": false,
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "title": "CPU",
+                      "description": "worker resource limit cpu"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "title": "Memory",
+                      "description": "worker resource limit memory"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "image": {
           "type": "object",
           "title": "Image",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -27,6 +27,19 @@ worker:
   # -- unique cluster identifier, if none is provided this value will be infered at time of helm install
   clusterUid: ""
 
+  initContainer:
+    # -- the resource specifications for the sync-base-job-template initContainer
+    # Defaults to the resources defined for the worker container
+    resources: {}
+      # -- the requested resources for the sync-base-job-template initContainer
+      # requests:
+      #   memory: 256Mi
+      #   cpu: 100m
+      # -- the requested limits for the sync-base-job-template initContainer
+      # limits:
+      #   memory: 1Gi
+      #   cpu: 1000m
+
   image:
     # -- worker image repository
     repository: prefecthq/prefect


### PR DESCRIPTION
## Summary

Configures resources on the prefect-worker Deployment's initContainer. Without this, the container could be OOM killed.

Closes https://github.com/PrefectHQ/prefect-helm/issues/359

## Testing

### Using defaults (no overrides)

```yaml
worker:
  # Needed to get a template result
  config:
    workPool: foo
    baseJobTemplate:
      existingConfigMapName: my-template
  cloudApiConfig:
    accountId: bar
    workspaceId: baz
```

```
$ helm template test charts/prefect-worker -f test.values.yaml --show-only templates/deployment.yaml | yq '.spec.template.spec.initContainers[0].resources'
limits:
  cpu: 1000m
  memory: 1Gi
requests:
  cpu: 100m
  memory: 256Mi
```

### Overriding defaults

```yaml
worker:
  # Overriding the resources
  initContainer:
    resources:
      limits:
        cpu: 123m

  # Needed to get a template result
  config:
    workPool: foo
    baseJobTemplate:
      existingConfigMapName: my-template
  cloudApiConfig:
    accountId: bar
    workspaceId: baz
```

```
$ helm template test charts/prefect-worker -f test.values.yaml --show-only templates/deployment.yaml | yq '.spec.template.spec.initContainers[0].resources'
limits:
  cpu: 123m
```