### PR TITLE
feat(all): add basic auth settings to server, worker, and prom exporter

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -24,6 +24,34 @@ kubectl port-forward svc/prefect-server 4200:4200
 
 Note: If you choose to make modifications to either the `server.prefectApiUrl` or `service.port`, make sure to update the other value with the updated port!
 
+### Basic Auth
+
+Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
+
+Self-hosted Prefect servers can be equipped with Basic Authentication string for an administrator/password combination.
+
+The format of the auth string is `admin:<password>` (no brackets).
+
+```yaml
+server:
+  basicAuth:
+    enabled: true
+    authString: "admin:pass"
+```
+
+Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
+
+```sh
+kubectl create secret generic prefect-server-basic-auth --from-literal=auth-string='admin:my-password'
+```
+
+```yaml
+server:
+  basicAuth:
+    enabled: true
+    existingSecret: prefect-server-basic-auth
+```
+
 ## Background Services Configuration
 
 The Prefect server includes background services related to scheduling and cleanup. By default, these run in the same deployment as the web server, but they can be separated for better resource management and scalability.
@@ -202,7 +230,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the background-services container |
 | backgroundServices.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the background-services container |
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
-| backgroundServices.runAsSeparateDeployment | bool | `false` | Run background services (like scheduling) in a separate deployment. |
+| backgroundServices.runAsSeparateDeployment | bool | `false` |  |
 | backgroundServices.serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
 | backgroundServices.serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | backgroundServices.serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template with "-background-services" appended |
@@ -253,6 +281,9 @@ the HorizontalPodAutoscaler.
 | server.autoscaling.minReplicas | int | `1` | minimum number of server replicas |
 | server.autoscaling.targetCPU | int | `80` | target CPU utilization percentage |
 | server.autoscaling.targetMemory | int | `80` | target Memory utilization percentage |
+| server.basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
+| server.basicAuth.enabled | bool | `false` | enable basic auth for the server, for an administrator/password combination |
+| server.basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | server.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set server containers' security context allowPrivilegeEscalation |
 | server.containerSecurityContext.capabilities | object | `{}` | set server container's security context capabilities |
 | server.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set server containers' security context readOnlyRootFilesystem |
@@ -279,6 +310,7 @@ the HorizontalPodAutoscaler.
 | server.podSecurityContext.fsGroup | int | `1001` | set server pod's security context fsGroup |
 | server.podSecurityContext.runAsNonRoot | bool | `true` | set server pod's security context runAsNonRoot |
 | server.podSecurityContext.runAsUser | int | `1001` | set server pod's security context runAsUser |
+| server.podSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | set server pod's seccomp profile |
 | server.priorityClassName | string | `""` | priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class |
 | server.readinessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | server.readinessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -28,9 +28,9 @@ Note: If you choose to make modifications to either the `server.prefectApiUrl` o
 
 Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
 
-Self-hosted Prefect servers can be equipped with Basic Authentication string for an administrator/password combination.
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination.
 
-The format of the auth string is `admin:<password>` (no brackets).
+The format of the auth string is `admin:<my-password>` (no brackets).
 
 ```yaml
 server:

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -42,14 +42,14 @@ server:
 Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
 
 ```sh
-kubectl create secret generic prefect-server-basic-auth --from-literal=auth-string='admin:my-password'
+kubectl create secret generic prefect-basic-auth --from-literal=auth-string='admin:my-password'
 ```
 
 ```yaml
 server:
   basicAuth:
     enabled: true
-    existingSecret: prefect-server-basic-auth
+    existingSecret: prefect-basic-auth
 ```
 
 ## Background Services Configuration

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -41,14 +41,14 @@ server:
 Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
 
 ```sh
-kubectl create secret generic prefect-server-basic-auth --from-literal=auth-string='admin:my-password'
+kubectl create secret generic prefect-basic-auth --from-literal=auth-string='admin:my-password'
 ```
 
 ```yaml
 server:
   basicAuth:
     enabled: true
