### PR TITLE
fix(prefect-server): loosen tag restriction with custom image

### DIFF
--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -1,5 +1,5 @@
 {{- define "prefect-server.validatePrefectVersion" -}}
-{{- if .Values.backgroundServices.runAsSeparateDeployment -}}
+{{- if and .Values.backgroundServices.runAsSeparateDeployment (eq .Values.global.prefect.image.repository "prefecthq/prefect") -}}
   {{- $prefectTag := .Values.global.prefect.image.prefectTag -}}
   {{- if not (regexMatch "^[0-9]+" $prefectTag) -}}
     {{- fail "When running background services separately, Prefect tag must start with a version number" -}}

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -565,3 +565,34 @@ tests:
             - prefect
             - worker
             - start
+
+  - it: Should configure custom entrypoint and args with custom image
+    set:
+      global:
+        prefect:
+          image:
+            repository: mycustomimage
+            prefectTag: 1.2.0
+      backgroundServices:
+        runAsSeparateDeployment: true
+        command:
+          - /usr/bin/tini
+          - myentrypoint
+        args:
+          - prefect
+          - worker
+          - start
+    asserts:
+      - template: background-services-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].command
+          value:
+            - /usr/bin/tini
+            - myentrypoint
+      - template: background-services-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].args
+          value:
+            - prefect
+            - worker
+            - start


### PR DESCRIPTION
### Summary

This is a small addition to make things work with a custom image, fixes https://github.com/PrefectHQ/prefect-helm/pull/473
Sorry for going back and forth :sweat_smile: 

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x]  Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
