### PR TITLE
feat(prefect-server): add custom entrypoint and args

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -276,6 +276,7 @@ the HorizontalPodAutoscaler.
 | secret.port | string | `""` | port for the PostgreSQL connection string |
 | secret.username | string | `""` | username for the PostgreSQL connection string |
 | server.affinity | object | `{}` | affinity for server pods assignment |
+| server.args | list | `[]` | Custom container command arguments |
 | server.autoscaling.enabled | bool | `false` | enable autoscaling for server |
 | server.autoscaling.maxReplicas | int | `100` | maximum number of server replicas |
 | server.autoscaling.minReplicas | int | `1` | minimum number of server replicas |
@@ -284,6 +285,7 @@ the HorizontalPodAutoscaler.
 | server.basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
 | server.basicAuth.enabled | bool | `false` | enable basic auth for the server, for an administrator/password combination |
 | server.basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
+| server.command | list | `[]` | Custom container entrypoint |
 | server.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set server containers' security context allowPrivilegeEscalation |
 | server.containerSecurityContext.capabilities | object | `{}` | set server container's security context capabilities |
 | server.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set server containers' security context readOnlyRootFilesystem |

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -57,11 +57,18 @@ spec:
           image: "{{ .Values.global.prefect.image.repository }}:{{ .Values.global.prefect.image.prefectTag }}"
           imagePullPolicy: {{ .Values.global.prefect.image.pullPolicy }}
           command:
+            {{- if .Values.server.command }}
+            {{- .Values.server.command | toYaml | nindent 12 }}
+            {{- else }}
             - /usr/bin/tini
             - -g
             - --
             - /opt/prefect/entrypoint.sh
+            {{- end }}
           args:
+            {{- if .Values.server.args }}
+            {{- .Values.server.args | toYaml | nindent 12 }}
+            {{- else }}
             - prefect
             - server
             - start
@@ -72,6 +79,7 @@ spec:
             - {{ .Values.service.targetPort | quote }}
             {{- range .Values.server.extraArgs }}
             - {{ . | toString }}
+            {{- end }}
             {{- end }}
           workingDir: /home/prefect
           ports:

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -645,3 +645,28 @@ tests:
         equal:
           path: .spec.metrics[1].resource.target.averageUtilization
           value: 80
+
+  - it: Should configure custom entrypoint and args
+    set:
+      server:
+        command:
+          - /usr/bin/tini
+          - myentrypoint
+        args:
+          - prefect
+          - worker
+          - start
+    asserts:
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].command
+          value:
+            - /usr/bin/tini
+            - myentrypoint
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].args
+          value:
+            - prefect
+            - worker
+            - start

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -200,6 +200,22 @@
             "type": "object"
           }
         },
+        "args": {
+          "type": "array",
+          "title": "Custom container command arguments",
+          "description": "array with arguments",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command": {
+          "type": "array",
+          "title": "Custom container entrypoint",
+          "description": "array with container entrypoint",
+          "items": {
+            "type": "string"
+          }
+        },
         "revisionHistoryLimit": {
           "type": "integer",
           "title": "Revision History Limit",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -83,6 +83,12 @@ server:
   ##   - name: PREFECT_API_ENABLE_HTTP2
   ##     value: false
 
+  # -- Custom container command arguments
+  args: []
+
+  # -- Custom container entrypoint
+  command: []
+
   # -- the number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10
 


### PR DESCRIPTION
This can be useful if we want to start a custom image for the server that has a different entrypoint and/or args.