### PR TITLE
enhancement(prefect-server): expose `PREFECT_SERVER_API_BASE_PATH` setting on server deployment

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -220,14 +220,14 @@ the HorizontalPodAutoscaler.
 | backgroundServices.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set background-services containers' security context readOnlyRootFilesystem |
 | backgroundServices.containerSecurityContext.runAsNonRoot | bool | `true` | set background-services containers' security context runAsNonRoot |
 | backgroundServices.containerSecurityContext.runAsUser | int | `1001` | set background-services containers' security context runAsUser |
-| backgroundServices.debug | bool | `false` | sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode |
+| backgroundServices.debug | bool | `false` | sets PREFECT_DEBUG_MODE |
 | backgroundServices.env | list | `[]` | array with environment variables to add to background-services container |
 | backgroundServices.extraContainers | list | `[]` | additional sidecar containers |
 | backgroundServices.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to background-services pod |
 | backgroundServices.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to background-services pod |
 | backgroundServices.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the background-services pod |
 | backgroundServices.extraVolumes | list | `[]` | array with extra volumes for the background-services pod |
-| backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2 |
+| backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | backgroundServices.nodeSelector | object | `{}` | node labels for background-services pod assignment |
 | backgroundServices.podAnnotations | object | `{}` | extra annotations for background-services pod |
 | backgroundServices.podLabels | object | `{}` | extra labels for background-services pod |
@@ -282,7 +282,7 @@ the HorizontalPodAutoscaler.
 | secret.port | string | `""` | port for the PostgreSQL connection string |
 | secret.username | string | `""` | username for the PostgreSQL connection string |
 | server.affinity | object | `{}` | affinity for server pods assignment |
-| server.apiBasePath | string | `"/api"` | sets PREFECT_SERVER_API_BASE_PATH - https://docs.prefect.io/v3/develop/settings-ref#base-path |
+| server.apiBasePath | string | `"/api"` | sets PREFECT_SERVER_API_BASE_PATH |
 | server.args | list | `[]` | Custom container command arguments |
 | server.autoscaling.enabled | bool | `false` | enable autoscaling for server |
 | server.autoscaling.maxReplicas | int | `100` | maximum number of server replicas |
@@ -298,7 +298,7 @@ the HorizontalPodAutoscaler.
 | server.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set server containers' security context readOnlyRootFilesystem |
 | server.containerSecurityContext.runAsNonRoot | bool | `true` | set server containers' security context runAsNonRoot |
 | server.containerSecurityContext.runAsUser | int | `1001` | set server containers' security context runAsUser |
-| server.debug | bool | `false` | sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode |
+| server.debug | bool | `false` | sets PREFECT_DEBUG_MODE |
 | server.env | list | `[]` | array with environment variables to add to server deployment |
 | server.extraArgs | list | `[]` | array with extra Arguments for the server container to start with |
 | server.extraContainers | list | `[]` | additional sidecar containers |
@@ -312,7 +312,7 @@ the HorizontalPodAutoscaler.
 | server.livenessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | server.livenessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
 | server.livenessProbe.enabled | bool | `false` |  |
-| server.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2 |
+| server.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | server.nodeSelector | object | `{}` | node labels for server pods assignment |
 | server.podAnnotations | object | `{}` | extra annotations for server pod |
 | server.podLabels | object | `{}` | extra labels for server pod |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -220,14 +220,14 @@ the HorizontalPodAutoscaler.
 | backgroundServices.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set background-services containers' security context readOnlyRootFilesystem |
 | backgroundServices.containerSecurityContext.runAsNonRoot | bool | `true` | set background-services containers' security context runAsNonRoot |
 | backgroundServices.containerSecurityContext.runAsUser | int | `1001` | set background-services containers' security context runAsUser |
-| backgroundServices.debug | bool | `false` | enable background-services debug mode |
+| backgroundServices.debug | bool | `false` | sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode |
 | backgroundServices.env | list | `[]` | array with environment variables to add to background-services container |
 | backgroundServices.extraContainers | list | `[]` | additional sidecar containers |
 | backgroundServices.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to background-services pod |
 | backgroundServices.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to background-services pod |
 | backgroundServices.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the background-services pod |
 | backgroundServices.extraVolumes | list | `[]` | array with extra volumes for the background-services pod |
