### PR TITLE
Support seccompProfile attribute

### DIFF
--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -318,6 +318,48 @@
               "type": "integer",
               "title": "FS Group",
               "description": "set server pod's security context fsGroup"
+            },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the pod",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
+                }
+              }
             }
           }
         },

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -131,6 +131,11 @@ server:
     runAsNonRoot: true
     # -- set server pod's security context fsGroup
     fsGroup: 1001
+    # -- set server pod's seccomp profile
+    seccompProfile:
+      type: RuntimeDefault
+      # -- in case of Localhost value in seccompProfile.type, set seccompProfile.localhostProfile value below
+      # localhostProfile: /my-path.json
 
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext:


### PR DESCRIPTION
This commit adds a seccompProfile attribute support for podSecurityContext of prefect-server. Defaults to kubernetes default value RuntimeDefault.