### PR TITLE
feat: Update worker deployment to set namespace for observer

### DIFF
--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -220,6 +220,8 @@ spec:
               value: {{ template "worker.apiUrl" . }}
             - name: PREFECT_KUBERNETES_CLUSTER_UID
               value: {{ template "worker.clusterUUID" . }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES
+              value: {{ include "common.names.namespace" . | quote }}
             {{- if eq .Values.worker.apiConfig "cloud" }}
             - name: PREFECT_API_KEY
               valueFrom:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -118,8 +118,8 @@ tests:
       worker:
         config:
           workQueues:
-          - one
-          - two
+            - one
+            - two
     asserts:
       - template: deployment.yaml
         equal:
@@ -666,3 +666,19 @@ tests:
       - template: deployment.yaml
         isNullOrEmpty:
           path: .spec.template.spec.dnsConfig.searches
+
+  - it: Should set Kubernetes worker observer namespaces by default
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")].value
+          value: prefect
+
+  - it: Should set Kubernetes worker observer namespaces with override
+    set:
+      namespaceOverride: my-namespace
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")].value
+          value: my-namespace


### PR DESCRIPTION
The upcoming `prefect-kubernetes` release (`0.6.0`) will include a new observer that will handle event replication and monitoring for crashed runs. By default, this observer watches the entire cluster, but can be restricted to specific namespaces with the `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES` setting.

 This PR updates the worker helm chart to set the `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES` env var for the worker to the namespace the worker is deployed into. This should be an appropriate scope for most cases, but if it turns out to be too restrictive in some cases, we can provide more configurability via the provided values.