-    existingSecret: prefect-server-basic-auth
+    existingSecret: prefect-basic-auth
 ```
 
 ## Background Services Configuration

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -27,9 +27,9 @@ Note: If you choose to make modifications to either the `server.prefectApiUrl` o
 
 Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
 
-Self-hosted Prefect servers can be equipped with Basic Authentication string for an administrator/password combination.
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination.
 
-The format of the auth string is `admin:<password>` (no brackets).
+The format of the auth string is `admin:<my-password>` (no brackets).
 
 ```yaml
 server:

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -23,6 +23,34 @@ kubectl port-forward svc/prefect-server 4200:4200
 
 Note: If you choose to make modifications to either the `server.prefectApiUrl` or `service.port`, make sure to update the other value with the updated port!
 
+### Basic Auth
+
+Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
+
+Self-hosted Prefect servers can be equipped with Basic Authentication string for an administrator/password combination.
+
+The format of the auth string is `admin:<password>` (no brackets).
+
+```yaml
+server:
+  basicAuth:
+    enabled: true
+    authString: "admin:pass"
+```
+
+Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
+
+```sh
+kubectl create secret generic prefect-server-basic-auth --from-literal=auth-string='admin:my-password'
+```
+
+```yaml
+server:
+  basicAuth:
+    enabled: true
+    existingSecret: prefect-server-basic-auth
+```
+
 ## Background Services Configuration
 
 The Prefect server includes background services related to scheduling and cleanup. By default, these run in the same deployment as the web server, but they can be separated for better resource management and scalability.

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -111,7 +111,7 @@ spec:
                   key: connection-string
               {{- end }}
             {{- if .Values.server.basicAuth.enabled }}
-            - name: PREFECT_BASIC_AUTH_STRING
+            - name: PREFECT_SERVER_API_AUTH_STRING
             {{- if .Values.server.basicAuth.existingSecret }}
               valueFrom:
                 secretKeyRef:

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -110,6 +110,17 @@ spec:
                   name: {{ include "server.postgres-string-secret-name" . }}
                   key: connection-string
               {{- end }}
