### PR TITLE
breaking(prefect-server): remove confusing & duplicative environment variables

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -324,7 +324,7 @@ the HorizontalPodAutoscaler.
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
-| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL |
+| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI form somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -243,8 +243,6 @@ the HorizontalPodAutoscaler.
 | global.prefect.image.pullPolicy | string | `"IfNotPresent"` | prefect image pull policy |
 | global.prefect.image.pullSecrets | list | `[]` | prefect image pull secrets |
 | global.prefect.image.repository | string | `"prefecthq/prefect"` | prefect image repository |
-| global.prefect.prefectApiHost | string | `"0.0.0.0"` | sets PREFECT_SERVER_API_HOST |
-| global.prefect.prefectApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_API_URL |
 | ingress.annotations | object | `{}` | additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. |
 | ingress.className | string | `""` | IngressClass that will be used to implement the Ingress (Kubernetes 1.18+) |
 | ingress.enabled | bool | `false` | enable ingress record generation for server |
@@ -328,7 +326,6 @@ the HorizontalPodAutoscaler.
 | server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
 | server.uiConfig.prefectUiApiUrl | string | `""` | sets PREFECT_UI_API_URL |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
-| server.uiConfig.prefectUiUrl | string | `""` | sets PREFECT_UI_URL |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |
 | service.externalTrafficPolicy | string | `"Cluster"` | service external traffic policy |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -324,7 +324,7 @@ the HorizontalPodAutoscaler.
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
-| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). |
+| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). You can find additional documentation on this here - https://docs.prefect.io/v3/manage/self-host#ui |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -324,7 +324,7 @@ the HorizontalPodAutoscaler.
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
-| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). |
+| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -324,7 +324,7 @@ the HorizontalPodAutoscaler.
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
-| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI form somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). |
+| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -230,7 +230,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the background-services container |
 | backgroundServices.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the background-services container |
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
-| backgroundServices.runAsSeparateDeployment | string | `"f"` |  |
+| backgroundServices.runAsSeparateDeployment | bool | `false` |  |
 | backgroundServices.serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
 | backgroundServices.serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | backgroundServices.serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template with "-background-services" appended |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -324,7 +324,7 @@ the HorizontalPodAutoscaler.
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
-| server.uiConfig.prefectUiApiUrl | string | `""` | sets PREFECT_UI_API_URL |
+| server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` | service Cluster IP |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -230,7 +230,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the background-services container |
 | backgroundServices.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the background-services container |
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
-| backgroundServices.runAsSeparateDeployment | bool | `false` |  |
+| backgroundServices.runAsSeparateDeployment | bool | `true` |  |
 | backgroundServices.serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
 | backgroundServices.serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | backgroundServices.serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template with "-background-services" appended |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -230,7 +230,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the background-services container |
 | backgroundServices.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the background-services container |
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
-| backgroundServices.runAsSeparateDeployment | bool | `true` |  |
+| backgroundServices.runAsSeparateDeployment | string | `"f"` |  |
 | backgroundServices.serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
 | backgroundServices.serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | backgroundServices.serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template with "-background-services" appended |

--- a/charts/prefect-server/UPGRADING.md
+++ b/charts/prefect-server/UPGRADING.md
@@ -1,5 +1,24 @@
 # Upgrade guidelines
 
+## > TBD
+
+After version `TBD` the `prefect-server` chart has removed some exposed environment variables in favor of a more simplified configuration. In particular, the `prefectApiUrl` and `prefectApiHost` values have been removed in favor of the single `prefectUiApiUrl` value.
+
+### Adjusting your configuration
+
+#### API URLs
+
+- `.Values.global.prefect.prefectApiUrl` => `.Values.server.uiConfig.prefectUiApiUrl`
+- `.Values.global.prefect.prefectApiHost` => `.Values.server.uiConfig.prefectUiApiUrl`
+
+Note: If you were using the default value for `prefectApiUrl` (i.e. `http://localhost:4200/api`) you do not need to make any changes, as the default value for `prefectUiApiUrl` is the same.
+
+#### UI URL
+
+`.Values.server.uiConfig.prefectUiUrl` has been removed altogether. This value was used solely for the purposes of printing out the UI URL during the installation process. It will now infer the UI URL from the `prefectUiApiUrl` value.
+
+---
+
 ## > 2025.1.23213604
 
 After version `2025.1.23213604`, the `prefect-server` chart [introduces the option to run background services as a separate deployment](https://github.com/PrefectHQ/prefect-helm/pull/425). Due to the numerous shared values between the `server` and `background-services` deployments, the `values.yaml` file has been consolidated in the following ways:

--- a/charts/prefect-server/templates/NOTES.txt
+++ b/charts/prefect-server/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- include "prefect-server.validatePrefectVersion" . }}
+{{- include "prefect-server.validatePrefectServerApiSettings" . }}
 {{- if .Values.ingress.enabled }}
 http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host.hostname }}{{ .Values.ingress.host.path }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -130,9 +130,5 @@ Create the name of the service account to associate with the background-services
 // ----- End connection string templates -----
 
 {{- define "server.uiUrl" -}}
-{{- if .Values.server.uiConfig.prefectUiUrl -}}
-  {{- .Values.server.uiConfig.prefectUiUrl -}}
-{{- else -}}
-  {{- printf "%s" (replace "/api" "" .Values.global.prefect.prefectApiUrl) -}}
-{{- end -}}
+  {{- printf "%s" (replace "/api" "" .Values.server.uiConfig.prefectUiApiUrl) -}}
 {{- end -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -1,5 +1,5 @@
 {{- define "prefect-server.validatePrefectVersion" -}}
-{{- if .Values.backgroundServices.runAsSeparateDeployment }}
+{{- if .Values.backgroundServices.runAsSeparateDeployment -}}
   {{- $prefectTag := .Values.global.prefect.image.prefectTag -}}
   {{- if not (regexMatch "^[0-9]+" $prefectTag) -}}
     {{- fail "When running background services separately, Prefect tag must start with a version number" -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -21,7 +21,6 @@
 {{- end -}}
 {{- end -}}
 
-
 {{- define "prefect-server.validatePrefectServerApiSettings" -}}
 {{- if .Values.global.prefect.prefectApiUrl -}}
   {{- fail "prefectApiUrl is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -26,7 +26,7 @@
   {{- fail "prefectApiUrl is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}
 {{- end -}}
 {{- if .Values.global.prefect.prefectApiHost -}}
-  {{- fail "prefectApiHost is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}
+  {{- fail "`global.prefect.prefectApiHost` has been removed. Please use `server.uiConfig.prefectUiApiUrl` instead." -}}
 {{- end -}}
 {{- if .Values.server.uiConfig.prefectUiUrl -}}
   {{- fail "`server.uiConfig.prefectUiUrl` has been removed. This value was used solely for the purposes of printing out the UI URL during the installation process. It will now infer the UI URL from the `prefectUiApiUrl` value." -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -19,7 +19,6 @@
     {{- fail "When running background services separately, Prefect version must be 3.1.13 or higher" -}}
   {{- end -}}
 {{- end -}}
-{{- end -}}
 
 {{- define "prefect-server.validatePrefectServerApiSettings" -}}
 {{- if .Values.global.prefect.prefectApiUrl -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -19,6 +19,7 @@
     {{- fail "When running background services separately, Prefect version must be 3.1.13 or higher" -}}
   {{- end -}}
 {{- end -}}
+{{- end -}}
 
 {{- define "prefect-server.validatePrefectServerApiSettings" -}}
 {{- if .Values.global.prefect.prefectApiUrl -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -1,21 +1,23 @@
 {{- define "prefect-server.validatePrefectVersion" -}}
-{{- $prefectTag := .Values.global.prefect.image.prefectTag -}}
-{{- if not (regexMatch "^[0-9]+" $prefectTag) -}}
-  {{- fail "When running background services separately, Prefect tag must start with a version number" -}}
-{{- end -}}
+{{- if .Values.backgroundServices.runAsSeparateDeployment }}
+  {{- $prefectTag := .Values.global.prefect.image.prefectTag -}}
+  {{- if not (regexMatch "^[0-9]+" $prefectTag) -}}
+    {{- fail "When running background services separately, Prefect tag must start with a version number" -}}
+  {{- end -}}
 
-{{- $version := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" $prefectTag -}}
-{{- if not $version -}}
-  {{- fail "When running background services separately, Prefect tag must be in format X.Y.Z" -}}
-{{- end -}}
+  {{- $version := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" $prefectTag -}}
+  {{- if not $version -}}
+    {{- fail "When running background services separately, Prefect tag must be in format X.Y.Z" -}}
+  {{- end -}}
 
-{{- $parts := splitList "." $version -}}
-{{- $major := index $parts 0 | atoi -}}
-{{- $minor := index $parts 1 | atoi -}}
-{{- $patch := index $parts 2 | atoi -}}
+  {{- $parts := splitList "." $version -}}
+  {{- $major := index $parts 0 | atoi -}}
+  {{- $minor := index $parts 1 | atoi -}}
+  {{- $patch := index $parts 2 | atoi -}}
 
-{{- if or (lt $major 3) (and (eq $major 3) (lt $minor 1)) (and (eq $major 3) (eq $minor 1) (lt $patch 13)) -}}
-  {{- fail "When running background services separately, Prefect version must be 3.1.13 or higher" -}}
+  {{- if or (lt $major 3) (and (eq $major 3) (lt $minor 1)) (and (eq $major 3) (eq $minor 1) (lt $patch 13)) -}}
+    {{- fail "When running background services separately, Prefect version must be 3.1.13 or higher" -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -1,22 +1,33 @@
 {{- define "prefect-server.validatePrefectVersion" -}}
-{{- if .Values.backgroundServices.runAsSeparateDeployment -}}
-  {{- $prefectTag := .Values.global.prefect.image.prefectTag -}}
-  {{- if not (regexMatch "^[0-9]+" $prefectTag) -}}
-    {{- fail "When running background services separately, Prefect tag must start with a version number" -}}
-  {{- end -}}
+{{- $prefectTag := .Values.global.prefect.image.prefectTag -}}
+{{- if not (regexMatch "^[0-9]+" $prefectTag) -}}
+  {{- fail "When running background services separately, Prefect tag must start with a version number" -}}
+{{- end -}}
 
-  {{- $version := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" $prefectTag -}}
-  {{- if not $version -}}
-    {{- fail "When running background services separately, Prefect tag must be in format X.Y.Z" -}}
-  {{- end -}}
+{{- $version := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" $prefectTag -}}
+{{- if not $version -}}
+  {{- fail "When running background services separately, Prefect tag must be in format X.Y.Z" -}}
+{{- end -}}
 
-  {{- $parts := splitList "." $version -}}
-  {{- $major := index $parts 0 | atoi -}}
-  {{- $minor := index $parts 1 | atoi -}}
-  {{- $patch := index $parts 2 | atoi -}}
+{{- $parts := splitList "." $version -}}
+{{- $major := index $parts 0 | atoi -}}
+{{- $minor := index $parts 1 | atoi -}}
+{{- $patch := index $parts 2 | atoi -}}
 
-  {{- if or (lt $major 3) (and (eq $major 3) (lt $minor 1)) (and (eq $major 3) (eq $minor 1) (lt $patch 13)) -}}
-    {{- fail "When running background services separately, Prefect version must be 3.1.13 or higher" -}}
-  {{- end -}}
+{{- if or (lt $major 3) (and (eq $major 3) (lt $minor 1)) (and (eq $major 3) (eq $minor 1) (lt $patch 13)) -}}
+  {{- fail "When running background services separately, Prefect version must be 3.1.13 or higher" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "prefect-server.validatePrefectServerApiSettings" -}}
+{{- if .Values.global.prefect.prefectApiUrl -}}
+  {{- fail "prefectApiUrl is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}
+{{- end -}}
+{{- if .Values.global.prefect.prefectApiHost -}}
+  {{- fail "prefectApiHost is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}
+{{- end -}}
+{{- if .Values.server.uiConfig.prefectUiUrl -}}
+  {{- fail "prefectUiUrl has been removed. This value was used solely for the purposes of printing out the UI URL during the installation process. It will now infer the UI URL from the `prefectUiApiUrl` value." -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -29,6 +29,6 @@
   {{- fail "prefectApiHost is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}
 {{- end -}}
 {{- if .Values.server.uiConfig.prefectUiUrl -}}
-  {{- fail "prefectUiUrl has been removed. This value was used solely for the purposes of printing out the UI URL during the installation process. It will now infer the UI URL from the `prefectUiApiUrl` value." -}}
+  {{- fail "`server.uiConfig.prefectUiUrl` has been removed. This value was used solely for the purposes of printing out the UI URL during the installation process. It will now infer the UI URL from the `prefectUiApiUrl` value." -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -23,7 +23,7 @@
 
 {{- define "prefect-server.validatePrefectServerApiSettings" -}}
 {{- if .Values.global.prefect.prefectApiUrl -}}
-  {{- fail "prefectApiUrl is deprecated. Please use `.Values.server.uiConfig.prefectUiApiUrl` instead." -}}
+  {{- fail "`global.prefect.prefectApiUrl` has been removed. Please use `server.uiConfig.prefectUiApiUrl` instead." -}}
 {{- end -}}
 {{- if .Values.global.prefect.prefectApiHost -}}
   {{- fail "`global.prefect.prefectApiHost` has been removed. Please use `server.uiConfig.prefectUiApiUrl` instead." -}}

--- a/charts/prefect-server/templates/background-services-deployment.yaml
+++ b/charts/prefect-server/templates/background-services-deployment.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.backgroundServices.runAsSeparateDeployment }}
-{{- include "prefect-server.validatePrefectVersion" . }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/prefect-server/templates/background-services-deployment.yaml
+++ b/charts/prefect-server/templates/background-services-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.backgroundServices.runAsSeparateDeployment }}
+{{- include "prefect-server.validatePrefectVersion" . }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/prefect-server/templates/background-services-deployment.yaml
+++ b/charts/prefect-server/templates/background-services-deployment.yaml
@@ -71,14 +71,10 @@ spec:
           env:
             - name: HOME
               value: /home/prefect
-            - name: PREFECT_API_URL
-              value: {{ .Values.global.prefect.prefectApiUrl | quote }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.backgroundServices.debug | quote }}
             - name: PREFECT_LOGGING_SERVER_LEVEL
               value: {{ .Values.backgroundServices.loggingLevel | quote }}
-            - name: PREFECT_SERVER_API_HOST
-              value: {{ .Values.global.prefect.prefectApiHost | quote }}
             - name: PREFECT_UI_ENABLED
               value: 'false'
             - name: PREFECT_API_DATABASE_CONNECTION_URL

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -95,10 +95,8 @@ spec:
               value: {{ .Values.service.targetPort | quote }}
             - name: PREFECT_UI_ENABLED
               value: {{ .Values.server.uiConfig.enabled | quote }}
-            {{- if .Values.server.uiConfig.prefectUiApiUrl }}
             - name: PREFECT_UI_API_URL
               value: {{ .Values.server.uiConfig.prefectUiApiUrl | quote }}
-            {{- end }}
             - name: PREFECT_UI_STATIC_DIRECTORY
               value: {{ .Values.server.uiConfig.prefectUiStaticDirectory | quote }}
             - name: PREFECT_API_DATABASE_CONNECTION_URL

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -1,4 +1,3 @@
-{{- include "prefect-server.validatePrefectServerApiSettings" . }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -87,14 +87,10 @@ spec:
           env:
             - name: HOME
               value: /home/prefect
-            - name: PREFECT_API_URL
-              value: {{ .Values.global.prefect.prefectApiUrl | quote }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.server.debug | quote }}
             - name: PREFECT_LOGGING_SERVER_LEVEL
               value: {{ .Values.server.loggingLevel | quote }}
-            - name: PREFECT_SERVER_API_HOST
-              value: {{ .Values.global.prefect.prefectApiHost | quote }}
             - name: PREFECT_SERVER_API_PORT
               value: {{ .Values.service.targetPort | quote }}
             - name: PREFECT_UI_ENABLED
@@ -102,10 +98,6 @@ spec:
             {{- if .Values.server.uiConfig.prefectUiApiUrl }}
             - name: PREFECT_UI_API_URL
               value: {{ .Values.server.uiConfig.prefectUiApiUrl | quote }}
-            {{- end }}
-            {{- if .Values.server.uiConfig.prefectUiUrl }}
-            - name: PREFECT_UI_URL
-              value: {{ .Values.server.uiConfig.prefectUiUrl | quote }}
             {{- end }}
             - name: PREFECT_UI_STATIC_DIRECTORY
               value: {{ .Values.server.uiConfig.prefectUiStaticDirectory | quote }}

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "prefect-server.validatePrefectServerApiSettings" . }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -9,7 +9,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13-python3.11-kubernetes-python3.11-kubernetes
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -4,15 +4,19 @@ release:
   namespace: prefect
 
 tests:
-  - it: Should set the correct image and tag
+  - it: Should set the correct image
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
       - template: background-services-deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].image
-          value: prefecthq/prefect:3-latest
+          value: prefecthq/prefect:3.1.13
 
   - it: Should set custom image and tag
     set:
@@ -20,17 +24,21 @@ tests:
         prefect:
           image:
             repository: custom/prefect
-            prefectTag: v2.0.0
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
       - template: background-services-deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].image
-          value: custom/prefect:v2.0.0
+          value: custom/prefect:3.1.13
 
   - it: Should set the correct pull policy
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -44,6 +52,7 @@ tests:
       global:
         prefect:
           image:
+            prefectTag: 3.1.13
             pullPolicy: Always
       backgroundServices:
         runAsSeparateDeployment: true
@@ -60,6 +69,7 @@ tests:
           image:
             pullSecrets:
               - my-secret
+          prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -70,6 +80,10 @@ tests:
 
   - it: Should set the correct priority class name
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         priorityClassName: high-priority
@@ -81,6 +95,10 @@ tests:
 
   - it: Should set the correct debug mode
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -91,6 +109,10 @@ tests:
 
   - it: Should enable debug mode
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         debug: true
@@ -102,6 +124,10 @@ tests:
 
   - it: Should set the correct logging level
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -112,6 +138,10 @@ tests:
 
   - it: Should set a custom logging level
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         loggingLevel: DEBUG
@@ -123,6 +153,10 @@ tests:
 
   - it: Should set custom environment variables
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         env:
@@ -136,6 +170,10 @@ tests:
 
   - it: Should set the correct revision history limit
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -146,6 +184,10 @@ tests:
 
   - it: Should set a custom revision history limit
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         revisionHistoryLimit: 5
@@ -157,6 +199,10 @@ tests:
 
   - it: Should set the correct resource requests and limits
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -179,6 +225,10 @@ tests:
 
   - it: Should set custom resource requests and limits
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         resources:
@@ -208,6 +258,10 @@ tests:
 
   - it: Should set the correct security context
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -226,6 +280,10 @@ tests:
 
   - it: Should set custom security context
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         podSecurityContext:
@@ -248,6 +306,10 @@ tests:
 
   - it: Should set the correct container security context
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -270,6 +332,10 @@ tests:
 
   - it: Should set custom container security context
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         containerSecurityContext:
@@ -297,6 +363,10 @@ tests:
 
   - it: Should set pod labels
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         podLabels:
@@ -309,6 +379,10 @@ tests:
 
   - it: Should set pod annotations
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         podAnnotations:
@@ -321,6 +395,10 @@ tests:
 
   - it: Should set affinity
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         affinity:
@@ -341,6 +419,10 @@ tests:
 
   - it: Should set node selector
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         nodeSelector:
@@ -353,6 +435,10 @@ tests:
 
   - it: Should set tolerations
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         tolerations:
@@ -368,6 +454,10 @@ tests:
 
   - it: Should set extra environment variables from ConfigMap
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         extraEnvVarsCM: my-config-map
@@ -379,6 +469,10 @@ tests:
 
   - it: Should set extra environment variables from Secret
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         extraEnvVarsSecret: my-secret
@@ -390,6 +484,10 @@ tests:
 
   - it: Should set extra containers
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         extraContainers:
@@ -403,6 +501,10 @@ tests:
 
   - it: Should set extra volumes
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         extraVolumes:
@@ -417,6 +519,10 @@ tests:
 
   - it: Should set extra volume mounts
     set:
+      global:
+        prefect:
+          image:
+            prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
         extraVolumeMounts:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -121,52 +121,6 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_LOGGING_SERVER_LEVEL")].value
           value: DEBUG
 
-  - it: Should set the correct API URL
-    set:
-      backgroundServices:
-        runAsSeparateDeployment: true
-    asserts:
-      - template: background-services-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_URL")].value
-          value: "http://localhost:4200/api"
-
-  - it: Should set a custom API URL
-    set:
-      global:
-        prefect:
-          prefectApiUrl: "https://custom-api.example.com"
-      backgroundServices:
-        runAsSeparateDeployment: true
-    asserts:
-      - template: background-services-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_URL")].value
-          value: "https://custom-api.example.com"
-
-  - it: Should set the correct API host
-    set:
-      backgroundServices:
-        runAsSeparateDeployment: true
-    asserts:
-      - template: background-services-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_HOST")].value
-          value: "0.0.0.0"
-
-  - it: Should set a custom API host
-    set:
-      global:
-        prefect:
-          prefectApiHost: "127.0.0.1"
-      backgroundServices:
-        runAsSeparateDeployment: true
-    asserts:
-      - template: background-services-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_HOST")].value
-          value: "127.0.0.1"
-
   - it: Should set custom environment variables
     set:
       backgroundServices:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -9,14 +9,14 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
       - template: background-services-deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].image
-          value: prefecthq/prefect:3.1.13
+          value: prefecthq/prefect:3.1.13-python3.11-kubernetes
 
   - it: Should set custom image and tag
     set:
@@ -24,21 +24,21 @@ tests:
         prefect:
           image:
             repository: custom/prefect
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
       - template: background-services-deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].image
-          value: custom/prefect:3.1.13
+          value: custom/prefect:3.1.13-python3.11-kubernetes
 
   - it: Should set the correct pull policy
     set:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -52,7 +52,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
             pullPolicy: Always
       backgroundServices:
         runAsSeparateDeployment: true
@@ -67,7 +67,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
             pullSecrets:
               - my-secret
       backgroundServices:
@@ -83,7 +83,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         priorityClassName: high-priority
@@ -98,7 +98,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -112,7 +112,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         debug: true
@@ -127,7 +127,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -141,7 +141,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         loggingLevel: DEBUG
@@ -156,7 +156,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         env:
@@ -173,7 +173,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -187,7 +187,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         revisionHistoryLimit: 5
@@ -202,7 +202,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -228,7 +228,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         resources:
@@ -261,7 +261,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -283,7 +283,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         podSecurityContext:
@@ -309,7 +309,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:
@@ -335,7 +335,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         containerSecurityContext:
@@ -366,7 +366,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         podLabels:
@@ -382,7 +382,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         podAnnotations:
@@ -398,7 +398,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         affinity:
@@ -422,7 +422,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         nodeSelector:
@@ -438,7 +438,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         tolerations:
@@ -457,7 +457,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         extraEnvVarsCM: my-config-map
@@ -472,7 +472,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         extraEnvVarsSecret: my-secret
@@ -487,7 +487,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         extraContainers:
@@ -504,7 +504,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         extraVolumes:
@@ -522,7 +522,7 @@ tests:
       global:
         prefect:
           image:
-            prefectTag: 3.1.13
+            prefectTag: 3.1.13-python3.11-kubernetes
       backgroundServices:
         runAsSeparateDeployment: true
         extraVolumeMounts:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -67,9 +67,9 @@ tests:
       global:
         prefect:
           image:
+            prefectTag: 3.1.13
             pullSecrets:
               - my-secret
-          prefectTag: 3.1.13
       backgroundServices:
         runAsSeparateDeployment: true
     asserts:

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -137,42 +137,6 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_LOGGING_SERVER_LEVEL")].value
           value: DEBUG
 
-  - it: Should set the correct API URL
-    asserts:
-      - template: server-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_URL")].value
-          value: "http://localhost:4200/api"
-
-  - it: Should set a custom API URL
-    set:
-      global:
-        prefect:
-          prefectApiUrl: "https://custom-api.example.com"
-    asserts:
-      - template: server-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_URL")].value
-          value: "https://custom-api.example.com"
-
-  - it: Should set the correct API host
-    asserts:
-      - template: server-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_HOST")].value
-          value: "0.0.0.0"
-
-  - it: Should set a custom API host
-    set:
-      global:
-        prefect:
-          prefectApiHost: "127.0.0.1"
-    asserts:
-      - template: server-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_HOST")].value
-          value: "127.0.0.1"
-
   - it: Should set the correct UI configuration
     asserts:
       - template: server-deployment.yaml
@@ -195,21 +159,16 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_UI_ENABLED")].value
           value: "false"
 
-  - it: Should set custom UI API URL and UI URL
+  - it: Should set custom UI API URL
     set:
       server:
         uiConfig:
           prefectUiApiUrl: "https://custom-ui-api.example.com"
-          prefectUiUrl: "https://custom-ui.example.com"
     asserts:
       - template: server-deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_UI_API_URL")].value
           value: "https://custom-ui-api.example.com"
-      - template: server-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_UI_URL")].value
-          value: "https://custom-ui.example.com"
 
   - it: Should set custom environment variables
     set:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -68,14 +68,6 @@
                 }
               }
             },
-            "prefectApiUrl": {
-              "type": "string",
-              "description": "sets PREFECT_API_URL"
-            },
-            "prefectApiHost": {
-              "type": "string",
-              "description": "sets PREFECT_SERVER_API_HOST"
-            },
             "env": {
               "type": "array",
               "description": "array with environment variables to add to all deployments",
@@ -160,16 +152,6 @@
           "title": "Logging Level",
           "description": "sets PREFECT_LOGGING_SERVER_LEVEL"
         },
-        "prefectApiUrl": {
-          "type": "string",
-          "title": "Prefect API URL",
-          "description": "sets PREFECT_API_URL"
-        },
-        "prefectApiHost": {
-          "type": "string",
-          "title": "Prefect API Host",
-          "description": "sets PREFECT_SERVER_API_HOST"
-        },
         "uiConfig": {
           "type": "object",
           "title": "UI Config",
@@ -184,11 +166,6 @@
               "type": "string",
               "title": "Prefect API URL",
               "description": "sets PREFECT_UI_API_URL"
-            },
-            "prefectUiUrl": {
-              "type": "string",
-              "title": "Prefect UI URL",
-              "description": "sets PREFECT_UI_URL"
             }
           }
         },

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -42,7 +42,7 @@
           "type": "object",
           "title": "Prefect",
           "description": "global prefect configuration",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "image": {
               "type": "object",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -31,12 +31,6 @@ global:
       # -- prefect image pull secrets
       pullSecrets: []
 
-    # -- sets PREFECT_API_URL
-    prefectApiUrl: http://localhost:4200/api
-
-    # -- sets PREFECT_SERVER_API_HOST
-    prefectApiHost: 0.0.0.0
-
     # see here for a full list of possible environment variables - https://docs.prefect.io/latest/api-ref/prefect/settings/
     # -- array with environment variables to add to all deployments
     env: []
@@ -71,8 +65,6 @@ server:
     enabled: true
     # -- sets PREFECT_UI_API_URL
     prefectUiApiUrl: ""
-    # -- sets PREFECT_UI_URL
-    prefectUiUrl: ""
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"
 

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -62,7 +62,7 @@ server:
   uiConfig:
     # -- set PREFECT_UI_ENABLED; enable the UI on the server
     enabled: true
-    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI form somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api).
+    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api).
     prefectUiApiUrl: "http://localhost:4200/api"
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -64,7 +64,7 @@ server:
     # -- set PREFECT_UI_ENABLED; enable the UI on the server
     enabled: true
     # -- sets PREFECT_UI_API_URL
-    prefectUiApiUrl: ""
+    prefectUiApiUrl: "http://localhost:4200/api"
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"
 

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -59,11 +59,10 @@ server:
   # sets PREFECT_LOGGING_SERVER_LEVEL
   loggingLevel: WARNING
 
-  ## If you want to run the UI seperately from the server, you will need to set the UI-specific URLs below
   uiConfig:
     # -- set PREFECT_UI_ENABLED; enable the UI on the server
     enabled: true
-    # -- sets PREFECT_UI_API_URL
+    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI form somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api).
     prefectUiApiUrl: "http://localhost:4200/api"
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -62,7 +62,7 @@ server:
   uiConfig:
     # -- set PREFECT_UI_ENABLED; enable the UI on the server
     enabled: true
-    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api).
+    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). You can find additional documentation on this here - https://docs.prefect.io/v3/manage/self-host#ui
     prefectUiApiUrl: "http://localhost:4200/api"
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -62,7 +62,7 @@ server:
   uiConfig:
     # -- set PREFECT_UI_ENABLED; enable the UI on the server
     enabled: true
-    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (like via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api).
+    # -- sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api).
     prefectUiApiUrl: "http://localhost:4200/api"
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"


### PR DESCRIPTION
This PR contains a breaking change. See the [upgrading document](https://github.com/PrefectHQ/prefect-helm/blob/main/charts/prefect-server/UPGRADING.md) for details on how to upgrade. Specifically, this PR removes the `prefectApiUrl` and `prefectApiHost` values. Instead, the chart will now use the `prefectUiApiUrl` value to define the URL that is provided to the UI by and for the API

---

### Testing
1. Authenticate to any Kubernetes cluster
2. Clone the repo locally, checkout this branch and change directory to the `prefect-server` chart
``` bash
git clone git@github.com:PrefectHQ/prefect-helm.git
git checkout adjust-prefect-server-settings
cd prefect-helm/charts/prefect-server
```
3. Install the helm chart without adjusting anything on the values.yaml file
```bash
helm install prefect-server .
```
4. You should observe the prefect-server and postgresql pods come up healthy. You can port forward the server service and interact with the UI
5. Modify the values.yaml file to enable a separate deployment for the `background services`
```yaml
backgroundServices:
  runAsSeparateDeployment: true
```
6. Upgrade the helm chart
```bash
helm upgrade prefect-server .
```
7. You should see all three pods (now including a dedicated one for the background services) come up healthy.

Resolves https://linear.app/prefect/issue/PLA-1051/fix-prefect-helm-server-values-and-docs-re-server-env-vars