### PR TITLE
feat(prefect-worker): Add support for DNS policy and config to prefect worker

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -371,9 +371,9 @@ worker:
 | worker.containerSecurityContext.runAsNonRoot | bool | `true` | set worker containers' security context runAsNonRoot |
 | worker.containerSecurityContext.runAsUser | int | `1001` | set worker containers' security context runAsUser |
 | worker.dnsConfig | object | `{"nameservers":[],"options":[],"searches":[]}` | optional dns config for worker deployment |
-| worker.dnsConfig.nameservers | list | `[]` | optional list of IP addresses that will be used as DNS servers for the Pod |
-| worker.dnsConfig.options | list | `[]` | optional list of DNS options for the Pod |
-| worker.dnsConfig.searches | list | `[]` | optional list of DNS search domains for hostname lookup in the Pod |
+| worker.dnsConfig.nameservers | list | `[]` | optional list of IP addresses that will be used as dns servers for the Pod |
+| worker.dnsConfig.options | list | `[]` | optional list of dns options for the Pod |
+| worker.dnsConfig.searches | list | `[]` | optional list of dns search domains for hostname lookup in the Pod |
 | worker.dnsPolicy | string | `""` | optional dns policy for worker deployment |
 | worker.extraArgs | list | `[]` | array with extra Arguments for the worker container to start with |
 | worker.extraContainers | list | `[]` | additional sidecar containers |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -370,6 +370,11 @@ worker:
 | worker.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set worker containers' security context readOnlyRootFilesystem |
 | worker.containerSecurityContext.runAsNonRoot | bool | `true` | set worker containers' security context runAsNonRoot |
 | worker.containerSecurityContext.runAsUser | int | `1001` | set worker containers' security context runAsUser |
+| worker.dnsConfig | object | `{"nameservers":[],"options":[],"searches":[]}` | optional dns config for worker deployment |
+| worker.dnsConfig.nameservers | list | `[]` | optional list of IP addresses that will be used as DNS servers for the Pod |
+| worker.dnsConfig.options | list | `[]` | optional list of DNS options for the Pod |
+| worker.dnsConfig.searches | list | `[]` | optional list of DNS search domains for hostname lookup in the Pod |
+| worker.dnsPolicy | string | `""` | optional dns policy for worker deployment |
 | worker.extraArgs | list | `[]` | array with extra Arguments for the worker container to start with |
 | worker.extraContainers | list | `[]` | additional sidecar containers |
 | worker.extraEnvVars | list | `[]` | array with extra environment variables to add to worker nodes |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -370,7 +370,6 @@ worker:
 | worker.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set worker containers' security context readOnlyRootFilesystem |
 | worker.containerSecurityContext.runAsNonRoot | bool | `true` | set worker containers' security context runAsNonRoot |
 | worker.containerSecurityContext.runAsUser | int | `1001` | set worker containers' security context runAsUser |
-| worker.dnsConfig | object | `{"nameservers":[],"options":[],"searches":[]}` | optional dns config for worker deployment |
 | worker.dnsConfig.nameservers | list | `[]` | optional list of IP addresses that will be used as dns servers for the Pod |
 | worker.dnsConfig.options | list | `[]` | optional list of dns options for the Pod |
 | worker.dnsConfig.searches | list | `[]` | optional list of dns search domains for hostname lookup in the Pod |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -38,6 +38,25 @@ spec:
         - name: {{ . }}
       {{- end }}
     {{- end }}
+    {{- if .Values.worker.dnsPolicy }}
+      dnsPolicy: {{ .Values.worker.dnsPolicy }}
+    {{- end }}
+    {{- if .Values.worker.dnsConfig }}
+      dnsConfig:
+        nameservers:
+        {{- range .Values.worker.dnsConfig.nameservers }}
+          - {{ . }}
+        {{- end }}
+        searches:
+        {{- range .Values.worker.dnsConfig.searches }}
+          - {{ . }}
+        {{- end }}
+        options:
+        {{- range .Values.worker.dnsConfig.options }}
+          - name: {{ .name }}
+            value: {{ .value }}
+        {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "worker.serviceAccountName" . }}
       {{- if .Values.worker.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.worker.affinity "context" $) | nindent 8 }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -53,8 +53,12 @@ spec:
         {{- end }}
         options:
         {{- range .Values.worker.dnsConfig.options }}