+            {{- if .Values.server.basicAuth.enabled }}
+            - name: PREFECT_BASIC_AUTH_STRING
+            {{- if .Values.server.basicAuth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.basicAuth.existingSecret }}
+                  key: auth-string
+            {{- else }}
+              value: {{ .Values.server.basicAuth.authString | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.global.prefect.env }}
             {{- include "common.tplvalues.render" (dict "value" .Values.global.prefect.env "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -10,7 +10,7 @@ tests:
         notContains:
           path: .spec.template.spec.containers[0].env
           content:
-            name: PREFECT_BASIC_AUTH_STRING
+            name: PREFECT_SERVER_API_AUTH_STRING
 
   - it: Should set basic auth from authString
     set:
@@ -21,7 +21,7 @@ tests:
     asserts:
       - template: server-deployment.yaml
         equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_BASIC_AUTH_STRING")].value
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_AUTH_STRING")].value
           value: "admin:mypassword"
 
   - it: Should set basic auth from existing secret
@@ -35,7 +35,7 @@ tests:
         contains:
           path: .spec.template.spec.containers[0].env
           content:
-            name: PREFECT_BASIC_AUTH_STRING
+            name: PREFECT_SERVER_API_AUTH_STRING
             valueFrom:
               secretKeyRef:
                 name: my-auth-secret

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -4,6 +4,43 @@ release:
   namespace: prefect
 
 tests:
+  - it: Should not set basic auth by default
+    asserts:
+      - template: server-deployment.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_BASIC_AUTH_STRING
+
+  - it: Should set basic auth from authString
+    set:
+      server:
+        basicAuth:
+          enabled: true
+          authString: "admin:mypassword"
+    asserts:
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_BASIC_AUTH_STRING")].value
+          value: "admin:mypassword"
+
+  - it: Should set basic auth from existing secret
+    set:
+      server:
+        basicAuth:
+          enabled: true
+          existingSecret: "my-auth-secret"
+    asserts:
+      - template: server-deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_BASIC_AUTH_STRING
+            valueFrom:
+              secretKeyRef:
+                name: my-auth-secret
+                key: auth-string
+
   - it: Should set the correct image and tag
     asserts:
       - template: server-deployment.yaml

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -93,6 +93,28 @@
       "description": "server configuration",
       "additionalProperties": false,
       "properties": {
+        "basicAuth": {
+          "type": "object",
+          "title": "Basic Auth",
+          "description": "basic auth configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled",
+              "description": "enable basic auth for the server, for an administrator/password combination"
+            },
+            "authString": {
+              "type": "string",
+              "title": "Auth String",
+              "description": "basic auth credentials in the format admin:<your-password> (no brackets)"
+            },
+            "existingSecret": {
+              "type": "string",
+              "title": "Existing Secret",
+              "description": "name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string"
+            }
+          }
+        },
         "image": {
           "type": "object",
           "title": "Image",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -46,6 +46,15 @@ global:
 
 ## Server Deployment Configuration
 server:
+  # ref: https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings
+  basicAuth:
+    # -- enable basic auth for the server, for an administrator/password combination
+    enabled: false
+    # -- basic auth credentials in the format admin:<your-password> (no brackets)
+    authString: "admin:pass"
+    # -- name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string
+    existingSecret: ""
+
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   # -- priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class
   priorityClassName: ""

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -339,6 +339,7 @@ worker:
 | worker.podSecurityContext.fsGroup | int | `1001` | set worker pod's security context fsGroup |
 | worker.podSecurityContext.runAsNonRoot | bool | `true` | set worker pod's security context runAsNonRoot |
 | worker.podSecurityContext.runAsUser | int | `1001` | set worker pod's security context runAsUser |
+| worker.podSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | set worker pod's seccomp profile |
 | worker.priorityClassName | string | `""` | priority class name to use for the worker pods; if the priority class is empty or doesn't exist, the worker pods are scheduled without a priority class |
 | worker.replicaCount | int | `1` | number of worker replicas to deploy |
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -193,14 +193,14 @@ worker:
 Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
 
 ```sh
-kubectl create secret generic prefect-worker-basic-auth --from-literal=auth-string='admin:my-password'
+kubectl create secret generic prefect-basic-auth --from-literal=auth-string='admin:my-password'
 ```
 
 ```yaml
 worker:
   basicAuth:
     enabled: true
-    existingSecret: prefect-worker-basic-auth
+    existingSecret: prefect-basic-auth
 ```
 
 ### Deploying multiple workers to a single namespace

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -173,7 +173,35 @@ Workers each have a type corresponding to the execution environment to which the
 
     You should see the Prefect worker pod running
 
-## FAQ
+## Additional Worker Configurations
+
+### Basic Auth
+
+Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
+
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a self-hosted server with basic auth enabled, you can authenticate your worker with the same credentials.
+
+The format of the auth string is `admin:<my-password>` (no brackets).
+
+```yaml
+worker:
+  basicAuth:
+    enabled: true
+    authString: "admin:pass"
+```
+
+Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
+
+```sh
+kubectl create secret generic prefect-worker-basic-auth --from-literal=auth-string='admin:my-password'
+```
+
+```yaml
+worker:
+  basicAuth:
+    enabled: true
+    existingSecret: prefect-worker-basic-auth
+```
 
 ### Deploying multiple workers to a single namespace
 
@@ -283,6 +311,9 @@ worker:
 | worker.autoscaling.minReplicas | int | `1` | minimum number of replicas to scale down to |
 | worker.autoscaling.targetCPUUtilizationPercentage | int | `80` | target CPU utilization percentage for scaling the worker |
 | worker.autoscaling.targetMemoryUtilizationPercentage | int | `80` | target memory utilization percentage for scaling the worker |
+| worker.basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
+| worker.basicAuth.enabled | bool | `false` | enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well |
+| worker.basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | worker.cloudApiConfig.accountId | string | `""` | prefect account ID |
 | worker.cloudApiConfig.apiKeySecret.key | string | `"key"` | prefect API secret key |
 | worker.cloudApiConfig.apiKeySecret.name | string | `"prefect-api-key"` | prefect API secret name |

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -193,14 +193,14 @@ worker:
 Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
 
 ```sh
-kubectl create secret generic prefect-worker-basic-auth --from-literal=auth-string='admin:my-password'
+kubectl create secret generic prefect-basic-auth --from-literal=auth-string='admin:my-password'
 ```
 
 ```yaml
 worker:
   basicAuth:
     enabled: true
-    existingSecret: prefect-worker-basic-auth
+    existingSecret: prefect-basic-auth
 ```
 
 ### Deploying multiple workers to a single namespace

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -173,7 +173,35 @@ Workers each have a type corresponding to the execution environment to which the
 
     You should see the Prefect worker pod running
 
-## FAQ
+## Additional Worker Configurations
+
+### Basic Auth
+
+Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
+
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a self-hosted server with basic auth enabled, you can authenticate your worker with the same credentials.
+
+The format of the auth string is `admin:<my-password>` (no brackets).
+
+```yaml
+worker:
+  basicAuth:
+    enabled: true
+    authString: "admin:pass"
+```
+
+Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
+
+```sh
+kubectl create secret generic prefect-worker-basic-auth --from-literal=auth-string='admin:my-password'
+```
+
+```yaml
+worker:
+  basicAuth:
+    enabled: true
+    existingSecret: prefect-worker-basic-auth
+```
 
 ### Deploying multiple workers to a single namespace
 

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -201,6 +201,17 @@ spec:
             {{- end }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.worker.image.debug | quote }}
+            {{- if .Values.worker.basicAuth.enabled }}
+            - name: PREFECT_API_AUTH_STRING
+            {{- if .Values.worker.basicAuth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.worker.basicAuth.existingSecret }}
+                  key: auth-string
+            {{- else }}
+              value: {{ .Values.worker.basicAuth.authString | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -8,6 +8,43 @@ values:
   - ./required_values.yaml
 
 tests:
+  - it: Should not set basic auth by default
+    asserts:
+      - template: deployment.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_API_AUTH_STRING
+
+  - it: Should set basic auth from authString
+    set:
+      worker:
+        basicAuth:
+          enabled: true
+          authString: "admin:mypassword"
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_AUTH_STRING")].value
+          value: "admin:mypassword"
+
+  - it: Should set basic auth from existing secret
+    set:
+      worker:
+        basicAuth:
+          enabled: true
+          existingSecret: "my-auth-secret"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_API_AUTH_STRING
+            valueFrom:
+              secretKeyRef:
+                name: my-auth-secret
+                key: auth-string
+
   - it: Should set extra init containers
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -67,6 +67,28 @@
             }
           }
         },
+        "basicAuth": {
+          "type": "object",
+          "title": "Basic Auth",
+          "description": "basic auth configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled",
+              "description": "enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well"
+            },
+            "authString": {
+              "type": "string",
+              "title": "Auth String",
+              "description": "basic auth credentials in the format admin:<your-password> (no brackets)"
+            },
+            "existingSecret": {
+              "type": "string",
+              "title": "Existing Secret",
+              "description": "name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string"
+            }
+          }
+        },
         "clusterUid": {
           "type": "string",
           "title": "Cluster UID",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -24,6 +24,15 @@ worker:
     # -- target memory utilization percentage for scaling the worker
     targetMemoryUtilizationPercentage: 80
 
+  # ref: https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings
+  basicAuth:
+    # -- enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well
+    enabled: false
+    # -- basic auth credentials in the format admin:<your-password> (no brackets)
+    authString: "admin:pass"
+    # -- name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string
+    existingSecret: ""
+
   # -- unique cluster identifier, if none is provided this value will be inferred at time of helm install
   clusterUid: ""
 

--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -96,7 +96,7 @@ basicAuth:
 | csrfAuth | bool | `false` | Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled) |
 | env | object | `{}` | Environment variables to configure application |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.6.6"}` | Image registry |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.1.0"}` | Image registry |
 | imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | Ingress configuration to expose app |
 | livenessProbe | bool | `false` | Enable livenessProbe |

--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -41,6 +41,34 @@ Shoutout to @ialejandro for the original work on this chart!
 
     You should see the Prometheus Prefect Exporter pod running
 
+## Additional Exporter Configurations
+
+### Basic Auth
+
+Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
+
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a self-hosted server with basic auth enabled, you can authenticate your exporter with the same credentials.
+
+The format of the auth string is `admin:<my-password>` (no brackets).
+
+```yaml
+basicAuth:
+    enabled: true
+    authString: "admin:pass"
+```
+
+Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
+
+```sh
+kubectl create secret generic prefect-exporter-basic-auth --from-literal=auth-string='admin:my-password'
+```
+
+```yaml
+basicAuth:
+    enabled: true
+    existingSecret: prefect-exporter-basic-auth
+```
+
 ## Maintainers
 
 | Name | Email | Url |
@@ -62,6 +90,9 @@ Shoutout to @ialejandro for the original work on this chart!
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | autoscaling | object | `{"enabled":false,"maxReplicas":100,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Autoscaling with CPU or memory utilization percentage |
+| basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
+| basicAuth.enabled | bool | `false` | enable basic auth for the exporter, for an administrator/password combination. must be enabled on the server as well |
+| basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | csrfAuth | bool | `false` | Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled) |
 | env | object | `{}` | Environment variables to configure application |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |

