### PR TITLE
feat(prefect-server): make Deployment strategy configurable

### DIFF
--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -18,6 +18,8 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
+  strategy:
+    type: {{ .Values.server.deploymentStrategyType }}
   template:
     metadata:
       {{- if .Values.server.podAnnotations }}

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
-  strategy: {{ toYaml .Values.controller.updateStrategy | nindent 4 }}
+  strategy: {{ toYaml .Values.server.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- if .Values.server.podAnnotations }}

--- a/charts/prefect-server/templates/server-deployment.yaml
+++ b/charts/prefect-server/templates/server-deployment.yaml
@@ -18,8 +18,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
-  strategy:
-    type: {{ .Values.server.deploymentStrategyType }}
+  strategy: {{ toYaml .Values.controller.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- if .Values.server.podAnnotations }}

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -590,6 +590,16 @@ tests:
           path: .spec.tls[0].secretName
           value: prefect.example.com-tls
 
+  - it: Should set deployment strategy
+    set:
+      server:
+        deploymentStrategyType: Recreate
+    asserts:
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.strategy.type
+          value: Recreate
+
   - it: Should set autoscaling configuration when enabled
     set:
       server:

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -601,6 +601,28 @@ tests:
           path: .spec.strategy.type
           value: Recreate
 
+  - it: Should set RollingUpdate strategy fields
+    set:
+      server:
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: "1"
+            maxUnavailable: "25%"
+    asserts:
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.strategy.type
+          value: RollingUpdate
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.strategy.rollingUpdate.maxSurge
+          value: "1"
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.strategy.rollingUpdate.maxUnavailable
+          value: "25%"
+
   - it: Should set autoscaling configuration when enabled
     set:
       server:

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -590,10 +590,11 @@ tests:
           path: .spec.tls[0].secretName
           value: prefect.example.com-tls
 
-  - it: Should set deployment strategy
+  - it: Should set update strategy
     set:
       server:
-        deploymentStrategyType: Recreate
+        updateStrategy:
+          type: Recreate
     asserts:
       - template: server-deployment.yaml
         equal:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -200,6 +200,11 @@
             "type": "string"
           }
         },
+        "deploymentStrategyType": {
+          "type": "string",
+          "title": "Deployment strategy type",
+          "description": "The type of deployment strategy to use to replace existing pods with new ones"
+        },
         "revisionHistoryLimit": {
           "type": "integer",
           "title": "Revision History Limit",

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -200,10 +200,34 @@
             "type": "string"
           }
         },
-        "deploymentStrategyType": {
-          "type": "string",
-          "title": "Deployment strategy type",
-          "description": "The type of deployment strategy to use to replace existing pods with new ones"
+        "updateStrategy": {
+          "type": "object",
+          "title": "Update strategy",
+          "description": "The type of update strategy to use to replace existing pods with new ones",
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Deployment type",
+              "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\"."
+            },
+            "rollingUpdate" : {
+              "type": "object",
+              "title": "Rolling update settings",
+              "description": "Rolling update config params. Should only be specified if updateStrategy is set to \"RollingUpdate\".",
+              "properties": {
+                "maxSurge": {
+                  "type": "string",
+                  "title": "Max pod surge",
+                  "description": ""
+                },
+                "maxSurge": {
+                  "type": "string",
+                  "title": "Max unavailable pods",
+                  "description": ""
+                }
+              }
+            }
+          }
         },
         "revisionHistoryLimit": {
           "type": "integer",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -172,6 +172,10 @@ server:
     # -- set server container's security context capabilities
     capabilities: {}
 
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+  # -- The type of deployment strategy, can be "Recreate" or RollingUpdate". Setting this to "Recreate" is useful when database is on a mounted volume that can only be attached to a single node at a time.
+  deploymentStrategyType: "RollingUpdate"
+
   # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for server pod
   podLabels: {}

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -178,7 +178,8 @@ server:
   updateStrategy:
     type: RollingUpdate
     #rollingUpdate:
-    #  maxUnavailable: 1
+    #  maxUnavailable: "1"
+    #  maxSurge: "25%"
 
   # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for server pod

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -173,8 +173,12 @@ server:
     capabilities: {}
 
   # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-  # -- The type of deployment strategy, can be "Recreate" or RollingUpdate". Setting this to "Recreate" is useful when database is on a mounted volume that can only be attached to a single node at a time.
-  deploymentStrategyType: "RollingUpdate"
+  # -- Specifies the strategy used to replace old Pods by new ones. Type can be "Recreate" or "RollingUpdate".
+  # Setting this to "Recreate" is useful when database is on a mounted volume that can only be attached to a single node at a time.
+  updateStrategy:
+    type: RollingUpdate
+    #rollingUpdate:
+    #  maxUnavailable: 1
 
   # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for server pod


### PR DESCRIPTION
### Summary

Adds value `server.deploymentStrategyType`.

Useful when using sqlite database backend on a mounted volume, where the volume can only be mounted on a single node at a time. If the strategy is "OrderedReady" and the new pod is scheduled on a different node, the deployment will hang indefinitely.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
