### PR TITLE
fix(prefect-server): remove deprecated helpers

### DIFF
--- a/charts/prefect-server/templates/ingress.yaml
+++ b/charts/prefect-server/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
   rules:
@@ -32,9 +32,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.host.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.host.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" .Values.ingress.servicePort "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -42,9 +40,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" $.Values.ingress.servicePort "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
### Summary

Closes https://github.com/PrefectHQ/prefect-helm/issues/488

Follow-up to https://github.com/PrefectHQ/prefect-helm/pull/486, which included https://github.com/bitnami/charts/pull/33496 that removed unused helpers. We need to remove them here as well.

Reported in community:

> Error: template: prefect-server/templates/ingress.yaml:23:51:
> executing "prefect-server/templates/ingress.yaml" at
> <include "common.ingress.supportsIngressClassname" .>: error calling include:
> template: no template "common.ingress.supportsIngressClassname" associated with template "gotpl"

Related to https://linear.app/prefect/issue/PLA-1479/cycle-19-catch-all



<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
