### PR TITLE
chore: add script to run `chart-testing` locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,7 @@ buildall: buildworker buildserver buildprom
 .PHONY: helmtest
 helmtest: ## Run Helm unittest
 	./scripts/helm_unittest.sh
+
+.PHONY: charttest
+charttest: ## Run chart-testing
+	./scripts/helm_charttest.sh

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ make buildall
 
 Make sure that any new functionality is well tested!  You can do this by installing the chart locally, see [above](https://github.com/PrefectHQ/prefect-helm#installing-development-versions) for how to do this.
 
+#### Helm unit tests
+
 You can also create and run test suites via [helm-unittest](https://github.com/helm-unittest/helm-unittest).
 Related test files are stored under `./charts/<chart>/tests/*_test.yaml`.
 Refer to the `helm-unittest` repository for more information.
@@ -251,6 +253,19 @@ make helmtest
 
 When `helm-unittest` is available via the [`mise` registry](https://mise.jdx.dev/registry.html), we'll add it to `.mise.toml`
 for easy local installation.
+
+#### Helm linting and validation
+
+We use [chart-testing](https://github.com/helm/chart-testing) for linting and validation of our charts.
+Configuration files are stored under `./github/linters/*-ct.yaml`.
+Refer to the `chart-testing` repository for more information.
+
+The following helper script will run the tests via the `chart-testing` Docker image. The `helm-ct` binary will
+be installed locally through `mise`, but the Docker image addresses the problem of a missing local `chart_schema.yaml` file.
+
+```shell
+make charttest
+```
 
 ### Opening a PR
 

--- a/scripts/helm_charttest.sh
+++ b/scripts/helm_charttest.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script uses https://github.com/helm/chart-testing
+# to run tests for our Helm Charts.
+#
+# It uses the Docker image to make it easier to run on local machines without
+# having to manage the binary and its correct version.
+#
+# Dependencies:
+# - docker
+#
+# Usage:
+#  ./scripts/helm_charttest.sh
+
+version=${VERSION:-v3.13.0}
+
+# Lint each chart.
+# Note: we'll skip validating maintainers, which doesn't play nicely
+# in the Docker container. This will still run in CI.
+for chart in worker server; do
+  docker run \
+    -it --rm \
+    -v "$(pwd)":/code \
+    -w /code \
+    "quay.io/helmpack/chart-testing:${version}" \
+    /bin/bash -c "ct lint --config .github/linters/${chart}-ct.yaml --validate-maintainers=false"
+done


### PR DESCRIPTION
To speed up the feedback loop of confirming `chart-testing` passes, this change adds a script to run them locally.

Related to https://linear.app/prefect/issue/PLA-1561/cycle-22-catch-all

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