-| backgroundServices.loggingLevel | string | `"WARNING"` |  |
+| backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2 |
 | backgroundServices.nodeSelector | object | `{}` | node labels for background-services pod assignment |
 | backgroundServices.podAnnotations | object | `{}` | extra annotations for background-services pod |
 | backgroundServices.podLabels | object | `{}` | extra labels for background-services pod |
@@ -282,6 +282,7 @@ the HorizontalPodAutoscaler.
 | secret.port | string | `""` | port for the PostgreSQL connection string |
 | secret.username | string | `""` | username for the PostgreSQL connection string |
 | server.affinity | object | `{}` | affinity for server pods assignment |
+| server.apiBasePath | string | `"/api"` | sets PREFECT_SERVER_API_BASE_PATH - https://docs.prefect.io/v3/develop/settings-ref#base-path |
 | server.args | list | `[]` | Custom container command arguments |
 | server.autoscaling.enabled | bool | `false` | enable autoscaling for server |
 | server.autoscaling.maxReplicas | int | `100` | maximum number of server replicas |
@@ -297,7 +298,7 @@ the HorizontalPodAutoscaler.
 | server.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set server containers' security context readOnlyRootFilesystem |
 | server.containerSecurityContext.runAsNonRoot | bool | `true` | set server containers' security context runAsNonRoot |
 | server.containerSecurityContext.runAsUser | int | `1001` | set server containers' security context runAsUser |
-| server.debug | bool | `false` | enable server debug mode |
+| server.debug | bool | `false` | sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode |
 | server.env | list | `[]` | array with environment variables to add to server deployment |
 | server.extraArgs | list | `[]` | array with extra Arguments for the server container to start with |
 | server.extraContainers | list | `[]` | additional sidecar containers |
@@ -311,7 +312,7 @@ the HorizontalPodAutoscaler.
 | server.livenessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | server.livenessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
 | server.livenessProbe.enabled | bool | `false` |  |
-| server.loggingLevel | string | `"WARNING"` |  |
+| server.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2 |
 | server.nodeSelector | object | `{}` | node labels for server pods assignment |
 | server.podAnnotations | object | `{}` | extra annotations for server pod |
 | server.podLabels | object | `{}` | extra labels for server pod |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -334,7 +334,7 @@ the HorizontalPodAutoscaler.
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). You can find additional documentation on this here - https://docs.prefect.io/v3/manage/self-host#ui |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
-| service.annotations | object | `{}` |  |
+| service.annotations | object | `{}` | additional custom annotations for server service |
 | service.clusterIP | string | `""` | service Cluster IP |
 | service.externalTrafficPolicy | string | `"Cluster"` | service external traffic policy |
 | service.extraPorts | list | `[]` |  |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -227,12 +227,6 @@ the HorizontalPodAutoscaler.
 | backgroundServices.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to background-services pod |
 | backgroundServices.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the background-services pod |
 | backgroundServices.extraVolumes | list | `[]` | array with extra volumes for the background-services pod |
-| backgroundServices.livenessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
-| backgroundServices.livenessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |
-| backgroundServices.livenessProbe.config.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |
-| backgroundServices.livenessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
-| backgroundServices.livenessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
-| backgroundServices.livenessProbe.enabled | bool | `false` |  |
 | backgroundServices.loggingLevel | string | `"WARNING"` |  |
 | backgroundServices.nodeSelector | object | `{}` | node labels for background-services pod assignment |
 | backgroundServices.podAnnotations | object | `{}` | extra annotations for background-services pod |
@@ -241,12 +235,6 @@ the HorizontalPodAutoscaler.
 | backgroundServices.podSecurityContext.runAsNonRoot | bool | `true` | set background-services pod's security context runAsNonRoot |
 | backgroundServices.podSecurityContext.runAsUser | int | `1001` | set background-services pod's security context runAsUser |
 | backgroundServices.priorityClassName | string | `""` | priority class name to use for the background-services pods; if the priority class is empty or doesn't exist, the background-services pods are scheduled without a priority class |
