### PR TITLE
Bump PostgreSQL from 14.3.0 to 14.13.0

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -152,7 +152,7 @@ prefect-server:
 | postgresql.auth.password | string | `"prefect-rocks"` | password for the custom user. Ignored if `auth.existingSecret` with key `password` is provided |
 | postgresql.auth.username | string | `"prefect"` | name for a custom user |
 | postgresql.enabled | bool | `true` | enable use of bitnami/postgresql subchart |
-| postgresql.image.tag | string | `"14.3.0"` | Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/ |
+| postgresql.image.tag | string | `"14.13.0"` | Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/ |
 | postgresql.primary.initdb.user | string | `"postgres"` | specify the PostgreSQL username to execute the initdb scripts |
 | postgresql.primary.persistence.enabled | bool | `false` | enable PostgreSQL Primary data persistence using PVC |
 | secret.create | bool | `true` | whether to create a Secret containing the PostgreSQL connection string |

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -348,4 +348,4 @@ postgresql:
 
   image:
     # -- Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/
-    tag: 14.3.0
+    tag: 14.13.0


### PR DESCRIPTION
## Summary

Bumps the PostgreSQL image version from 14.3.0 to 14.13.0 to match the version used in production.

This version is currently overridden to downgrade the default version used by the chart, which is PostgreSQL 15.4.0.

When we're ready for newer versions of PostgreSQL, we can look into bumping the PostgreSQL chart version as well. At the moment, there are no newer chart v12 versions, so we'll stick with this for now.

Closes https://linear.app/prefect/issue/PLA-636/update-bitnami-postgresql-helm-chart