### PR TITLE
CI: don't run lint-and-test on gh-pages PRs

### DIFF
--- a/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
+++ b/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
@@ -1,7 +1,9 @@
 name: Lint and Test Prometheus Prefect Exporter Chart
 
 "on":
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   lint_test:

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -1,7 +1,9 @@
 name: Lint and Test Prefect Server Chart
 
 "on":
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
 
 # Do not grant jobs any permissions by default
 permissions: {}

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -2,6 +2,8 @@ name: Lint and Test Prefect Worker Chart
 
 "on":
   pull_request_target:
+    branches:
+      - main
 
 # Do not grant jobs any permissions by default
 permissions: {}


### PR DESCRIPTION
Ensures that lint-and-test actions are only included when the PR target is 'main', which will avoid the problem where these tests try to run on PRs targeting 'gh-pages' where these CI files don't exist.

Example: https://github.com/PrefectHQ/prefect-helm/pull/385/checks

Related to https://linear.app/prefect/issue/PLA-277/cycle-1-catch-all-issue