### PR TITLE
Support seccompProfile attribute in the worker chart.

### DIFF
--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -526,6 +526,64 @@
               "type": "integer",
               "title": "Run As User",
               "description": "set worker pod's security context runAsUser"
+            },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the init container",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "RuntimeDefault",
+                    "Unconfined",
+                    "Localhost"
+                  ]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "RuntimeDefault",
+                            "Unconfined"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "Localhost"
+                          ]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "localhostProfile"
+                      ]
+                    }
+                  ]
+                }
+              }
             }
           }
         },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -206,6 +206,11 @@ worker:
     runAsNonRoot: true
     # -- set worker pod's security context fsGroup
     fsGroup: 1001
+    # -- set worker pod's seccomp profile
+    seccompProfile:
+      type: RuntimeDefault
+      # -- in case of Localhost value in seccompProfile.type, set seccompProfile.localhostProfile value below
+      # localhostProfile: /my-path.json
 
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   # -- priority class name to use for the worker pods; if the priority class is empty or doesn't exist, the worker pods are scheduled without a priority class


### PR DESCRIPTION
This commit adds a seccompProfile attribute support for podSecurityContext in the worker chart similarly to what is done in this PR https://github.com/PrefectHQ/prefect-helm/pull/424. Defaults to kubernetes default value RuntimeDefault.