+        {{- if .value }}
           - name: {{ .name }}
-            value: {{ .value }}
+            value: {{ .value | quote }}
+        {{- else }}
+          - name: {{ .name }}
+        {{- end }}
         {{- end }}
     {{- end }}
       serviceAccountName: {{ template "worker.serviceAccountName" . }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -550,7 +550,7 @@ tests:
   - it: Should not set Kubernetes worker dnsConfig if not provided
     set:
       worker:
-        dnsConfig: {}
+        dnsConfig:
     asserts:
       - template: deployment.yaml
         notExists:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -556,7 +556,7 @@ tests:
         notExists:
           path: .spec.template.spec.dnsConfig
 
-  - it: Should set Kubernetes worker dsnConfig, all sub-values provided
+  - it: Should set Kubernetes worker dnsConfig, all sub-values provided
     set:
       worker:
         dnsConfig:
@@ -598,7 +598,7 @@ tests:
         notExists:
           path: .spec.template.spec.dnsConfig.options[1].value
 
-  - it: Should set Kubernetes worker dsnConfig, only nameservers provided
+  - it: Should set Kubernetes worker dnsConfig, only nameservers provided
     set:
       worker:
         dnsConfig:
@@ -620,7 +620,7 @@ tests:
         isNullOrEmpty:
           path: .spec.template.spec.dnsConfig.options
 
-  - it: Should set Kubernetes worker dsnConfig, only searches provided
+  - it: Should set Kubernetes worker dnsConfig, only searches provided
     set:
       worker:
         dnsConfig:
@@ -642,7 +642,7 @@ tests:
         isNullOrEmpty:
           path: .spec.template.spec.dnsConfig.options
 
-  - it: Should set Kubernetes worker dsnConfig, only options provided
+  - it: Should set Kubernetes worker dnsConfig, only options provided
     set:
       worker:
         dnsConfig:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -527,3 +527,142 @@ tests:
         equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY")].value
           value: secret-key
+
+  - it: Should not set Kubernetes worker dnsPolicy if not provided
+    set:
+      worker:
+        dnsPolicy: ""
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.dnsPolicy
+
+  - it: Should set Kubernetes worker dnsPolicy if provided
+    set:
+      worker:
+        dnsPolicy: ClusterFirst
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsPolicy
+          value: ClusterFirst
+
+  - it: Should not set Kubernetes worker dnsConfig if not provided
+    set:
+      worker:
+        dnsConfig: {}
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.dnsConfig
+
+  - it: Should set Kubernetes worker dsnConfig, all sub-values provided
+    set:
+      worker:
+        dnsConfig:
+          nameservers:
+            - 1.1.1.1
+            - 8.8.8.8
+          searches:
+            - example.com
+          options:
+            - name: ndots
+              value: "2"
+            - name: edns0
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.nameservers[0]
+          value: 1.1.1.1
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.nameservers[1]
+          value: 8.8.8.8
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.searches[0]
+          value: example.com
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.options[0].name
+          value: ndots
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.options[0].value
+          value: "2"
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.options[1].name
+          value: edns0
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.dnsConfig.options[1].value
+
+  - it: Should set Kubernetes worker dsnConfig, only nameservers provided
+    set:
+      worker:
+        dnsConfig:
+          nameservers:
+            - 1.1.1.1
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.nameservers[0]
+          value: 1.1.1.1
+      - template: deployment.yaml
+        lengthEqual:
+          path: .spec.template.spec.dnsConfig.nameservers
+          count: 1
+      - template: deployment.yaml
+        isNullOrEmpty:
+          path: .spec.template.spec.dnsConfig.searches
+      - template: deployment.yaml
+        isNullOrEmpty:
+          path: .spec.template.spec.dnsConfig.options
+
+  - it: Should set Kubernetes worker dsnConfig, only searches provided
+    set:
+      worker:
+        dnsConfig:
+          searches:
+            - example.com
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.searches[0]
+          value: example.com
+      - template: deployment.yaml
+        lengthEqual:
+          path: .spec.template.spec.dnsConfig.searches
+          count: 1
+      - template: deployment.yaml
+        isNullOrEmpty:
+          path: .spec.template.spec.dnsConfig.nameservers
+      - template: deployment.yaml
+        isNullOrEmpty:
+          path: .spec.template.spec.dnsConfig.options
+
+  - it: Should set Kubernetes worker dsnConfig, only options provided
+    set:
+      worker:
+        dnsConfig:
+          options:
+            - name: edns0
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.dnsConfig.options[0].name
+          value: edns0
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.dnsConfig.options[0].value
+      - template: deployment.yaml
+        lengthEqual:
+          path: .spec.template.spec.dnsConfig.options
+          count: 1
+      - template: deployment.yaml
+        isNullOrEmpty:
+          path: .spec.template.spec.dnsConfig.nameservers
+      - template: deployment.yaml
+        isNullOrEmpty:
+          path: .spec.template.spec.dnsConfig.searches

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -743,6 +743,34 @@
           "type": "array",
           "title": "Extra Container Args",
           "description": "array with extra Arguments for the worker container to start with"
+        },
+        "dnsPolicy": {
+          "type": "string",
+          "title": "DNS Policy",
+          "description": "worker deployment dns policy"
+        },
+        "dnsConfig": {
+          "type": "object",
+          "title": "DNS Config",
+          "description": "worker deployment dns configuration",
+          "additionalProperties": false,
+          "properties": {
+            "nameservers": {
+              "type": "array",
+              "title": "Nameservers",
+              "description": "a list of DNS name server IP addresses"
+            },
+            "searches": {
+              "type": "array",
+              "title": "Searches",
+              "description": "a list of DNS search domains for host-name lookup"
+            },
+            "options": {
+              "type": "array",
+              "title": "Options",
+              "description": "a list of DNS resolver options"
+            }
+          }
         }
       }
     },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -62,11 +62,11 @@ worker:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
   # -- optional dns config for worker deployment
   dnsConfig:
