### PR TITLE
feat(prefect-worker): support initContainer securityContext

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -292,6 +292,12 @@ Please note that updating JSON inside of a `baseJobTemplate.existingConfigMapNam
 | worker.image.pullPolicy | string | `"IfNotPresent"` | worker image pull policy |
 | worker.image.pullSecrets | list | `[]` | worker image pull secrets |
 | worker.image.repository | string | `"prefecthq/prefect"` | worker image repository |
+| worker.initContainer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1001}` | security context for the sync-base-job-template initContainer |
+| worker.initContainer.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set init containers' security context allowPrivilegeEscalation |
+| worker.initContainer.containerSecurityContext.capabilities | object | `{}` | set init container's security context capabilities |
+| worker.initContainer.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set init containers' security context readOnlyRootFilesystem |
+| worker.initContainer.containerSecurityContext.runAsNonRoot | bool | `true` | set init containers' security context runAsNonRoot |
+| worker.initContainer.containerSecurityContext.runAsUser | int | `1001` | set init containers' security context runAsUser |
 | worker.initContainer.resources | object | `{}` | the resource specifications for the sync-base-job-template initContainer Defaults to the resources defined for the worker container |
 | worker.livenessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | worker.livenessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -121,6 +121,9 @@ spec:
           {{- with .Values.worker }}
           resources: {{ coalesce .initContainer.resources .resources | toYaml | nindent 12 }}
           {{- end }}
+          {{- with .Values.worker.initContainer.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         - name: prefect-worker

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -87,36 +87,87 @@
                 "requests": {
                   "type": "object",
                   "title": "Requests",
-                  "description": "the requested resources for the worker container",
+                  "description": "the requested resources for the init container",
                   "additionalProperties": false,
                   "properties": {
                     "cpu": {
                       "type": "string",
                       "title": "CPU",
-                      "description": "worker resource request cpu"
+                      "description": "init resource request cpu"
                     },
                     "memory": {
                       "type": "string",
                       "title": "Memory",
-                      "description": "worker resource request memory"
+                      "description": "init resource request memory"
                     }
                   }
                 },
                 "limits": {
                   "type": "object",
                   "title": "Limits",
-                  "description": "the requested limits for the worker container",
+                  "description": "the requested limits for the init container",
                   "additionalProperties": false,
                   "properties": {
                     "cpu": {
                       "type": "string",
                       "title": "CPU",
-                      "description": "worker resource limit cpu"
+                      "description": "init resource limit cpu"
                     },
                     "memory": {
                       "type": "string",
                       "title": "Memory",
-                      "description": "worker resource limit memory"
+                      "description": "init resource limit memory"
+                    }
+                  }
+                }
+              }
+            },
+            "containerSecurityContext": {
+              "type": "object",
+              "title": "Container Security Context",
+              "description": "init container security context configuration",
+              "additionalProperties": false,
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "type": "boolean",
+                  "title": "Allow Privilege Escalation",
+                  "description": "set init containers' security context allowPrivilegeEscalation"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean",
+                  "title": "Read Only Root Filesystem",
+                  "description": "set init containers' security context readOnlyRootFilesystem"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean",
+                  "title": "Run As Non Root",
+                  "description": "set init containers' security context runAsNonRoot"
+                },
+                "runAsUser": {
+                  "type": "integer",
+                  "title": "Run As User",
+                  "description": "set init containers' security context runAsUser"
+                },
+                "capabilities": {
+                  "type": "object",
+                  "title": "Configure Linux capabilities",
+                  "description": "set init container's security context capabilities",
+                  "properties": {
+                    "add": {
+                      "type": "array",
+                      "title": "Added capabilities",
+                      "description": "set init container's security context capabilities to add",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "drop": {
+                      "type": "array",
+                      "title": "Removed capabilities",
+                      "description": "set init container's security context capabilities to remove",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   }
                 }

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -39,6 +39,19 @@ worker:
       # limits:
       #   memory: 1Gi
       #   cpu: 1000m
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    # -- security context for the sync-base-job-template initContainer
+    containerSecurityContext:
+      # -- set init containers' security context runAsUser
+      runAsUser: 1001
+      # -- set init containers' security context runAsNonRoot
+      runAsNonRoot: true
+      # -- set init containers' security context readOnlyRootFilesystem
+      readOnlyRootFilesystem: true
+      # -- set init containers' security context allowPrivilegeEscalation
+      allowPrivilegeEscalation: false
+      # -- set init container's security context capabilities
+      capabilities: {}
 
   image:
     # -- worker image repository


### PR DESCRIPTION
Adds support for setting the securityContext for the init container on prefect-worker chart.

Closes #362

Tested with values:
```
worker:
  initContainer:
    containerSecurityContext:
      runAsUser: 1001
      runAsNonRoot: true
      readOnlyRootFilesystem: true
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
```

```
kubectl get pod prefect-worker-774888d8b4-d28wc -ojson | jq '.spec.initContainers[0].securityContext'
{
  "allowPrivilegeEscalation": false,
  "capabilities": {
    "drop": [
      "ALL"
    ]
  },
  "readOnlyRootFilesystem": true,
  "runAsNonRoot": true,
  "runAsUser": 1001
}
```