### PR TITLE
Allow to define SpreadTopologyContraints in values for server and worker

### DIFF
--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -135,6 +135,17 @@ spec:
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.readinessProbe.config | nindent 12 }}
           {{- end }}
+          {{- if .Values.server.topologySpreadConstraints.enabled }}
+          topologySpreadConstraints:
+            {{- range .Values.server.topologySpreadConstraints.constraints }}
+            - maxSkew: {{ .maxSkew }}
+              topologyKey: {{ .topologyKey }}
+              whenUnsatisfiable: {{ .whenUnsatisfiable }}
+              labelSelector:
+                matchLabels:
+                  {{- toYaml .labelSelector.matchLabels | nindent 12 }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - mountPath: /home/prefect
               name: scratch

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
               whenUnsatisfiable: {{ .whenUnsatisfiable }}
               labelSelector:
                 matchLabels:
-                  {{- toYaml .labelSelector.matchLabels | nindent 12 }}
+                  {{- toYaml .labelSelector.matchLabels | nindent 18 }}
             {{- end }}
           {{- end }}
           volumeMounts:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -206,6 +206,53 @@
             }
           }
         },
+        "topologySpreadConstraints": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "enable or disable topology spread constraints for pods."
+            },
+            "constraints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "maxSkew": {
+                    "type": "integer",
+                    "description": "describes the degree to which Pods may be unevenly distributed.",
+                    "default": 1
+                  },
+                  "topologyKey": {
+                    "type": "string",
+                    "description": "the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.",
+                    "default": "topology.kubernetes.io/zone"
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string",
+                    "enum": ["ScheduleAnyway", "DoNotSchedule"],
+                    "description": "indicates how to deal with a Pod if it doesn't satisfy the spread constraint.",
+                    "default": "ScheduleAnyway"
+                  },
+                  "labelSelector": {
+                    "type": "object",
+                    "properties": {
+                      "matchLabels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "required": ["maxSkew", "topologyKey", "whenUnsatisfiable", "labelSelector"]
+            },
+            "description": "Array of constraints for topology spread of the pods."
+          }
+        },
         "livenessProbe": {
           "type": "object",
           "title": "Liveness Probe",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -95,6 +95,22 @@ server:
       cpu: "1"
       memory: 1Gi
 
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints:
+    enabled: false
+    constraints:
+      # -- describes the degree to which Pods may be unevenly distributed
+      - maxSkew: 1
+        # -- is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology
+        topologyKey: "topology.kubernetes.io/zone"
+        # -- indicates how to deal with a Pod if it doesn't satisfy the spread constraint: ScheduleAnyway or DoNotSchedule
+        whenUnsatisfiable: "ScheduleAnyway"
+        # -- used to find matching Pods
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "prefect-server"
+
+
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:
     enabled: false

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -222,7 +222,8 @@ spec:
           {{- toYaml .Values.worker.livenessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.worker.topologySpreadConstraints.enabled }}
-          topologySpreadConstraints:
+          {{- /*
+ topologySpreadConstraints:
             {{- range .Values.worker.topologySpreadConstraints.constraints }}
             - maxSkew: {{ .maxSkew }}
               topologyKey: {{ .topologyKey }}
@@ -231,7 +232,8 @@ spec:
                 matchLabels:
                   {{- toYaml .labelSelector.matchLabels | nindent 12 }}
             {{- end }}
-          {{- end }}
+          {{- end }} 
+*/ -}}
           volumeMounts:
             - mountPath: /home/prefect
               name: scratch

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -229,7 +229,7 @@ spec:
               whenUnsatisfiable: {{ .whenUnsatisfiable }}
               labelSelector:
                 matchLabels:
-                  {{- toYaml .labelSelector.matchLabels | nindent 12 }}
+                  {{- toYaml .labelSelector.matchLabels | nindent 18 }}
             {{- end }}
           {{- end }}
           volumeMounts:

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -222,8 +222,7 @@ spec:
           {{- toYaml .Values.worker.livenessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.worker.topologySpreadConstraints.enabled }}
-          {{- /*
- topologySpreadConstraints:
+          topologySpreadConstraints:
             {{- range .Values.worker.topologySpreadConstraints.constraints }}
             - maxSkew: {{ .maxSkew }}
               topologyKey: {{ .topologyKey }}
@@ -232,8 +231,7 @@ spec:
                 matchLabels:
                   {{- toYaml .labelSelector.matchLabels | nindent 12 }}
             {{- end }}
-          {{- end }} 
-*/ -}}
+          {{- end }}
           volumeMounts:
             - mountPath: /home/prefect
               name: scratch

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -221,6 +221,17 @@ spec:
               port: 8080
           {{- toYaml .Values.worker.livenessProbe.config | nindent 12 }}
           {{- end }}
+          {{- if .Values.worker.topologySpreadConstraints.enabled }}
+          topologySpreadConstraints:
+            {{- range .Values.worker.topologySpreadConstraints.constraints }}
+            - maxSkew: {{ .maxSkew }}
+              topologyKey: {{ .topologyKey }}
+              whenUnsatisfiable: {{ .whenUnsatisfiable }}
+              labelSelector:
+                matchLabels:
+                  {{- toYaml .labelSelector.matchLabels | nindent 12 }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - mountPath: /home/prefect
               name: scratch

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -452,6 +452,53 @@
             }
           }
         },