--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -60,13 +60,13 @@ basicAuth:
 Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
 
 ```sh
-kubectl create secret generic prefect-exporter-basic-auth --from-literal=auth-string='admin:my-password'
+kubectl create secret generic prefect-basic-auth --from-literal=auth-string='admin:my-password'
 ```
 
 ```yaml
 basicAuth:
     enabled: true
-    existingSecret: prefect-exporter-basic-auth
+    existingSecret: prefect-basic-auth
 ```
 
 ## Maintainers
@@ -96,7 +96,7 @@ basicAuth:
 | csrfAuth | bool | `false` | Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled) |
 | env | object | `{}` | Environment variables to configure application |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.1.0"}` | Image registry |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.6.6"}` | Image registry |
 | imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | Ingress configuration to expose app |
 | livenessProbe | bool | `false` | Enable livenessProbe |

--- a/charts/prometheus-prefect-exporter/README.md.gotmpl
+++ b/charts/prometheus-prefect-exporter/README.md.gotmpl
@@ -41,6 +41,34 @@ Shoutout to @ialejandro for the original work on this chart!
 
     You should see the Prometheus Prefect Exporter pod running
 
+## Additional Exporter Configurations
+
+### Basic Auth
+
+Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
+
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a self-hosted server with basic auth enabled, you can authenticate your exporter with the same credentials.
+
+The format of the auth string is `admin:<my-password>` (no brackets).
+
+```yaml
+basicAuth:
+    enabled: true
+    authString: "admin:pass"
+```
+
+Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
+
+```sh
+kubectl create secret generic prefect-exporter-basic-auth --from-literal=auth-string='admin:my-password'
+```
+
+```yaml
+basicAuth:
+    enabled: true
+    existingSecret: prefect-exporter-basic-auth
+```
+
 
 {{ template "chart.maintainersSection" . }}
 

--- a/charts/prometheus-prefect-exporter/README.md.gotmpl
+++ b/charts/prometheus-prefect-exporter/README.md.gotmpl
@@ -60,13 +60,13 @@ basicAuth:
 Alternatively, you can provide an existing Kubernetes Secret containing the auth string credentials. The secret must contain a key `auth-string` with the value of the auth string.
 
 ```sh