-| backgroundServices.readinessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
-| backgroundServices.readinessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |
-| backgroundServices.readinessProbe.config.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |
-| backgroundServices.readinessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
-| backgroundServices.readinessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
-| backgroundServices.readinessProbe.enabled | bool | `false` |  |
 | backgroundServices.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the background-services container |
 | backgroundServices.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the background-services container |
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |

--- a/charts/prefect-server/templates/background-services-deployment.yaml
+++ b/charts/prefect-server/templates/background-services-deployment.yaml
@@ -107,20 +107,6 @@ spec:
           {{- with .Values.backgroundServices.containerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.backgroundServices.livenessProbe.enabled }}
-          livenessProbe:
-            httpGet:
-              path: /api/health
-              port: {{ .Values.service.targetPort }}
-          {{- toYaml .Values.backgroundServices.livenessProbe.config | nindent 12 }}
-          {{- end }}
-          {{- if .Values.backgroundServices.readinessProbe.enabled }}
-          readinessProbe:
-            httpGet:
-              path: /api/ready
-              port: {{ .Values.service.targetPort }}
-          {{- toYaml .Values.backgroundServices.readinessProbe.config | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - mountPath: /home/prefect
               name: scratch

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
               value: {{ .Values.server.debug | quote }}
             - name: PREFECT_LOGGING_SERVER_LEVEL
               value: {{ .Values.server.loggingLevel | quote }}
+            - name: PREFECT_SERVER_API_BASE_PATH
+              value: {{ .Values.server.apiBasePath | quote }}
             - name: PREFECT_SERVER_API_HOST
               value: 0.0.0.0
             - name: PREFECT_SERVER_API_PORT
@@ -143,14 +145,14 @@ spec:
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: {{ .Values.server.apiBasePath }}/health
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.livenessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /api/ready
+              path: {{ .Values.server.apiBasePath }}/ready
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.readinessProbe.config | nindent 12 }}
           {{- end }}

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -127,6 +127,13 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_LOGGING_SERVER_LEVEL")].value
           value: WARNING
 
+  - it: Should set the correct API base path
+    asserts:
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_BASE_PATH")].value
+          value: "/api"
+
   - it: Should set a custom logging level
     set:
       server:
@@ -136,6 +143,16 @@ tests:
         equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_LOGGING_SERVER_LEVEL")].value
           value: DEBUG
+
+  - it: Should set a custom API base path
+    set:
+      server:
+        apiBasePath: "/custom-api"
+    asserts:
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_SERVER_API_BASE_PATH")].value
+          value: "/custom-api"
 
   - it: Should set the correct UI configuration
     asserts:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -142,6 +142,12 @@
           "title": "Priority Class Name",
           "description": "priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class"
         },
