### PR TITLE
breaking(prefect-server): remove the ability to disable the `UI` on `prefect-server`

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -343,7 +343,6 @@ the HorizontalPodAutoscaler.
 | server.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the server container |
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
-| server.uiConfig.enabled | bool | `true` | set PREFECT_UI_ENABLED; enable the UI on the server |
 | server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). You can find additional documentation on this here - https://docs.prefect.io/v3/manage/self-host#ui |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | service.annotations | object | `{}` |  |

--- a/charts/prefect-server/UPGRADING.md
+++ b/charts/prefect-server/UPGRADING.md
@@ -2,7 +2,9 @@
 
 ## > TBD
 
-After version `TBD` the `prefect-server` chart has removed some exposed environment variables in favor of a more simplified configuration. In particular, the `prefectApiUrl` and `prefectApiHost` values have been removed in favor of the single `prefectUiApiUrl` value.
+After version TBD, there have been several breaking changes to the `prefect-worker` chart:
+- The `prefectApiUrl` and `prefectApiHost` values have been removed in favor of the single `prefectUiApiUrl` value.
+- `.Values.server.uiConfig.prefectUiUrl` has been removed.
 
 ### Adjusting your configuration
 
@@ -16,6 +18,17 @@ Note: If you were using the default value for `prefectApiUrl` (i.e. `http://loca
 #### UI URL
 
 `.Values.server.uiConfig.prefectUiUrl` has been removed altogether. This value was used solely for the purposes of printing out the UI URL during the installation process. It will now infer the UI URL from the `prefectUiApiUrl` value.
+
+#### Disabling the UI
+
+If you would like to disable the UI, you can pass this configuration via the `env` key.
+
+```yaml
+server:
+  env:
+    - name: PREFECT_UI_ENABLED
+      value: 'false'
+```
 
 ---
 

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -95,8 +95,6 @@ spec:
               value: 0.0.0.0
             - name: PREFECT_SERVER_API_PORT
               value: {{ .Values.service.targetPort | quote }}
-            - name: PREFECT_UI_ENABLED
-              value: {{ .Values.server.uiConfig.enabled | quote }}
             - name: PREFECT_UI_API_URL
               value: {{ .Values.server.uiConfig.prefectUiApiUrl | quote }}
             - name: PREFECT_UI_STATIC_DIRECTORY

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -141,23 +141,8 @@ tests:
     asserts:
       - template: server-deployment.yaml
         equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_UI_ENABLED")].value
-          value: "true"
-      - template: server-deployment.yaml
-        equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_UI_STATIC_DIRECTORY")].value
           value: "/ui_build"
-
-  - it: Should disable the UI
-    set:
-      server:
-        uiConfig:
-          enabled: false
-    asserts:
-      - template: server-deployment.yaml
-        equal:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_UI_ENABLED")].value
-          value: "false"
 
   - it: Should set custom UI API URL
     set:

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -60,8 +60,6 @@ server:
   loggingLevel: WARNING
 
   uiConfig:
-    # -- set PREFECT_UI_ENABLED; enable the UI on the server
-    enabled: true
     # -- sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). You can find additional documentation on this here - https://docs.prefect.io/v3/manage/self-host#ui
     prefectUiApiUrl: "http://localhost:4200/api"
     # -- sets PREFECT_UI_STATIC_DIRECTORY


### PR DESCRIPTION
### Summary

This PR removes the ability to disable the UI on the `prefect-server` deployment. Running the UI independently of the server is not currently supported.

In the event a user has a valid use case to disable the UI on the server deployment, they could continue to accomplish that by setting it as an environment variables in their values file:
```yaml
server:
  env:
    - name: PREFECT_UI_ENABLED
      value: 'false'
```

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

Closes PLA-1116
