### PR TITLE
chore(CI): fix logic for finding prefect version

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -33,7 +33,10 @@ jobs:
           echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_ENV
           echo "PREFECT_VERSION=$(\
             git ls-remote --tags --refs --sort="v:refname" \
-            https://github.com/PrefectHQ/prefect.git '[3].*.[!rc]' | tail -n1 | sed 's/.*\///' \
+              https://github.com/PrefectHQ/prefect.git '3.*.*' \
+              | grep -E -v 'rc|dev' \
+              | tail -n1 \
+              | sed 's/.*\///' \
           )" >> $GITHUB_ENV
 
       - name: Output version as GitHub Output


### PR DESCRIPTION
## Summary

Fixes the logic for finding the latest Prefect version. Previously, this wasn't including versions that had multiple digits in the patch (or minor) version.

We fix it by simplifying the pattern supplied to `git`, and then using `grep` to remove any results containing 'rc' or 'dev'.

Closes https://linear.app/prefect/issue/PLA-898/prefect-helm-fix-semver-release-logic

## Testing

```bash
# incorrect: finds 3.1.9
$ git ls-remote --tags --refs --sort="v:refname" \
            https://github.com/PrefectHQ/prefect.git '[3].*.[!rc]' | tail -n1 | sed 's/.*\///'
3.1.9

# correct: finds 3.1.12
$  git ls-remote --tags --refs --sort="v:refname" \
              https://github.com/PrefectHQ/prefect.git '3.*.*' \
              | grep -E -v 'rc|dev' \
              | tail -n1 \
              | sed 's/.*\///'
3.1.12
```