### PR TITLE
breaking(prefect-server): update `basicAuth` settings to be nested under the right `selfHostedServerApiConfig` key

### DIFF
--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
               value: {{ .Values.server.debug | quote }}
             - name: PREFECT_LOGGING_SERVER_LEVEL
               value: {{ .Values.server.loggingLevel | quote }}
+            - name: PREFECT_SERVER_API_HOST
+              value: 0.0.0.0
             - name: PREFECT_SERVER_API_PORT
               value: {{ .Values.service.targetPort | quote }}
             - name: PREFECT_UI_ENABLED

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -348,9 +348,6 @@ worker:
 | worker.autoscaling.minReplicas | int | `1` | minimum number of replicas to scale down to |
 | worker.autoscaling.targetCPUUtilizationPercentage | int | `80` | target CPU utilization percentage for scaling the worker |
 | worker.autoscaling.targetMemoryUtilizationPercentage | int | `80` | target memory utilization percentage for scaling the worker |
-| worker.basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
-| worker.basicAuth.enabled | bool | `false` | enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well |
-| worker.basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | worker.cloudApiConfig.accountId | string | `""` | prefect account ID |
 | worker.cloudApiConfig.apiKeySecret.key | string | `"key"` | prefect API secret key |
 | worker.cloudApiConfig.apiKeySecret.name | string | `"prefect-api-key"` | prefect API secret name |
@@ -414,6 +411,9 @@ worker:
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
 | worker.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | worker.selfHostedServerApiConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |
+| worker.selfHostedServerApiConfig.basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
+| worker.selfHostedServerApiConfig.basicAuth.enabled | bool | `false` | enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well |
+| worker.selfHostedServerApiConfig.basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | worker.selfManagedCloudApiConfig.accountId | string | `""` | prefect account ID |
 | worker.selfManagedCloudApiConfig.apiKeySecret.key | string | `"key"` | prefect API secret key |
 | worker.selfManagedCloudApiConfig.apiKeySecret.name | string | `"prefect-api-key"` | prefect API secret name |

--- a/charts/prefect-worker/UPGRADING.md
+++ b/charts/prefect-worker/UPGRADING.md
@@ -2,13 +2,21 @@
 
 ## > TBD
 
-After version TBD, the `prefect-worker` chart renamed the `server` key to `selfHostedServer`. Also, the allowed values for the `apiConfig` key changed from `cloud`, `server`, or `selfManaged` to `cloud`, `selfManagedCloud`, or `selfHostedServer`.
+After version TBD, there have been several breaking changes to the `prefect-worker` chart:
+- The allowed values for the `apiConfig` key changed from `cloud`, `server`, or `selfManaged` to `cloud`, `selfHostedServer`, and `selfManagedCloud`.
+- `.Values.worker.server` => `.Values.worker.selfHostedServerApiConfig`
+- `.Values.worker.basicAuth` => `.Values.worker.selfHostedServerApiConfig.basicAuth`
 
-### Self Hosted Server Configuration
+### Adjusting Your Configuration
+
+#### Self Hosted Server Configuration
+
 **Before**
 
 ```yaml
 worker:
+  basicAuth:
+    ...
   apiConfig: server
   server:
     ...
@@ -20,10 +28,12 @@ worker:
 worker:
   apiConfig: selfHostedServer
   selfHostedServerApiConfig:
-    ...
+    basicAuth:
+      ...
 ```
 
 ### Self Managed Cloud Configuration
+
 **Before**
 
 ```yaml

--- a/charts/prefect-worker/UPGRADING.md
+++ b/charts/prefect-worker/UPGRADING.md
@@ -32,7 +32,7 @@ worker:
       ...
 ```
 
-### Self Managed Cloud Configuration
+#### Self Managed Cloud Configuration
 
 **Before**
 

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -105,15 +105,15 @@ spec:
               value: /home/prefect
             - name: PREFECT_API_URL
               value: {{ template "worker.apiUrl" . }}
