### PR TITLE
chore: turn off release workflow with an input flag

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -3,12 +3,16 @@ name: Release Prefect Server and Worker Helm Charts
 
 "on":
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      really:
+        required: true
+        default: "false"
 
 permissions: {}
 
 jobs:
   release:
+    if: inputs.really == 'true'
     runs-on: ubuntu-latest
     permissions:
       # GitHub considers creating releases and uploading assets as writing contents.
@@ -132,6 +136,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   update_helm_chart_worker_version_downstream:
+    if: inputs.really == 'true'
     name: Update Helm Chart Worker version in `ops-cluster-deployment`
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
My [first](https://github.com/PrefectHQ/prefect-helm/pull/451) iteration of this did not [work](https://github.com/PrefectHQ/prefect-helm/releases/tag/2025.2.21193831)

Relates to https://linear.app/prefect/issue/PLA-1056/cycle-13-catch-all