### PR TITLE
Send the Prometheus Exporter version to GITHUB_ENV

### DIFF
--- a/.github/workflows/prometheus-exporter-helm-release.yaml
+++ b/.github/workflows/prometheus-exporter-helm-release.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "PROMETHEUS_PREFECT_EXPORTER_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/PrefectHQ/prometheus-prefect-exporter | tail -n1 | sed 's/.*\///' \
-          )" >> $GITHUB_OUTPUT
+          )" >> $GITHUB_ENV
 
       - name: Output version as GitHub Output
         id: output_version


### PR DESCRIPTION
Rather than GITHUB_OUTPUT. This should fix
https://github.com/PrefectHQ/prefect-helm/actions/runs/11391300042/job/31694790555

Related to https://linear.app/prefect/issue/PLA-400/cycle-4-catch-all