### PR TITLE
fix(appVersion): adjust refs to prefect version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ helm install my-release prefect/prefect-<chart>
 
 ### Installing released versions
 
-Charts are automatically versioned and released together. The `appVersion` and `prefectTag` version are pinned at package time to the current release of Prefect 2.
+Charts are automatically versioned and released together. The `appVersion` and `prefectTag` version are pinned at package time to the current release of Prefect 3.
 
 The charts are hosted in a [Helm repository](https://helm.sh/docs/chart_repository/) deployed to the web courtesy of GitHub Pages.
 

--- a/charts/prefect-server/Chart.yaml
+++ b/charts/prefect-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2-latest
+appVersion: 3-latest
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -109,29 +109,6 @@ prefect-server:
     postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
     ```
 
-## SQLite Configuration
-
-SQLite can be used as an alternative to PostgreSQL. As mentioned in the
-[documentation on hosting Prefect](https://docs-3.prefect.io/v3/manage/self-host),
-SQLite is only recommended for lightweight, single-server deployments.
-
-To use SQLite for the database, provide the following configuration values:
-
-```yaml
-postgresql:
-  enabled: false
-sqlite:
-  enabled: true
-```
-
-More configuration options are available in [`values.yaml`](./values.yaml).
-
-By default, a PersistentVolumeClaim persists the SQLite database file between
-Pod restarts.
-
-Note that enabling SQLite enforces 1 replica in the Deployment, and disables
-the HorizontalPodAutoscaler.
-
 ## Maintainers
 
 | Name | Email | Url |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -109,6 +109,29 @@ prefect-server:
     postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
     ```
 
+## SQLite Configuration
+
+SQLite can be used as an alternative to PostgreSQL. As mentioned in the
+[documentation on hosting Prefect](https://docs-3.prefect.io/v3/manage/self-host),
+SQLite is only recommended for lightweight, single-server deployments.
+
+To use SQLite for the database, provide the following configuration values:
+
+```yaml
+postgresql:
+  enabled: false
+sqlite:
+  enabled: true
+```
+
+More configuration options are available in [`values.yaml`](./values.yaml).
+
+By default, a PersistentVolumeClaim persists the SQLite database file between
+Pod restarts.
+
+Note that enabling SQLite enforces 1 replica in the Deployment, and disables
+the HorizontalPodAutoscaler.
+
 ## Maintainers
 
 | Name | Email | Url |

--- a/charts/prefect-worker/Chart.yaml
+++ b/charts/prefect-worker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2-latest
+appVersion: 3-latest
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Prefect version was bumped to 3 in
https://github.com/PrefectHQ/prefect-helm/pull/377. This adjusts a couple other references to match.

Related to https://linear.app/prefect/issue/PLA-880/cycle-10-catch-all