### PR TITLE
feat(prefect-server): support ephemeral-storage resource settings

### DIFF
--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -244,9 +244,11 @@ tests:
           requests:
             cpu: 250m
             memory: 256Mi
+            ephemeral-storage: 100Mi
           limits:
             cpu: 500m
             memory: 512Mi
+            ephemeral-storage: 200Mi
     asserts:
       - template: server-deployment.yaml
         equal:
@@ -258,12 +260,20 @@ tests:
           value: 256Mi
       - template: server-deployment.yaml
         equal:
+          path: .spec.template.spec.containers[0].resources.requests.ephemeral-storage
+          value: 100Mi
+      - template: server-deployment.yaml
+        equal:
           path: .spec.template.spec.containers[0].resources.limits.cpu
           value: 500m
       - template: server-deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].resources.limits.memory
           value: 512Mi
+      - template: server-deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].resources.limits.ephemeral-storage
+          value: 200Mi
 
   - it: Should set the correct security context
     asserts:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -264,6 +264,11 @@
                   "type": "string",
                   "title": "Memory",
                   "description": "server memory request"
+                },
+                "ephemeral-storage": {
+                  "type": "string",
+                  "title": "Ephemeral Storage",
+                  "description": "server ephemeral storage request"
                 }
               }
             },
@@ -282,6 +287,11 @@
                   "type": "string",
                   "title": "Memory",
                   "description": "server memory limit"
+                },
+                "ephemeral-storage": {
+                  "type": "string",
+                  "title": "Ephemeral Storage",
+                  "description": "server ephemeral storage limit"
                 }
               }
             }

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -110,10 +110,12 @@ server:
     requests:
       cpu: 500m
       memory: 512Mi
+      # ephemeral-storage:
     # -- the requested limits for the server container
     limits:
       cpu: "1"
       memory: 1Gi
+      # ephemeral-storage:
 
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:


### PR DESCRIPTION

### Summary

Supports setting `resources.{requests,limits}.ephemeral-storage` for the `prefect-server` chart.

See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage

Closes https://github.com/PrefectHQ/prefect-helm/issues/495


<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