-kubectl create secret generic prefect-exporter-basic-auth --from-literal=auth-string='admin:my-password'
+kubectl create secret generic prefect-basic-auth --from-literal=auth-string='admin:my-password'
 ```
 
 ```yaml
 basicAuth:
     enabled: true
-    existingSecret: prefect-exporter-basic-auth
+    existingSecret: prefect-basic-auth
 ```
 
 

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -84,6 +84,17 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.basicAuth.enabled }}
+          - name: PREFECT_API_AUTH_STRING
+          {{- if .Values.basicAuth.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.basicAuth.existingSecret }}
+                key: auth-string
+          {{- else }}
+            value: {{ .Values.basicAuth.authString | quote }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/prometheus-prefect-exporter/tests/exporter_test.yaml
+++ b/charts/prometheus-prefect-exporter/tests/exporter_test.yaml
@@ -4,6 +4,41 @@ release:
   namespace: default
 
 tests:
+  - it: Should not set basic auth by default
+    asserts:
+      - template: deployment.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_API_AUTH_STRING
+
+  - it: Should set basic auth from authString
+    set:
+      basicAuth:
+        enabled: true
+        authString: "admin:mypassword"
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_AUTH_STRING")].value
+          value: "admin:mypassword"
+
+  - it: Should set basic auth from existing secret
+    set:
+      basicAuth:
+        enabled: true
+        existingSecret: "my-auth-secret"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_API_AUTH_STRING
+            valueFrom:
+              secretKeyRef:
+                name: my-auth-secret
+                key: auth-string
+
   - it: Should set the correct image and tag
     asserts:
       - template: deployment.yaml

--- a/charts/prometheus-prefect-exporter/values.schema.json
+++ b/charts/prometheus-prefect-exporter/values.schema.json
@@ -82,6 +82,28 @@
       "title": "CSRF Auth",
       "description": "Enable CSRF auth"
     },
+    "basicAuth": {
+      "type": "object",
+      "title": "Basic Auth",
+      "description": "basic auth configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled",
+          "description": "enable basic auth for the exporter, for an administrator/password combination. must be enabled on the server as well"
+        },
+        "authString": {
+          "type": "string",
+          "title": "Auth String",
+          "description": "basic auth credentials in the format admin:<your-password> (no brackets)"
+        },
+        "existingSecret": {
+          "type": "string",
+          "title": "Existing Secret",
+          "description": "name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string"
+        }
+      }
+    },
     "pagination": {
       "type": "object",
       "title": "Pagination",

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: prefecthq/prometheus-prefect-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 1.1.0
+  tag: 1.6.6
 
 # -- String to partially override common.names.fullname template (will maintain the release name)
 nameOverride: ""

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -35,6 +35,16 @@ prefectApiUrl: http://prefect-server.prefect.svc.cluster.local:4200/api
 
 # -- Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled)
 csrfAuth: false
+
+# ref: https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings
+basicAuth:
+  # -- enable basic auth for the exporter, for an administrator/password combination. must be enabled on the server as well
+  enabled: false
+  # -- basic auth credentials in the format admin:<your-password> (no brackets)
+  authString: "admin:pass"
+  # -- name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string
+  existingSecret: ""
+
 # -- Pagination settings. If enabled, the exporter will paginate the API requests to Prefect Server which uses more resources.  Remember to increase the resources for the exporter if enabled.
 pagination:
   enabled: true

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: prefecthq/prometheus-prefect-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 1.6.6
+  tag: 1.1.0
 
 # -- String to partially override common.names.fullname template (will maintain the release name)
 nameOverride: ""


### PR DESCRIPTION
relates to https://github.com/PrefectHQ/prefect/pull/16408

implements the env var needed support https://github.com/PrefectHQ/prometheus-prefect-exporter/pull/60

in https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings, there are two env vars:
- `PREFECT_SERVER_API_AUTH_STRING` -> for server processes (eg. prefect-server)
- `PREFECT_API_AUTH_STRING` -> for client processes (eg. prefect-worker, prometheus-exporter)

## Testing
(1) Create a shared secret:
```sh
➜ k create secret generic server-auth --from-literal=auth-string=from-k8s
```

(2) Deploy the server chart

Server values:
```yaml
server:
  basicAuth:
    enabled: true
    existingSecret: server-auth
