### PR TITLE
Add `run-helm-docs` flag to updatecli action

### DIFF
--- a/.github/linters/prometheus-prefect-exporter-ct.yaml
+++ b/.github/linters/prometheus-prefect-exporter-ct.yaml
@@ -4,5 +4,4 @@ charts:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s
-namespace: prefect
 release-label: prefect

--- a/.github/linters/server-ct.yaml
+++ b/.github/linters/server-ct.yaml
@@ -4,5 +4,4 @@ charts:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 90s
-namespace: prefect
 release-label: prefect

--- a/.github/updatecli/manifest-major.yaml
+++ b/.github/updatecli/manifest-major.yaml
@@ -7,7 +7,6 @@ sources:
       name: common
       versionFilter:
         kind: semver
-        pattern: 2.x.x
     sourceid: common
   postgresql:
     kind: helmchart
@@ -16,7 +15,6 @@ sources:
       name: postgresql
       versionFilter:
         kind: semver
-        pattern: 11.x.x
     sourceid: postgresql
 conditions: {}
 targets:

--- a/.github/workflows/updatecli-major-versions.yaml
+++ b/.github/workflows/updatecli-major-versions.yaml
@@ -24,4 +24,5 @@ jobs:
         uses: prefecthq/actions-updatecli-apply@main
         with:
           manifest-path: .github/updatecli/manifest-major.yaml
+          run-helm-docs: true
           run-type: major

--- a/.github/workflows/updatecli-minor-versions.yaml
+++ b/.github/workflows/updatecli-minor-versions.yaml
@@ -24,4 +24,5 @@ jobs:
         uses: prefecthq/actions-updatecli-apply@main
         with:
           manifest-path: .github/updatecli/manifest-minor.yaml
+          run-helm-docs: true
           run-type: minor


### PR DESCRIPTION
Relates to [PLA-381](https://linear.app/prefect/issue/PLA-381/re-introduce-helm-docs-into-updatecli-prs-where-applicable)

Depends on https://github.com/PrefectHQ/actions-updatecli-apply/pull/4