-            {{- if .Values.worker.basicAuth.enabled }}
+            {{- if .Values.worker.selfHostedServerApiConfig.basicAuth.enabled }}
             - name: PREFECT_API_AUTH_STRING
-            {{- if .Values.worker.basicAuth.existingSecret }}
+            {{- if .Values.worker.selfHostedServerApiConfig.basicAuth.existingSecret }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.worker.basicAuth.existingSecret }}
+                  name: {{ .Values.worker.selfHostedServerApiConfig.basicAuth.existingSecret }}
                   key: auth-string
             {{- else }}
-              value: {{ .Values.worker.basicAuth.authString | quote }}
+              value: {{ .Values.worker.selfHostedServerApiConfig.basicAuth.authString | quote }}
             {{- end }}
             {{- end }}
             - name: PREFECT_KUBERNETES_CLUSTER_UID
@@ -214,15 +214,15 @@ spec:
             {{- end }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.worker.image.debug | quote }}
-            {{- if .Values.worker.basicAuth.enabled }}
+            {{- if .Values.worker.selfHostedServerApiConfig.basicAuth.enabled }}
             - name: PREFECT_API_AUTH_STRING
-            {{- if .Values.worker.basicAuth.existingSecret }}
+            {{- if .Values.worker.selfHostedServerApiConfig.basicAuth.existingSecret }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.worker.basicAuth.existingSecret }}
+                  name: {{ .Values.worker.selfHostedServerApiConfig.basicAuth.existingSecret }}
                   key: auth-string
             {{- else }}
-              value: {{ .Values.worker.basicAuth.authString | quote }}
+              value: {{ .Values.worker.selfHostedServerApiConfig.basicAuth.authString | quote }}
             {{- end }}
             {{- end }}
             {{- if .Values.worker.extraEnvVars }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -19,9 +19,10 @@ tests:
   - it: Should set basic auth from authString
     set:
       worker:
-        basicAuth:
-          enabled: true
-          authString: "admin:mypassword"
+        selfHostedServerApiConfig:
+          basicAuth:
+            enabled: true
+            authString: "admin:mypassword"
     asserts:
       - template: deployment.yaml
         equal:
@@ -31,9 +32,10 @@ tests:
   - it: Should set basic auth from existing secret
     set:
       worker:
-        basicAuth:
-          enabled: true
-          existingSecret: "my-auth-secret"
+        selfHostedServerApiConfig:
+          basicAuth:
+            enabled: true
+            existingSecret: "my-auth-secret"
     asserts:
       - template: deployment.yaml
         contains:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -67,28 +67,6 @@
             }
           }
         },
-        "basicAuth": {
-          "type": "object",
-          "title": "Basic Auth",
-          "description": "basic auth configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Enabled",
-              "description": "enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well"
-            },
-            "authString": {
-              "type": "string",
-              "title": "Auth String",
-              "description": "basic auth credentials in the format admin:<your-password> (no brackets)"
-            },
-            "existingSecret": {
-              "type": "string",
-              "title": "Existing Secret",
-              "description": "name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string"
-            }
-          }
-        },
         "clusterUid": {
           "type": "string",
           "title": "Cluster UID",
@@ -288,7 +266,8 @@
             "installPolicy": {
               "type": "string",
               "title": "Install Policy",
-              "description": "Install policy to use workers from Prefect integration packages."
+              "description": "install policy to use workers from Prefect integration packages.",
+              "enum": ["always", "if-not-present", "never", "prompt"]
             },
             "type": {
               "type": "string",
@@ -421,6 +400,28 @@
               "type": "string",
               "title": "API",
               "description": "prefect API url (PREFECT_API_URL)"
+            },
+            "basicAuth": {
+              "type": "object",
+              "title": "Basic Auth",
+              "description": "basic auth configuration",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Enabled",
+                  "description": "enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well"
+                },
+                "authString": {
+                  "type": "string",
+                  "title": "Auth String",
+                  "description": "basic auth credentials in the format admin:<your-password> (no brackets)"
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "title": "Existing Secret",
+                  "description": "name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string"
+                }
+              }
             }
           }
         },
