### PR TITLE
breaking(prefect-worker): update self-hosted server references to be consistent

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -147,7 +147,7 @@ Workers each have a type corresponding to the execution environment to which the
     ```
 
     These settings will ensure the worker connects with the local deployment of Self-hosted Prefect Server.
-    If the Self-hosted Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `prefect-server.<namespace>.svc.cluster.local`
+    If the Self-hosted Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `http://<prefect-server-service-name>.<namespace>.svc.cluster.local:<prefect-server-port>/api`. If the Self-hosted Prefect Server pod is deployed in a different cluster, set the apiUrl to the fully qualified domain name of the Self-hosted Prefect Server.
 
 ### Installing & Verifying Deployment of the Prefect Worker
 

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -123,18 +123,15 @@ Workers each have a type corresponding to the execution environment to which the
       config:
         workPool: <target work pool name>
       selfManagedCloudApiConfig:
-        # If the prefect server is located external to this cluster, set a fully qualified domain name as the apiUrl
-        # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local:<prefect-server-port>/api
         apiUrl: "https://<DNS of Self-managed Cloud API>"
         accountId: <target account ID>
         workspaceId: <target workspace ID>
-        uiUrl: "https://<DNS of Self-managed Cloud UI>"
     ```
 
     These settings will ensure that the worker connects to the proper account, workspace, and work pool.
     View your Account ID and Workspace ID in your browser URL when logged into Prefect Cloud. For example: `https://self-managed-prefect.company/account/abc-my-account-id-is-here/workspaces/123-my-workspace-id-is-here`
 
-### Configuring a Worker for Prefect Server
+### Configuring a Worker for Self-hosted Prefect Server
 
 1. Configure the Prefect worker values
 
@@ -149,8 +146,8 @@ Workers each have a type corresponding to the execution environment to which the
         apiUrl: <dns or ip address of the prefect-server pod here>
     ```
 
-    These settings will ensure the worker connects with the local deployment of Prefect Server.
-    If the Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `prefect-server.<namespace>.svc.cluster.local`
+    These settings will ensure the worker connects with the local deployment of Self-hosted Prefect Server.
+    If the Self-hosted Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `prefect-server.<namespace>.svc.cluster.local`
 
 ### Installing & Verifying Deployment of the Prefect Worker
 
@@ -179,7 +176,7 @@ Workers each have a type corresponding to the execution environment to which the
 
 Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
 
-Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a Self-hosted server with basic auth enabled, you can authenticate your worker with the same credentials.
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a Self-hosted Prefect server with basic auth enabled, you can authenticate your worker with the same credentials.
 
 The format of the auth string is `admin:<my-password>` (no brackets).
 

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -119,7 +119,7 @@ Workers each have a type corresponding to the execution environment to which the
 
     ```yaml
     worker:
-      apiConfig: selfManaged
+      apiConfig: selfManagedCloud
       config:
         workPool: <target work pool name>
       selfManagedCloudApiConfig:
@@ -142,10 +142,10 @@ Workers each have a type corresponding to the execution environment to which the
 
     ```yaml
     worker:
-      apiConfig: server
+      apiConfig: selfHostedServer
       config:
         workPool: <target work pool name>
-      serverApiConfig:
+      selfHostedServerApiConfig:
         apiUrl: <dns or ip address of the prefect-server pod here>
     ```
 
@@ -345,7 +345,7 @@ worker:
 | serviceAccount.create | bool | `true` | specifies whether a ServiceAccount should be created |
 | serviceAccount.name | string | `""` | the name of the ServiceAccount to use. if not set and create is true, a name is generated using the common.names.fullname template |
 | worker.affinity | object | `{}` | affinity for worker pods assignment |
-| worker.apiConfig | string | `"cloud"` | one of 'cloud', 'selfManaged', or 'server' |
+| worker.apiConfig | string | `"cloud"` | one of 'cloud', 'selfManagedCloud', or 'selfHostedServer' |
 | worker.autoscaling.enabled | bool | `false` | enable autoscaling for the worker |
 | worker.autoscaling.maxReplicas | int | `1` | maximum number of replicas to scale up to |
 | worker.autoscaling.minReplicas | int | `1` | minimum number of replicas to scale down to |