```

verify the auth string is correctly mounted on the server container
```
➜ keti prefect-server-5c5c977768-7ld25 -- env | grep PREFECT_SERVER_API_AUTH_STRING
PREFECT_SERVER_API_AUTH_STRING=from-k8s
```

(3) Deploy the worker chart, no basic auth
```yaml
worker:
  basicAuth:
    enabled: false
  apiConfig: server
  serverApiConfig:
    apiUrl: http://prefect-server:4200/api
  config:
    workPool: my-pool
```

Verify that the worker is failing auth
```
➜ kl prefect-worker-55b49458b6-9lj96

  File "/usr/local/lib/python3.11/site-packages/prefect/client/base.py", line 355, in send
    response.raise_for_status()
  File "/usr/local/lib/python3.11/site-packages/prefect/client/base.py", line 163, in raise_for_status
    raise PrefectHTTPStatusError.from_httpx_error(exc) from exc.__cause__
prefect.exceptions.PrefectHTTPStatusError: Client error '401 Unauthorized' for url 'http://prefect-server:4200/api/work_pools/my-pool'
Response: {'exception_message': 'Unauthorized'}
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
An exception occurred.
```

Enable basicAuth, mount the same secret

```yaml
worker:
  basicAuth:
    enabled: true
    existingSecret: server-auth