@@ -508,7 +509,7 @@
                 "timeoutSeconds": {
                   "type": "integer",
                   "title": "Timeout Seconds",
-                  "description": "number of seconds after which the probe times out"
+                  "description": "The number of seconds to wait for a probe response before considering it as failed."
                 },
                 "successThreshold": {
                   "type": "integer",
@@ -741,7 +742,7 @@
         "extraArgs": {
           "type": "array",
           "title": "Extra Container Args",
-          "description": "array with extra args for the worker container"
+          "description": "array with extra Arguments for the worker container to start with"
         }
       }
     },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -126,7 +126,7 @@ worker:
 
   ## connection settings
   # -- one of 'cloud', 'selfManagedCloud', or 'selfHostedServer'
-  apiConfig: "cloud"
+  apiConfig: cloud
 
   cloudApiConfig:
     # -- prefect account ID

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -24,15 +24,6 @@ worker:
     # -- target memory utilization percentage for scaling the worker
     targetMemoryUtilizationPercentage: 80
 
-  # ref: https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings
-  basicAuth:
-    # -- enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well
-    enabled: false
-    # -- basic auth credentials in the format admin:<your-password> (no brackets)
-    authString: "admin:pass"
-    # -- name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string
-    existingSecret: ""
-
   # -- unique cluster identifier, if none is provided this value will be inferred at time of helm install
   clusterUid: ""
 
@@ -175,6 +166,15 @@ worker:
     # If the prefect server pod is deployed to this cluster, use the cluster DNS endpoint: http://<prefect-server-service-name>.<namespace>.svc.cluster.local:<prefect-server-port>/api
     # -- prefect API url (PREFECT_API_URL)
     apiUrl: ""
+
+    # ref: https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings
+    basicAuth:
+      # -- enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well
+      enabled: false
+      # -- basic auth credentials in the format admin:<your-password> (no brackets)
+      authString: "admin:pass"
+      # -- name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string
+      existingSecret: ""
 
   # -- the number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10


### PR DESCRIPTION
### Summary

This PR contains a breaking change. See the [upgrading document](https://github.com/PrefectHQ/prefect-helm/blob/main/charts/prefect-worker/UPGRADING.md) for details on how to upgrade. Specifically, this PR moves the `worker.basicAuth` key down one level to be nested under `worker.selfHostedServerApiConfig.basicAuth`. Basic Auth is **_only_** relevant for self hosted server (i.e., not cloud or self managed cloud). As such, it made sense to move this down to the appropriate configuration level.

---

### Testing

1. Authenticate to any Kubernetes cluster
2. Clone the repo locally, checkout this branch and change directory to the `prefect-server` chart
``` bash
git clone git@github.com:PrefectHQ/prefect-helm.git
git checkout fix-basic-auth-settings
cd prefect-helm/charts/prefect-server
```
3. Update the `values.yaml` file to include the following configuration and then Install the helm chart.
```yaml
server:
  basicAuth:
    enabled: true
```

```bash
helm install prefect-server .
```
5. Change directory to the `prefect-worker` chart. Modify the `values.yaml` file there. Then install the worker chart.
```bash
cd ../prefect-worker
```
```yaml
worker:
  config:
    workPool: test
    apiConfig: selfHostedServer
    selfHostedServerApiConfig:
      apiUrl: http://prefect-server.YOUR_NAMESPACE.svc.cluster.local:4200/api
      basicAuth:
        enabled: true
```
```bash
helm install prefect-worker .
```
6. You will see a prefect worker pod come up healthy, and can visualize a healthy workpool in the UI. 

---

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt` -- JZ: I decided not to add any validation steps for this change. It would require allowing additional properties for the `worker` key to be true. I felt like changing that to be true was not worth the validation step we would get.
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

Resolves https://linear.app/prefect/issue/PLA-1120/basicauth-is-referenced-at-the-wrong-level-in-the-prefect-helm-worker