### PR TITLE
fix(prefect-server): update ingress.servicePort type from string to both string and integer

### DIFF
--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -776,7 +776,7 @@
         "servicePort": {
           "type": ["integer", "string"],
           "title": "Service Port Name",
-          "description": "service port name"
+          "description": "service port name or number"
         },
         "className": {
           "type": "string",

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -774,7 +774,7 @@
           "description": "enable ingress record generation for server"
         },
         "servicePort": {
-          "type": "string",
+          "type": "integer",
           "title": "Service Port Name",
           "description": "service port name"
         },

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -774,7 +774,7 @@
           "description": "enable ingress record generation for server"
         },
         "servicePort": {
-          "type": "integer",
+          "type": ["integer", "string"],
           "title": "Service Port Name",
           "description": "service port name"
         },


### PR DESCRIPTION
Updates the JSON schema to correctly define the ingress.servicePort as an both string and integer type rather than only  string.

### Summary

Updates the JSON schema to correctly define the ingress.servicePort as an integer type rather than a string, aligning with its actual usage as a numeric port value.


### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