-    # -- optional list of IP addresses that will be used as DNS servers for the Pod
+    # -- optional list of IP addresses that will be used as dns servers for the Pod
     nameservers: []
-    # -- optional list of DNS search domains for hostname lookup in the Pod
+    # -- optional list of dns search domains for hostname lookup in the Pod
     searches: []
-    # -- optional list of DNS options for the Pod
+    # -- optional list of dns options for the Pod
     options: []
     # - name: ndots
     #   value: "2"

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -55,6 +55,13 @@ worker:
     # -- additional sidecar containers
     extraContainers: []
 
+    # -- set dns policy and config for worker deployment
+    # dnsPolicy: ""
+    # dnsConfig:
+    #   nameservers: []
+    #   searches: []
+    #   options: []
+
   image:
     # -- worker image repository
     repository: prefecthq/prefect

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -55,12 +55,21 @@ worker:
     # -- additional sidecar containers
     extraContainers: []
 
-    # -- set dns policy and config for worker deployment
-    # dnsPolicy: ""
-    # dnsConfig:
-    #   nameservers: []
-    #   searches: []
-    #   options: []
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  # -- optional dns policy for worker deployment
+  dnsPolicy: ""
+
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  # -- optional dns config for worker deployment
+  dnsConfig:
+    # -- optional list of IP addresses that will be used as DNS servers for the Pod
+    nameservers: []
+    # -- optional list of DNS search domains for hostname lookup in the Pod
+    searches: []
+    # -- optional list of DNS options for the Pod
+    options: []
+    # - name: ndots
+    #   value: "2"
 
   image:
     # -- worker image repository

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -60,7 +60,6 @@ worker:
   dnsPolicy: ""
 
   ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
-  # -- optional dns config for worker deployment
   dnsConfig:
     # -- optional list of IP addresses that will be used as dns servers for the Pod
     nameservers: []


### PR DESCRIPTION
### Summary

Add support for specifying dnsPolicy and dnsConfig to the prefect worker deployment. This change should be non-breaking and backwards compatible. 

Closes https://github.com/PrefectHQ/prefect-helm/issues/466. 

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
