### PR TITLE
feat(worker): support env vars from multiple ConfigMaps, Secrets

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -310,7 +310,8 @@ worker:
 | worker.extraEnvVars | list | `[]` | array with extra environment variables to add to worker nodes |
 | worker.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsCMs) |
 | worker.extraEnvVarsCMs | list | `[]` | names of existing ConfigMaps containing extra env vars to add to worker nodes |
-| worker.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to worker nodes |
+| worker.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsSecrets) |
+| worker.extraEnvVarsSecrets | list | `[]` | names of existing Secrets containing extra env vars to add to worker nodes |
 | worker.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the worker pod |
 | worker.extraVolumes | list | `[]` | array with extra volumes for the worker pod |
 | worker.image.debug | bool | `false` | enable worker image debug mode |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -308,7 +308,8 @@ worker:
 | worker.extraArgs | list | `[]` | array with extra Arguments for the worker container to start with |
 | worker.extraContainers | list | `[]` | additional sidecar containers |
 | worker.extraEnvVars | list | `[]` | array with extra environment variables to add to worker nodes |
-| worker.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to worker nodes |
+| worker.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsCMs) |
+| worker.extraEnvVarsCMs | list | `[]` | names of existing ConfigMaps containing extra env vars to add to worker nodes |
 | worker.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to worker nodes |
 | worker.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the worker pod |
 | worker.extraVolumes | list | `[]` | array with extra volumes for the worker pod |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -217,6 +217,10 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVarsSecret "context" $) }}
             {{- end }}
+            {{- range .Values.worker.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+            {{- end }}
           {{- if .Values.worker.resources }}
           resources: {{- toYaml .Values.worker.resources | nindent 12 }}
           {{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -209,6 +209,10 @@ spec:
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVarsCM "context" $) }}
             {{- end }}
+            {{- range .Values.worker.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+            {{- end }}
             {{- if .Values.worker.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVarsSecret "context" $) }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -339,6 +339,38 @@ tests:
             configMapRef:
               name: my-other-config-map
 
+  - it: Should set extra environment variables from Secret
+    set:
+      worker:
+        extraEnvVarsSecret: my-secret
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-secret
+
+  - it: Should set extra environment variables from Secrets
+    set:
+      worker:
+        extraEnvVarsSecrets:
+          - my-secret
+          - my-other-secret
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-secret
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-other-secret
+
   - it: Should set extra volumes
     set:
       worker:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -319,6 +319,26 @@ tests:
           path: .spec.template.spec.containers[0].envFrom[0].configMapRef.name
           value: my-config-map
 
+  - it: Should set extra environment variables from ConfigMaps
+    set:
+      worker:
+        extraEnvVarsCMs:
+          - my-config-map
+          - my-other-config-map
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-config-map
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-other-config-map
+
   - it: Should set extra volumes
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -621,7 +621,12 @@
         "extraEnvVarsCM": {
           "type": "string",
           "title": "Extra Env Vars ConfigMap",
-          "description": "name of existing ConfigMap containing extra env vars to add to worker nodes"
+          "description": "name of existing ConfigMap containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsCMs)"
+        },
+        "extraEnvVarsCMs": {
+          "type": "array",
+          "title": "Extra Env Vars ConfigMaps",
+          "description": "names of existing ConfigMaps containing extra env vars to add to worker nodes"
         },
         "extraEnvVarsSecret": {
           "type": "string",

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -631,7 +631,12 @@
         "extraEnvVarsSecret": {
           "type": "string",
           "title": "Extra Env Vars Secret",
-          "description": "name of existing Secret containing extra env vars to add to worker nodes"
+          "description": "name of existing Secret containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsSecrets)"
+        },
+        "extraEnvVarsSecrets": {
+          "type": "array",
+          "title": "Extra Env Vars Secrets",
+          "description": "names of existing Secrets containing extra env vars to add to worker nodes"
         },
         "extraContainers": {
           "type": "array",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -252,8 +252,11 @@ worker:
   # -- array with extra environment variables to add to worker nodes
   extraEnvVars: []
 
-  # -- name of existing ConfigMap containing extra env vars to add to worker nodes
+  # -- name of existing ConfigMap containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsCMs)
   extraEnvVarsCM: ""
+
+  # -- names of existing ConfigMaps containing extra env vars to add to worker nodes
+  extraEnvVarsCMs: []
 
   # -- name of existing Secret containing extra env vars to add to worker nodes
   extraEnvVarsSecret: ""

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -258,8 +258,11 @@ worker:
   # -- names of existing ConfigMaps containing extra env vars to add to worker nodes
   extraEnvVarsCMs: []
 
-  # -- name of existing Secret containing extra env vars to add to worker nodes
+  # -- name of existing Secret containing extra env vars to add to worker nodes (deprecated, use extraEnvVarsSecrets)
   extraEnvVarsSecret: ""
+
+  # -- names of existing Secrets containing extra env vars to add to worker nodes
+  extraEnvVarsSecrets: []
 
   # -- additional sidecar containers
   extraContainers: []


### PR DESCRIPTION
## Summary

Adds two new keys that support configuring multiple ConfigMaps and/or Secrets in the Worker Deployment to reference environment variables.

This approach was taken to avoid a breaking change. The old keys are marked as deprecated and we can remove them in a subsequent release.

Closes https://github.com/PrefectHQ/prefect-helm/issues/421