### PR TITLE
Update worker to pass API auth string to created jobs via Kubernetes secret

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -419,6 +419,8 @@ worker:
 | worker.selfHostedServerApiConfig.basicAuth.enabled | bool | `false` | enable basic auth for the worker, for an administrator/password combination. must be enabled on the server as well |
 | worker.selfHostedServerApiConfig.basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | worker.selfManagedCloudApiConfig.accountId | string | `""` | prefect account ID |
+| worker.selfManagedCloudApiConfig.apiAuthStringSecret.key | string | `"key"` | prefect API basic auth string secret key |
+| worker.selfManagedCloudApiConfig.apiAuthStringSecret.name | string | `"prefect-api-auth-string"` | prefect API basic auth string secret name |
 | worker.selfManagedCloudApiConfig.apiKeySecret.key | string | `"key"` | prefect API secret key |
 | worker.selfManagedCloudApiConfig.apiKeySecret.name | string | `"prefect-api-key"` | prefect API secret name |
 | worker.selfManagedCloudApiConfig.apiUrl | string | `""` | prefect API url (PREFECT_API_URL) |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -247,6 +247,10 @@ spec:
               value: {{ .Values.worker.selfManagedCloudApiConfig.apiKeySecret.name }}
             - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY
               value: {{ .Values.worker.selfManagedCloudApiConfig.apiKeySecret.key }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_NAME
+              value: {{ .Values.worker.selfManagedCloudApiConfig.apiAuthStringSecret.name }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_KEY
+              value: {{ .Values.worker.selfManagedCloudApiConfig.apiAuthStringSecret.key }}
             {{- end }}
             - name: PREFECT_DEBUG_MODE
               value: {{ .Values.worker.image.debug | quote }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -1,3 +1,4 @@
+---
 suite: Worker configuration
 release:
   name: test
@@ -571,6 +572,9 @@ tests:
           apiKeySecret:
             name: self-managed-api-key-secret
             key: secret-key
+          apiAuthStringSecret:
+            name: self-managed-api-auth-string-secret
+            key: secret-key
     asserts:
       - template: deployment.yaml
         equal:
@@ -579,6 +583,14 @@ tests:
       - template: deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_KEY")].value
+          value: secret-key
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_NAME")].value
+          value: self-managed-api-auth-string-secret
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_KEY")].value
           value: secret-key
 
   - it: Should not set Kubernetes worker dnsPolicy if not provided

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -388,6 +388,23 @@
                 }
               }
             },
+            "apiAuthStringSecret": {
+              "type": "object",
+              "title": "API auth string Secret",
+              "description": "prefect api auth string secret",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "description": "prefect API auth string secret name"
+                },
+                "key": {
+                  "type": "string",
+                  "title": "Key",
+                  "description": "prefect API auth string secret key"
+                }
+              }
+            },
             "cloudApiUrl": {
               "type": "string",
               "title": "Self Managed Cloud API URL",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -1,3 +1,4 @@
+---
 ## Common parameters
 # -- partially overrides common.names.name
 nameOverride: ""
@@ -31,16 +32,16 @@ worker:
     # -- the resource specifications for the sync-base-job-template initContainer
     # Defaults to the resources defined for the worker container
     resources: {}
-      # -- the requested resources for the sync-base-job-template initContainer
-      # requests:
-      #   memory: 256Mi
-      #   cpu: 100m
-      #   ephemeral-storage:
-      # -- the requested limits for the sync-base-job-template initContainer
-      # limits:
-      #   memory: 1Gi
-      #   cpu: 1000m
-      #   ephemeral-storage:
+    # -- the requested resources for the sync-base-job-template initContainer
+    # requests:
+    #   memory: 256Mi
+    #   cpu: 100m
+    #   ephemeral-storage:
+    # -- the requested limits for the sync-base-job-template initContainer
+    # limits:
+    #   memory: 1Gi
+    #   cpu: 1000m
+    #   ephemeral-storage:
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
     # -- security context for the sync-base-job-template initContainer
     containerSecurityContext:
@@ -172,6 +173,12 @@ worker:
       # -- prefect API secret name
       name: prefect-api-key
       # -- prefect API secret key
+      key: key
+
+    apiAuthStringSecret:
+      # -- prefect API basic auth string secret name
+      name: prefect-api-auth-string
+      # -- prefect API basic auth string secret key
       key: key
 
     # -- Cloud API url for PREFECT_CLOUD_API_URL


### PR DESCRIPTION
## Summary

⚠️  **Needs https://github.com/PrefectHQ/prefect/pull/18578**

Follow-up to https://github.com/PrefectHQ/prefect-helm/pull/463 for the PREFECT_API_AUTH_STRING.

Related to https://github.com/PrefectHQ/prefect-helm/issues/442

Related to https://github.com/PrefectHQ/prefect/issues/17093

### Summary

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
