### PR TITLE
chore: turn off automatic releases by requiring inputs

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,7 +2,8 @@
 name: Release Prefect Server and Worker Helm Charts
 
 "on":
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs: {}
 
 permissions: {}
 


### PR DESCRIPTION
This is temporary, while we iterate on some breaking changes. We want to ensure they aren't rolled out until well tested & documented.

Relates to https://linear.app/prefect/issue/PLA-1056/cycle-13-catch-all