+        "topologySpreadConstraints": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "enable or disable topology spread constraints for pods."
+            },
+            "constraints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "maxSkew": {
+                    "type": "integer",
+                    "description": "describes the degree to which Pods may be unevenly distributed.",
+                    "default": 1
+                  },
+                  "topologyKey": {
+                    "type": "string",
+                    "description": "the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.",
+                    "default": "topology.kubernetes.io/zone"
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string",
+                    "enum": ["ScheduleAnyway", "DoNotSchedule"],
+                    "description": "indicates how to deal with a Pod if it doesn't satisfy the spread constraint.",
+                    "default": "ScheduleAnyway"
+                  },
+                  "labelSelector": {
+                    "type": "object",
+                    "properties": {
+                      "matchLabels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "required": ["maxSkew", "topologyKey", "whenUnsatisfiable", "labelSelector"]
+            },
+            "description": "Array of constraints for topology spread of the pods."
+          }
+        },
         "livenessProbe": {
           "type": "object",
           "title": "Liveness Probe",

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -462,6 +462,8 @@
             },
             "constraints": {
               "type": "array",
+              "description": "Array of constraints for topology spread of the pods.",
+              "required": ["maxSkew", "topologyKey", "whenUnsatisfiable", "labelSelector"],
               "items": {
                 "type": "object",
                 "properties": {
@@ -493,10 +495,8 @@
                     }
                   }
                 }
-              },
-              "required": ["maxSkew", "topologyKey", "whenUnsatisfiable", "labelSelector"]
-            },
-            "description": "Array of constraints for topology spread of the pods."
+              }
+            }
           }
         },
         "livenessProbe": {

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -452,53 +452,6 @@
             }
           }
         },
-        "topologySpreadConstraints": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "description": "enable or disable topology spread constraints for pods."
-            },
-            "constraints": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "maxSkew": {
-                    "type": "integer",
-                    "description": "describes the degree to which Pods may be unevenly distributed.",
-                    "default": 1
-                  },
-                  "topologyKey": {
-                    "type": "string",
-                    "description": "the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology.",
-                    "default": "topology.kubernetes.io/zone"
-                  },
-                  "whenUnsatisfiable": {
-                    "type": "string",
-                    "enum": ["ScheduleAnyway", "DoNotSchedule"],
-                    "description": "indicates how to deal with a Pod if it doesn't satisfy the spread constraint.",
-                    "default": "ScheduleAnyway"
-                  },
-                  "labelSelector": {
-                    "type": "object",
-                    "properties": {
-                      "matchLabels": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "required": ["maxSkew", "topologyKey", "whenUnsatisfiable", "labelSelector"]
-            },
-            "description": "Array of constraints for topology spread of the pods."
-          }
-        },
         "livenessProbe": {
           "type": "object",
           "title": "Liveness Probe",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -182,19 +182,7 @@ worker:
       cpu: 1000m
 
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints:
-    enabled: false
-    constraints:
-      # -- describes the degree to which Pods may be unevenly distributed
-      - maxSkew: 1
-        # -- is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology
-        topologyKey: "topology.kubernetes.io/zone"
-        # -- indicates how to deal with a Pod if it doesn't satisfy the spread constraint: ScheduleAnyway or DoNotSchedule
-        whenUnsatisfiable: "ScheduleAnyway"
-        # -- used to find matching Pods
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: "prefect-worker"
+  
 
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -181,6 +181,7 @@ worker:
       memory: 1Gi
       cpu: 1000m
 
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   topologySpreadConstraints:
     enabled: false
     constraints:

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -182,7 +182,19 @@ worker:
       cpu: 1000m
 
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  
+  topologySpreadConstraints:
+    enabled: false
+    constraints:
+      # -- describes the degree to which Pods may be unevenly distributed
+      - maxSkew: 1
+        # -- is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology
+        topologyKey: "topology.kubernetes.io/zone"
+        # -- indicates how to deal with a Pod if it doesn't satisfy the spread constraint: ScheduleAnyway or DoNotSchedule
+        whenUnsatisfiable: "ScheduleAnyway"
+        # -- used to find matching Pods
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "prefect-worker"
 
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -181,6 +181,20 @@ worker:
       memory: 1Gi
       cpu: 1000m
 
+  topologySpreadConstraints:
+    enabled: false
+    constraints:
+      # -- describes the degree to which Pods may be unevenly distributed
+      - maxSkew: 1
+        # -- is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology
+        topologyKey: "topology.kubernetes.io/zone"
+        # -- indicates how to deal with a Pod if it doesn't satisfy the spread constraint: ScheduleAnyway or DoNotSchedule
+        whenUnsatisfiable: "ScheduleAnyway"
+        # -- used to find matching Pods
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "prefect-worker"
+
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:
     enabled: false


### PR DESCRIPTION
Hi, 

This PR allows user to define the SpreadTopologyConstraints for the charts of server and worker.

This feature was requested in https://github.com/PrefectHQ/prefect-helm/issues/360 