```

```
➜ kl prefect-worker-c9488cc6c-7nsjn
Worker 'KubernetesWorker f52b5522-fd96-44d7-8352-57dd45ecc3b3' started!
```

(4) Deploy the exporter chart, no basic auth
```yaml
basicAuth:
  enabled: false
prefectApiUrl: http://prefect-server:4200/api
```

```sh
➜ kl prefect-exporter-prometheus-prefect-exporter-7d99857d6f-b9chz
2025-01-24 22:25:14,798 - prometheus-prefect-exporter - [INFO] Prefect health check: 200 - OK
2025-01-24 22:25:14,799 - prometheus-prefect-exporter - [INFO] Inizializing metrics...
2025-01-24 22:25:14,803 - prometheus-prefect-exporter - [ERROR] 401 Client Error: Unauthorized for url: http://prefect-server:4200/api/deployments/filter
2025-01-24 22:25:14,807 - prometheus-prefect-exporter - [ERROR] 401 Client Error: Unauthorized for url: http://prefect-server:4200/api/deployments/filter
```

Enable basic auth with shared secret, and profit

```yaml
basicAuth:
  enabled: true
  existingSecret: server-auth
prefectApiUrl: http://prefect-server:4200/api
```

```
➜ kl prefect-exporter-prometheus-prefect-exporter-f9d6d8b65-kh66b
2025-01-24 22:28:48,593 - prometheus-prefect-exporter - [INFO] Added Basic Authorization header for PREFECT_API_AUTH_STRING
2025-01-24 22:28:48,603 - prometheus-prefect-exporter - [INFO] Prefect health check: 200 - OK
2025-01-24 22:28:48,603 - prometheus-prefect-exporter - [INFO] Pagination is enabled
2025-01-24 22:28:48,603 - prometheus-prefect-exporter - [INFO] Pagination limit is 200
2025-01-24 22:28:48,603 - prometheus-prefect-exporter - [INFO] Initializing metrics...
2025-01-24 22:28:48,734 - prometheus-prefect-exporter - [INFO] Exporter listening on 0.0.0.0:8000
```