### PR TITLE
docs: fix minor prefect-server README.md typos

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -65,7 +65,7 @@ services to field the increased API requests.
 By default, the web services and background services share a connection pool to the
 database, but their connection needs are very different and even antagonistic
 with each other at times. Splitting the background services out also allows you
-to tune the datbase connections for each deployment (pool size, timeout, etc.),
+to tune the database connections for each deployment (pool size, timeout, etc.),
 which can help with the database load.
 
 The separate deployment for background services is currently limited to one replica
@@ -166,7 +166,7 @@ secret:
     type: Opaque
     ```
 
-3. Set the connection string in the existing secret following this format - `?ssl=verify-ca` is cruicial:
+3. Set the connection string in the existing secret following this format - `?ssl=verify-ca` is crucial:
     ```
     postgresql+asyncpg://{username}:{password}@{hostname}/{database}?ssl=verify-ca
     ```


### PR DESCRIPTION
### Summary

Fix minor spelling mistakes in the `prefect-server` README.md.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [ ] Relevant labels are added
- [x] `Draft` status is used until ready for review
