### PR TITLE
chore(CI): do not run scheduled workflows in forks

### DIFF
--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   update_mise_tools:
+    if: github.repository == 'prefecthq/prefect-helm'
     runs-on: ubuntu-latest
     permissions:
       # required to write to the repo

--- a/.github/workflows/updatecli-major-versions.yaml
+++ b/.github/workflows/updatecli-major-versions.yaml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   updatecli_major:
+    if: github.repository == 'prefecthq/prefect-helm'
     runs-on: ubuntu-latest
     permissions:
       # required to write to the repo

--- a/.github/workflows/updatecli-minor-versions.yaml
+++ b/.github/workflows/updatecli-minor-versions.yaml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   updatecli_minor:
+    if: github.repository == 'prefecthq/prefect-helm'
     runs-on: ubuntu-latest
     permissions:
       # required to write to the repo


### PR DESCRIPTION
Ensures that forks of this repository do not inherit the schedules. For example, this happened in https://github.com/stigok/prefect-helm/pull/3

Related to https://linear.app/prefect/issue/PLA-1593/cycle-23-catch-all

References:

https://github.com/orgs/community/discussions/26704#discussioncomment-3252979 (the approach taken here)
https://beckysweger.com/2025/01/02/skip-a-job-in-a.html (an alternative we can consider later if needed)