@@ -416,15 +416,13 @@ worker:
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
 | worker.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
+| worker.selfHostedServerApiConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
 | worker.selfManagedCloudApiConfig.accountId | string | `""` | prefect account ID |
 | worker.selfManagedCloudApiConfig.apiKeySecret.key | string | `"key"` | prefect API secret key |
 | worker.selfManagedCloudApiConfig.apiKeySecret.name | string | `"prefect-api-key"` | prefect API secret name |
 | worker.selfManagedCloudApiConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
 | worker.selfManagedCloudApiConfig.cloudApiUrl | string | `""` | This is used in self managed cloud instances to congfigure events and logs over websockets |
-| worker.selfManagedCloudApiConfig.uiUrl | string | `""` | self hosted UI url |
 | worker.selfManagedCloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
-| worker.serverApiConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
-| worker.serverApiConfig.uiUrl | string | `"http://localhost:4200"` | prefect UI url |
 | worker.tolerations | list | `[]` | tolerations for worker pods assignment |
 
 ----------------------------------------------

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -147,7 +147,7 @@ Workers each have a type corresponding to the execution environment to which the
     ```
 
     These settings will ensure the worker connects with the local deployment of Self-hosted Prefect Server.
-    If the Self-hosted Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `prefect-server.<namespace>.svc.cluster.local`
+    If the Self-hosted Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `http://<prefect-server-service-name>.<namespace>.svc.cluster.local:<prefect-server-port>/api`. If the Self-hosted Prefect Server pod is deployed in a different cluster, set the apiUrl to the fully qualified domain name of the Self-hosted Prefect Server.
 
 ### Installing & Verifying Deployment of the Prefect Worker
 

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -123,18 +123,15 @@ Workers each have a type corresponding to the execution environment to which the
       config:
         workPool: <target work pool name>
       selfManagedCloudApiConfig:
-        # If the prefect server is located external to this cluster, set a fully qualified domain name as the apiUrl
-        # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local:<prefect-server-port>/api
         apiUrl: "https://<DNS of Self-managed Cloud API>"
         accountId: <target account ID>
         workspaceId: <target workspace ID>
-        uiUrl: "https://<DNS of Self-managed Cloud UI>"
     ```
 
     These settings will ensure that the worker connects to the proper account, workspace, and work pool.
     View your Account ID and Workspace ID in your browser URL when logged into Prefect Cloud. For example: `https://self-managed-prefect.company/account/abc-my-account-id-is-here/workspaces/123-my-workspace-id-is-here`
 
-### Configuring a Worker for Prefect Server
+### Configuring a Worker for Self-hosted Prefect Server
 
 1. Configure the Prefect worker values
 
@@ -149,8 +146,8 @@ Workers each have a type corresponding to the execution environment to which the
         apiUrl: <dns or ip address of the prefect-server pod here>
     ```
 
-    These settings will ensure the worker connects with the local deployment of Prefect Server.
-    If the Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `prefect-server.<namespace>.svc.cluster.local`
+    These settings will ensure the worker connects with the local deployment of Self-hosted Prefect Server.
+    If the Self-hosted Prefect Server pod is deployed in the same cluster, you can use the local Kubernetes DNS address to connect to it: `prefect-server.<namespace>.svc.cluster.local`
 
 ### Installing & Verifying Deployment of the Prefect Worker
 
@@ -179,7 +176,7 @@ Workers each have a type corresponding to the execution environment to which the
 
 Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)
 
-Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a Self-hosted server with basic auth enabled, you can authenticate your worker with the same credentials.
+Self-hosted Prefect servers can be equipped with a Basic Authentication string for an administrator/password combination. Assuming you are running a Self-hosted Prefect server with basic auth enabled, you can authenticate your worker with the same credentials.
 
 The format of the auth string is `admin:<my-password>` (no brackets).
 

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -119,7 +119,7 @@ Workers each have a type corresponding to the execution environment to which the
 
     ```yaml
     worker:
-      apiConfig: selfManaged
+      apiConfig: selfManagedCloud
       config:
         workPool: <target work pool name>
       selfManagedCloudApiConfig:
@@ -142,10 +142,10 @@ Workers each have a type corresponding to the execution environment to which the
 
     ```yaml
     worker:
-      apiConfig: server
+      apiConfig: selfHostedServer
       config:
         workPool: <target work pool name>
-      serverApiConfig:
+      selfHostedServerApiConfig:
         apiUrl: <dns or ip address of the prefect-server pod here>
     ```
 

--- a/charts/prefect-worker/UPGRADING.md
+++ b/charts/prefect-worker/UPGRADING.md
@@ -1,5 +1,51 @@
 # Upgrade guidelines
 
+## > TBD
+
+After version TBD, the `prefect-worker` chart renamed the `server` key to `selfHostedServer`. Also, the allowed values for the `apiConfig` key changed from `cloud`, `server`, or `selfManaged` to `cloud`, `selfManagedCloud`, or `selfHostedServer`.
+
+### Self Hosted Server Configuration
+**Before**
+
+```yaml
+worker:
+  apiConfig: server
+  server:
+    ...
+```
+
+**After**
+
+```yaml
+worker:
+  apiConfig: selfHostedServer
+  selfHostedServerApiConfig:
+    ...
+```
+
+### Self Managed Cloud Configuration
+**Before**
+
+```yaml
+worker:
+  apiConfig: selfManaged
+  ...
+```
+
+**After**
+
+```yaml
+worker:
+  apiConfig: selfManagedCloud
+  ...
+```
+
+### UI URL in NOTES.txt
+
+The UI URL related values (`Values.worker.serverApiConfig.uiUrl` and `.Values.worker.selfManagedCloudApiConfig.uiUrl`) have been removed. These values were previously only used in the NOTES.txt file to provide a link to the Prefect UI.
+
+---
+
 ## > 2025.1.28020410
 
 After version `2025.1.28020410`, the `prefect-worker` chart renamed the `selfHostedCloudApiConfig` key to `selfManagedCloudApiConfig`.

--- a/charts/prefect-worker/templates/NOTES.txt
+++ b/charts/prefect-worker/templates/NOTES.txt
@@ -1,1 +1,1 @@
-1. Check Prefect worker connections in the prefect UI at {{ template "worker.appUrl" . }}
+1. Check Prefect worker connections in the prefect UI

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -31,7 +31,7 @@ Require Prefect Cloud Workspace ID
 Require Self-managed Cloud Account ID
 */}}
 {{- define "selfManaged.requiredConfig.accountId" -}}
-{{- if eq .Values.worker.apiConfig "selfManaged" }}
+{{- if eq .Values.worker.apiConfig "selfManagedCloud" }}
     {{- required "A Prefect Cloud Account ID is required (worker.selfManagedCloudApiConfig.accountId)" .Values.worker.selfManagedCloudApiConfig.accountId -}}
 {{- end -}}
 {{- end -}}
@@ -40,7 +40,7 @@ Require Self-managed Cloud Account ID
 Require Self-managed Cloud Workspace ID
 */}}
 {{- define "selfManaged.requiredConfig.workspaceId" -}}
-{{- if eq .Values.worker.apiConfig "selfManaged" }}
+{{- if eq .Values.worker.apiConfig "selfManagedCloud" }}
     {{- required "A Prefect Cloud Workspace ID is required (worker.selfManagedCloudApiConfig.workspaceId)" .Values.worker.selfManagedCloudApiConfig.workspaceId -}}
 {{- end -}}
 {{- end -}}
@@ -49,7 +49,7 @@ Require Self-managed Cloud Workspace ID
 Require Self-managed Cloud API URL
 */}}
 {{- define "selfManaged.requiredConfig.apiUrl" -}}
