### PR TITLE
Add support using secret to provide a basic auth string to flow run pods

### DIFF
--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -260,6 +260,12 @@ spec:
             {{- else }}
               value: {{ .Values.worker.selfHostedServerApiConfig.basicAuth.authString | quote }}
             {{- end }}
+            {{- if .Values.worker.selfHostedServerApiConfig.basicAuth.existingSecret }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_NAME
+              value: {{ .Values.worker.selfHostedServerApiConfig.basicAuth.existingSecret }}
+            - name: PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_KEY
+              value: auth-string
+            {{- end }}
             {{- end }}
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -735,3 +735,20 @@ tests:
         equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")].value
           value: my-namespace
+
+  - it: Should set auth string secret environment variables when existingSecret is provided
+    set:
+      worker:
+        selfHostedServerApiConfig:
+          basicAuth:
+            enabled: true
+            existingSecret: "my-auth-secret"
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_NAME")].value
+          value: "my-auth-secret"
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_KEY")].value
+          value: "auth-string"


### PR DESCRIPTION
Following the updates in https://github.com/PrefectHQ/prefect/pull/18578, this PR updates the worker helm chart to add the necessary environment variables to enable a worker to provide a K8s secret to flow run pods.

Closes https://github.com/PrefectHQ/prefect-helm/issues/442