### PR TITLE
feat: Update worker to pass API key to created jobs via Kubernetes secret

### DIFF
--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -212,6 +212,17 @@ spec:
             - name: PREFECT_CLOUD_API_URL
               value: {{ .Values.worker.selfManagedCloudApiConfig.cloudApiUrl}}
             {{- end }}
+            {{- if eq .Values.worker.apiConfig "cloud" }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME
+              value: {{ .Values.worker.cloudApiConfig.apiKeySecret.name }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY
+              value: {{ .Values.worker.cloudApiConfig.apiKeySecret.key }}
+            {{- else if eq .Values.worker.apiConfig "selfManagedCloud" }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME
+              value: {{ .Values.worker.selfManagedCloudApiConfig.apiKeySecret.name }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY
+              value: {{ .Values.worker.selfManagedCloudApiConfig.apiKeySecret.key }}
+            {{- end }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.worker.image.debug | quote }}
             {{- if .Values.worker.selfHostedServerApiConfig.basicAuth.enabled }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -488,3 +488,42 @@ tests:
         equal:
           path: .spec.template.spec.containers[0].livenessProbe.successThreshold
           value: 1
+
+  - it: Should set Kubernetes worker secret env vars for cloud config
+    set:
+      worker:
+        apiConfig: cloud
+        cloudApiConfig:
+          apiKeySecret:
+            name: cloud-api-key-secret
+            key: api-key
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME")].value
+          value: cloud-api-key-secret
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY")].value
+          value: api-key
+
+  - it: Should set Kubernetes worker secret env vars for self-managed config
+    set:
+      worker:
+        apiConfig: selfManagedCloud
+        selfManagedCloudApiConfig:
+          apiUrl: https://my-prefect-cloud.example.com/api
+          accountId: test-account
+          workspaceId: test-workspace
+          apiKeySecret:
+            name: self-managed-api-key-secret
+            key: secret-key
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME")].value
+          value: self-managed-api-key-secret
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY")].value
+          value: secret-key


### PR DESCRIPTION
### Summary

This PR updates the worker Helm chart to include two new environment variables:
- PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME
- PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY
These environment variables tell the worker which secret to use to pass the Prefect API key to created jobs. The Helm chart is configured to use the same secret created for the worker itself.

Here's an example of a job pod with these changes:
```yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2025-03-06T03:37:12Z"
  generateName: great-mayfly-44hgj-
  labels:
    batch.kubernetes.io/controller-uid: 143acf44-4c0e-44fb-b3c4-dc814f8ab7b5
    batch.kubernetes.io/job-name: great-mayfly-44hgj
    controller-uid: 143acf44-4c0e-44fb-b3c4-dc814f8ab7b5
    job-name: great-mayfly-44hgj
  name: great-mayfly-44hgj-w42ht
  namespace: prefect
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: great-mayfly-44hgj
    uid: 143acf44-4c0e-44fb-b3c4-dc814f8ab7b5
  resourceVersion: "484289"
  uid: a98aef3a-a7e6-43c1-84e0-142a2b25992d
spec:
  containers:
  - args:
    - prefect
    - flow-run
    - execute
    env:
    - name: PREFECT_DEBUG_MODE
      value: "False"
    - name: PREFECT_API_URL
      value: https://api.prefect.cloud/api/accounts/a0f10033-f08a-42f8-9b8d-b7a7d4b4b3c1/workspaces/e4b1c666-a4ab-42c7-8172-48d43966e691
    - name: PREFECT_API_KEY
      valueFrom:
        secretKeyRef:
          key: key
          name: prefect-api-key
    - name: PREFECT_API_ENABLE_HTTP2
      value: "True"
    - name: PREFECT_SERVER_EPHEMERAL_ENABLED
      value: "True"
    - name: PREFECT_WORKER_QUERY_SECONDS
      value: "5.0"
    - name: PREFECT_WORKER_PREFETCH_SECONDS
      value: "10.0"
    - name: PREFECT__FLOW_RUN_ID
      value: 049c19a2-777b-4ce7-a96c-c9aa80e5b520
    image: prefecthq/prefect:3.2.11-python3.11
    imagePullPolicy: IfNotPresent
    name: prefect-job
```

The key part is:
```yaml
    - name: PREFECT_API_KEY
      valueFrom:
        secretKeyRef:
          key: key
          name: prefect-api-key
```
where the key comes from a secret instead of a plaintext environment variable.

Related to https://github.com/PrefectHQ/prefect/issues/17093

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