+        "apiBasePath": {
+          "type": "string",
+          "title": "API Base Path",
+          "description": "sets PREFECT_SERVER_API_BASE_PATH",
+          "default": "/api"
+        },
         "debug": {
           "type": "boolean",
           "title": "Debug",
@@ -150,7 +156,8 @@
         "loggingLevel": {
           "type": "string",
           "title": "Logging Level",
-          "description": "sets PREFECT_LOGGING_SERVER_LEVEL"
+          "description": "sets PREFECT_LOGGING_SERVER_LEVEL",
+          "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         },
         "uiConfig": {
           "type": "object",
@@ -623,7 +630,8 @@
         },
         "loggingLevel": {
           "type": "string",
-          "description": "sets PREFECT_LOGGING_SERVER_LEVEL"
+          "description": "sets PREFECT_LOGGING_SERVER_LEVEL",
+          "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         },
         "env": {
           "type": "array",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -242,34 +242,6 @@ backgroundServices:
       cpu: "1"
       memory: 1Gi
 
-  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-  livenessProbe:
-    enabled: false
-    config:
-      # -- The number of seconds to wait before starting the first probe.
-      initialDelaySeconds: 10
-      # -- The number of seconds to wait between consecutive probes.
-      periodSeconds: 10
-      # -- The number of seconds to wait for a probe response before considering it as failed.
-      timeoutSeconds: 5
-      # -- The number of consecutive failures allowed before considering the probe as failed.
-      failureThreshold: 3
-      # -- The minimum consecutive successes required to consider the probe successful.
-      successThreshold: 1
-  readinessProbe:
-    enabled: false
-    config:
-      # -- The number of seconds to wait before starting the first probe.
-      initialDelaySeconds: 10
-      # -- The number of seconds to wait between consecutive probes.
-      periodSeconds: 10
-      # -- The number of seconds to wait for a probe response before considering it as failed.
-      timeoutSeconds: 5
-      # -- The number of consecutive failures allowed before considering the probe as failed.
-      failureThreshold: 3
-      # -- The minimum consecutive successes required to consider the probe successful.
-      successThreshold: 1
-
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext:
     # -- set background-services pod's security context runAsUser

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -53,13 +53,16 @@ server:
   # -- priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class
   priorityClassName: ""
 
-  # -- sets PREFECT_SERVER_API_BASE_PATH - https://docs.prefect.io/v3/develop/settings-ref#base-path
+  # ref: https://docs.prefect.io/v3/develop/settings-ref#base-path
+  # -- sets PREFECT_SERVER_API_BASE_PATH
   apiBasePath: "/api"
 
-  # -- sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode
+  # ref: https://docs.prefect.io/v3/develop/settings-ref#debug-mode
+  # -- sets PREFECT_DEBUG_MODE
   debug: false
 
-  # -- sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2
+  # ref: https://docs.prefect.io/v3/develop/settings-ref#logging-level-2
+  # -- sets PREFECT_LOGGING_SERVER_LEVEL
   loggingLevel: WARNING
 
   uiConfig:
@@ -140,7 +143,7 @@ server:
       # -- The minimum consecutive successes required to consider the probe successful.
       successThreshold: 1
 
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext:
     # -- set server pod's security context runAsUser
     runAsUser: 1001
@@ -154,7 +157,7 @@ server:
       # -- in case of Localhost value in seccompProfile.type, set seccompProfile.localhostProfile value below
       # localhostProfile: /my-path.json
 
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext:
     # -- set server containers' security context runAsUser
     runAsUser: 1001
@@ -167,23 +170,23 @@ server:
     # -- set server container's security context capabilities
     capabilities: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for server pod
   podLabels: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   # -- extra annotations for server pod
   podAnnotations: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # -- affinity for server pods assignment
   affinity: {}
 
-  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
   # -- node labels for server pods assignment
   nodeSelector: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   # -- tolerations for server pods assignment
   tolerations: []
 
@@ -207,7 +210,7 @@ server:
 
 ## Background Services Deployment Configuration
 backgroundServices:
-  # https://github.com/PrefectHQ/prefect/tree/main/src/prefect/server/services
+  # ref: https://github.com/PrefectHQ/prefect/tree/main/src/prefect/server/services
   # This can help with:
   # - Separate scaling of web server and background services
   # - Independent connection pools for better database management
@@ -219,10 +222,12 @@ backgroundServices:
   # -- priority class name to use for the background-services pods; if the priority class is empty or doesn't exist, the background-services pods are scheduled without a priority class
   priorityClassName: ""
 
-  # -- sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode
+  # ref: https://docs.prefect.io/v3/develop/settings-ref#debug-mode
+  # -- sets PREFECT_DEBUG_MODE
   debug: false
 
-  # -- sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2
+  # ref: https://docs.prefect.io/v3/develop/settings-ref#logging-level-2
+  # -- sets PREFECT_LOGGING_SERVER_LEVEL
   loggingLevel: WARNING
 
   # see here for a full list of possible environment variables - https://docs.prefect.io/latest/api-ref/prefect/settings/

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -24,7 +24,7 @@ global:
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
-      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
       ## e.g:
       ## pullSecrets:
       ##   - myRegistryKeySecretName
@@ -250,7 +250,7 @@ backgroundServices:
       cpu: "1"
       memory: 1Gi
 
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext:
     # -- set background-services pod's security context runAsUser
     runAsUser: 1001
@@ -259,7 +259,7 @@ backgroundServices:
     # -- set background-services pod's security context fsGroup
     fsGroup: 1001
 
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext:
     # -- set background-services containers' security context runAsUser
     runAsUser: 1001
@@ -272,23 +272,23 @@ backgroundServices:
     # -- set background-services container's security context capabilities
     capabilities: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for background-services pod
   podLabels: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   # -- extra annotations for background-services pod
   podAnnotations: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # -- affinity for background-services pod assignment
   affinity: {}
 
-  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
   # -- node labels for background-services pod assignment
   nodeSelector: {}
 
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   # -- tolerations for background-services pod assignment
   tolerations: []
 
@@ -350,10 +350,10 @@ service:
   clusterIP: ""
 
 
-  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  # ref: http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # -- service external traffic policy
   externalTrafficPolicy: Cluster
-  ## -- additional custom annotations for server service
+  # -- additional custom annotations for server service
   annotations: {}
 
 # Ingress configuration
@@ -365,7 +365,7 @@ ingress:
   servicePort: server-svc-port
 
   ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
-  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  # ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
   # -- IngressClass that will be used to implement the Ingress (Kubernetes 1.18+)
   className: ""
   host:
@@ -377,7 +377,7 @@ ingress:
     pathType: ImplementationSpecific
 
   ## Use this parameter to set the required annotations for cert-manager, see
-  ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+  # ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
   # -- additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
   annotations: {}
   ## annotations:
@@ -408,7 +408,7 @@ ingress:
   ##     serviceName: ssl-redirect
   ##     servicePort: use-annotation
 
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   # -- an array with additional tls configuration to be added to the ingress record
   extraTls: []
   ## extraTls:
@@ -416,7 +416,7 @@ ingress:
   ##     - server.local
   ##   secretName: server.local-tls
 
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
   # -- additional rules to be covered with this ingress record
   extraRules: []
   ## extraRules:
@@ -479,7 +479,7 @@ postgresql:
     password: prefect-rocks
 
   ## Initdb configuration
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#specifying-initdb-arguments
+  # ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#specifying-initdb-arguments
   primary:
     initdb:
       # -- specify the PostgreSQL username to execute the initdb scripts

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -53,10 +53,13 @@ server:
   # -- priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class
   priorityClassName: ""
 
-  # -- enable server debug mode
+  # -- sets PREFECT_SERVER_API_BASE_PATH - https://docs.prefect.io/v3/develop/settings-ref#base-path
+  apiBasePath: "/api"
+
+  # -- sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode
   debug: false
 
-  # sets PREFECT_LOGGING_SERVER_LEVEL
+  # -- sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2
   loggingLevel: WARNING
 
   uiConfig:
@@ -65,7 +68,7 @@ server:
     # -- sets PREFECT_UI_STATIC_DIRECTORY
     prefectUiStaticDirectory: "/ui_build"
 
-  # see here for a full list of possible environment variables - https://docs.prefect.io/latest/api-ref/prefect/settings/
+  # see here for a full list of possible environment variables - https://docs.prefect.io/v3/develop/settings-ref#serversettings
   # -- array with environment variables to add to server deployment
   env: []
   ## env:
@@ -216,10 +219,10 @@ backgroundServices:
   # -- priority class name to use for the background-services pods; if the priority class is empty or doesn't exist, the background-services pods are scheduled without a priority class
   priorityClassName: ""
 
-  # -- enable background-services debug mode
+  # -- sets PREFECT_DEBUG_MODE - https://docs.prefect.io/v3/develop/settings-ref#debug-mode
   debug: false
 
-  # sets PREFECT_LOGGING_SERVER_LEVEL
+  # -- sets PREFECT_LOGGING_SERVER_LEVEL - https://docs.prefect.io/v3/develop/settings-ref#logging-level-2
   loggingLevel: WARNING
 
   # see here for a full list of possible environment variables - https://docs.prefect.io/latest/api-ref/prefect/settings/


### PR DESCRIPTION
### Summary

This PR exposes the ability to set the environment variable `PREFECT_SERVER_API_BASE_PATH` on the server deployment. This allows users to set a custom api path to use. This is not breaking, as the exposed value is set to the previous default of `/api`. 

Additionally, when configuring this new setting, I realized that the background services deployment does not currently support readiness/liveness probe checks. I've removed them from the chart for now. 

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

Relates to https://github.com/PrefectHQ/prefect/pull/16967
Resolves https://linear.app/prefect/issue/PLA-1119/add-support-for-prefect-server-api-base-path-in-the-prefect-helm
