### PR TITLE
feat(prefect-worker): support extra initContainers

### DIFF
--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -54,8 +54,9 @@ spec:
       {{- if .Values.worker.priorityClassName }}
       priorityClassName: {{ .Values.worker.priorityClassName }}
       {{- end }}
-      {{- if include "worker.baseJobTemplateName" . }}
+      {{- if or (include "worker.baseJobTemplateName" .) (.Values.worker.initContainer.extraContainers) }}
       initContainers:
+        {{- if include "worker.baseJobTemplateName" . }}
         - name: sync-base-job-template
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.prefectTag }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
@@ -125,6 +126,10 @@ spec:
           {{- with .Values.worker.initContainer.containerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.worker.initContainer.extraContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainer.extraContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: prefect-worker

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -8,6 +8,23 @@ values:
   - ./required_values.yaml
 
 tests:
+  - it: Should set extra init containers
+    set:
+      worker:
+        initContainer:
+          extraContainers:
+            - name: code-init
+              image: custom/prefect-init:v2.0.0
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].name
+          value: code-init
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].image
+          value: custom/prefect-init:v2.0.0
+
   - it: Should set the correct image and tag
     asserts:
       - template: deployment.yaml

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -172,6 +172,14 @@
                   }
                 }
               }
+            },
+            "extraContainers": {
+              "type": "array",
+              "title": "Extra Containers",
+              "description": "additional init containers",
+              "items": {
+                "type": "object"
+              }
             }
           }
         },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -52,7 +52,6 @@ worker:
       allowPrivilegeEscalation: false
       # -- set init container's security context capabilities
       capabilities: {}
-    
     # -- additional sidecar containers
     extraContainers: []
 

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -52,6 +52,9 @@ worker:
       allowPrivilegeEscalation: false
       # -- set init container's security context capabilities
       capabilities: {}
+    
+    # -- additional sidecar containers
+    extraContainers: []
 
   image:
     # -- worker image repository


### PR DESCRIPTION
Providing option to create extra Init Containers for Workers. The Init Containers are set up as optional in addition to the Init Container that is already present in the worker to allow for syncing basejob template. A definition for "extraContainers" has been added.

Resolves https://github.com/PrefectHQ/prefect-helm/issues/393 