### PR TITLE
Add workflow to update mise tool versions

### DIFF
--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -17,13 +17,5 @@ jobs:
       # required to open a pr with changes
       pull-requests: write
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
-        with:
-          # This should be 'main' anyway as it will run
-          # on a schedule, but let's be explicit so we can,
-          # for example, run this from pull request branches.
-          ref: 'main'
-
       - name: upgrade mise tools
         uses: prefecthq/actions-mise-upgrade@main

--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -19,15 +19,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          # This should be 'main' anyway as it will run
+          # on a schedule, but let's be explicit so we can,
+          # for example, run this from pull request branches.
+          ref: 'main'
 
-      - name: install mise
-        uses: jdx/mise-action@v2
-
-      - name: upgrade tools in mise
-        run: mise upgrade --bump
-
-      - name: commit and push changes
-        run: |
-          git add .mise.toml
-          git commit -m 'Update mise tool versions'
-          git push origin main
+      - name: upgrade mise tools
+        uses: prefecthq/actions-mise-upgrade@first-implementation

--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -1,0 +1,33 @@
+---
+name: Update mise tool versions
+
+"on":
+  schedule:
+    - cron: 0 15 1 * *  # First of the month @ 3pm UTC
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  updatecli_major:
+    runs-on: ubuntu-latest
+    permissions:
+      # required to write to the repo
+      contents: write
+      # required to open a pr with changes
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install mise
+        uses: jdx/mise-action@v2
+
+      - name: upgrade tools in mise
+        run: mise upgrade --bump
+
+      - name: commit and push changes
+        run: |
+          git add .mise.toml
+          git commit -m 'Update mise tool versions'
+          git push origin main

--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -26,4 +26,4 @@ jobs:
           ref: 'main'
 
       - name: upgrade mise tools
-        uses: prefecthq/actions-mise-upgrade@first-implementation
+        uses: prefecthq/actions-mise-upgrade@main


### PR DESCRIPTION
## Summary

Adds a workflow that updates the versions in .mise.toml and commits and pushes the changes.

Related to https://linear.app/prefect/issue/PLA-961/automate-updating-dependencies-defined-in-mise

## Testing

From what I can tell, I can't really run this until we merge it. This is a completely separate workflow with no dependencies or downstream calls, so we should be safe to merge this, run it, and then tweak as needed.