### PR TITLE
fix(ci): pin `helm-unittest` version

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -23,3 +23,4 @@ jobs:
         uses: d3adb5/helm-unittest-action@v2
         with:
           helm-version: v3.17.1
+          unittest-version: 0.7.2

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Resolve chart dependencies
-        run: make buildall
-
       - name: Run helm unittest
         uses: d3adb5/helm-unittest-action@v2
         with:

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Run helm unittest
         uses: d3adb5/helm-unittest-action@v2
         with:
-          helm-version: v3.15.3
+          helm-version: v3.17.1

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -13,8 +13,13 @@ jobs:
       # required to read from the repo
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: d3adb5/helm-unittest-action@v2
+      - name: Resolve chart dependencies
+        run: make buildall
+
+      - name: Run helm unittest
+        uses: d3adb5/helm-unittest-action@v2
         with:
           helm-version: v3.15.3

--- a/scripts/helm_unittest.sh
+++ b/scripts/helm_unittest.sh
@@ -13,7 +13,7 @@
 # Usage:
 #  ./scripts/helm_unittest.sh
 
-version=${VERSION:-3.17.1-0.8.0}
+version=${VERSION:-3.17.1-0.7.2}
 
 docker run \
   -it --rm \

--- a/scripts/helm_unittest.sh
+++ b/scripts/helm_unittest.sh
@@ -13,7 +13,7 @@
 # Usage:
 #  ./scripts/helm_unittest.sh
 
-version=${VERSION:-3.15.4-0.6.1}
+version=${VERSION:-3.17.1-0.8.0}
 
 docker run \
   -it --rm \


### PR DESCRIPTION
### Summary

The helm-unittest action does its best to resolve dependencies for each chart being tested, but it seems this doesn't always work.

We noticed some unit test failures claiming to not have access to a template that comes from the PostgreSQL chart.

This appears to be a known issue: https://github.com/helm-unittest/helm-unittest/issues/588

For now, we'll pin to the last known good version.

Closes https://linear.app/prefect/issue/PLA-1222

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