-{{- if eq .Values.worker.apiConfig "selfManaged" }}
+{{- if eq .Values.worker.apiConfig "selfManagedCloud" }}
     {{- required "The Self-managed Cloud API URL is required (worker.selfManagedCloudApiConfig.apiUrl)" .Values.worker.selfManagedCloudApiConfig.apiUrl -}}
 {{- end -}}
 {{- end -}}
@@ -58,38 +58,25 @@ Require Self-managed Cloud API URL
 Require Prefect Server API URL
 */}}
 {{- define "server.requiredConfig.apiUrl" -}}
-{{- if eq .Values.worker.apiConfig "server" }}
-    {{- required "The Prefect Server API URL is required (worker.serverApiConfig.apiUrl)" .Values.worker.serverApiConfig.apiUrl -}}
+{{- if eq .Values.worker.apiConfig "selfHostedServer" }}
+    {{- required "The Prefect Server API URL is required (worker.selfHostedServerApiConfig.apiUrl)" .Values.worker.selfHostedServerApiConfig.apiUrl -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
   worker.apiUrl:
-    Define API URL for cloud or server worker install
+    Define the API URL for the worker based on the API config
 */}}
 {{- define "worker.apiUrl" -}}
 {{- if eq .Values.worker.apiConfig "cloud" }}
     {{- printf "%s/accounts/%s/workspaces/%s" .Values.worker.cloudApiConfig.cloudUrl (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
-{{- else if eq .Values.worker.apiConfig "selfManaged" }}
+{{- else if eq .Values.worker.apiConfig "selfManagedCloud" }}
     {{- printf "%s/accounts/%s/workspaces/%s" (include "selfManaged.requiredConfig.apiUrl" .) (include "selfManaged.requiredConfig.accountId" .) (include "selfManaged.requiredConfig.workspaceId" .) | quote }}
-{{- else }}
+{{- else if eq .Values.worker.apiConfig "selfHostedServer" }}
     {{- include "server.requiredConfig.apiUrl" . | quote }}
 {{- end }}
 {{- end }}
 
-{{/*
-  worker.appUrl:
-    Define APP URL for cloud worker install
-*/}}
-{{- define "worker.appUrl" -}}
-{{- if eq .Values.worker.apiConfig "cloud" }}
-    {{- printf "https://app.prefect.cloud/account/%s/workspace/%s" (include "cloud.requiredConfig.accountId" .) (include "cloud.requiredConfig.workspaceId" .) | quote }}
-{{- else if eq .Values.worker.apiConfig "selfManaged" }}
-    {{- printf "%s/account/%s/workspace/%s" .Values.worker.selfManagedCloudApiConfig.uiUrl (include "selfManaged.requiredConfig.accountId" .) (include "selfManaged.requiredConfig.workspaceId" .) | quote }}
-{{- else }}
-    {{- .Values.worker.serverApiConfig.uiUrl | quote }}
-{{- end }}
-{{- end }}
 
 {{/*
   worker.clusterUUID:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -154,7 +154,7 @@ tests:
   - it: Should set the correct API configuration for self-managed cloud
     set:
       worker:
-        apiConfig: "selfManaged"
+        apiConfig: "selfManagedCloud"
         selfManagedCloudApiConfig:
           apiUrl: "https://my-prefect-api.com/api"
           accountId: "my-account-id"
@@ -165,11 +165,11 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_URL")].value
           value: "https://my-prefect-api.com/api/accounts/my-account-id/workspaces/my-workspace-id"
 
-  - it: Should set the correct API configuration for Prefect server
+  - it: Should set the correct API configuration for self-hosted server
     set:
       worker:
-        apiConfig: "server"
-        serverApiConfig:
+        apiConfig: "selfHostedServer"
+        selfHostedServerApiConfig:
           apiUrl: "http://prefect-server:4200/api"
     asserts:
       - template: deployment.yaml

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -323,7 +323,8 @@
         "apiConfig": {
           "type": "string",
           "title": "API Config",
-          "description": "one of 'cloud' or 'server'"
+          "description": "one of 'cloud', 'selfManagedCloud', or 'selfHostedServer'",
+          "enum": ["cloud", "selfManagedCloud", "selfHostedServer"]
         },
         "cloudApiConfig": {
           "type": "object",
@@ -403,11 +404,6 @@
               "title": "Self Managed Cloud API URL",
               "description": "self managed cloud api url"
             },
-            "uiUrl": {
-              "type": "string",
-              "title": "Self-managed Cloud URL",
-              "description": "Self-managed Cloud URL"
-            },
             "apiUrl": {
               "type": "string",
               "title": "Self-managed API URL",
@@ -415,7 +411,7 @@
             }
           }
         },
-        "serverApiConfig": {
+        "selfHostedServerApiConfig": {
           "type": "object",
           "title": "Server API Config",
           "description": "server api configuration",
@@ -425,11 +421,6 @@
               "type": "string",
               "title": "API",
               "description": "prefect API url (PREFECT_API_URL)"
-            },
-            "uiUrl": {
-              "type": "string",
-              "title": "UI",
-              "description": "prefect UI url"
             }
           }
         },

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -362,7 +362,7 @@
             "cloudUrl": {
               "type": "string",
               "title": "Cloud URL",
-              "description": "prefect cloud url"
+              "description": "prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId"
             }
           }
         },
@@ -402,7 +402,7 @@
             "cloudApiUrl": {
               "type": "string",
               "title": "Self Managed Cloud API URL",
-              "description": "self managed cloud api url"
+              "description": "Cloud API url for PREFECT_CLOUD_API_URL. This is used in self managed cloud instances to configure events and logs over websockets"
             },
             "apiUrl": {
               "type": "string",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -134,7 +134,7 @@ worker:
       # name: ""
 
   ## connection settings
-  # -- one of 'cloud', 'selfManaged', or 'server'
+  # -- one of 'cloud', 'selfManagedCloud', or 'selfHostedServer'
   apiConfig: "cloud"
 
   cloudApiConfig:
@@ -169,16 +169,12 @@ worker:
     # -- Cloud API url for PREFECT_CLOUD_API_URL
     # -- This is used in self managed cloud instances to congfigure events and logs over websockets
     cloudApiUrl: ""
-    # -- self hosted UI url
-    uiUrl: ""
 
-  serverApiConfig:
+  selfHostedServerApiConfig:
     # If the prefect server is located external to this cluster, set a fully qualified domain name as the apiUrl
     # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local:<prefect-server-port>/api
     # -- prefect API url (PREFECT_API_URL)
     apiUrl: ""
-    # -- prefect UI url
-    uiUrl: http://localhost:4200
 
   # -- the number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10


### PR DESCRIPTION
This PR contains a breaking change. See the [upgrading document](https://github.com/PrefectHQ/prefect-helm/blob/main/charts/prefect-worker/UPGRADING.md) for details on how to upgrade. Specifically, this PR replaces the previous `serverApiConfig` key with `selfHostedServerApiConfig`. It also updates the allowed values for `apiConfig` to include `cloud`, `selfManagedCloud`, and `selfHostedServer`.

---

### Testing

#### Self-hosted Server

1. Authenticate to any Kubernetes cluster
2. Clone the repo locally, checkout this branch and change directory to the `prefect-server` chart
``` bash
git clone git@github.com:PrefectHQ/prefect-helm.git
git checkout rename-server-values-key
cd prefect-helm/charts/prefect-server
```
3. Install the helm chart without adjusting anything on the values.yaml file
```bash
helm install prefect-server .
```
4. Change directory to the `prefect-worker` chart. Modify the values file 
```bash
cd ../prefect-worker
```
```yaml
worker:
  config:
    workPool: test
    apiConfig: selfHostedServer
    selfHostedServerApiConfig:
      apiUrl: http://prefect-server.YOUR_NAMESPACE.svc.cluster.local:4200/api
```
```bash
helm install prefect-worker .
```
5. You will see a prefect worker pod come up healthy, and can visualize a healthy workpool in the UI. 

Resolves https://linear.app/prefect/issue/PLA-1121/update-serverapiconfig-key-to-selfhostedserverapiconfig