### PR TITLE
feat(server, worker): allow omitting security context

### DIFF
--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -356,6 +356,30 @@ tests:
           path: .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: true
 
+  - it: Should unset security context
+    set:
+      server:
+        podSecurityContext:
+          runAsUser: null
+          fsGroup: null
+    asserts:
+      - template: server-deployment.yaml
+        notExists:
+          path: .spec.template.spec.securityContext.runAsUser
+      - template: server-deployment.yaml
+        notExists:
+          path: .spec.template.spec.securityContext.fsGroup
+
+  - it: Should unset container security context
+    set:
+      server:
+        containerSecurityContext:
+          runAsUser: null
+    asserts:
+      - template: server-deployment.yaml
+        notExists:
+          path: .spec.template.spec.containers[0].securityContext.runAsUser
+
   - it: Should set pod labels
     set:
       server:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -425,7 +425,7 @@
           "additionalProperties": false,
           "properties": {
             "runAsUser": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "title": "Run As User",
               "description": "set server pod's security context runAsUser"
             },
@@ -435,7 +435,7 @@
               "description": "set server pods security context runAsNonRoot"
             },
             "fsGroup": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "title": "FS Group",
               "description": "set server pod's security context fsGroup"
             },
@@ -490,7 +490,7 @@
           "additionalProperties": false,
           "properties": {
             "runAsUser": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "title": "Run As User",
               "description": "set server container's security context runAsUser"
             },
@@ -751,15 +751,15 @@
         "podSecurityContext": {
           "type": "object",
           "properties": {
-            "runAsUser": { "type": "integer" },
+            "runAsUser": { "type": ["integer", "null"] },
             "runAsNonRoot": { "type": "boolean" },
-            "fsGroup": { "type": "integer" }
+            "fsGroup": { "type": ["integer", "null"] }
           }
         },
         "containerSecurityContext": {
           "type": "object",
           "properties": {
-            "runAsUser": { "type": "integer" },
+            "runAsUser": { "type": ["integer", "null"] },
             "runAsNonRoot": { "type": "boolean" },
             "readOnlyRootFilesystem": { "type": "boolean" },
             "allowPrivilegeEscalation": { "type": "boolean" },

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -369,7 +369,7 @@ worker:
 | worker.containerSecurityContext.capabilities | object | `{}` | set worker container's security context capabilities |
 | worker.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set worker containers' security context readOnlyRootFilesystem |
 | worker.containerSecurityContext.runAsNonRoot | bool | `true` | set worker containers' security context runAsNonRoot |
-| worker.containerSecurityContext.runAsUser | int | `1001` | set worker containers' security context runAsUser |
+| worker.containerSecurityContext.runAsUser | int | `1001` | set worker containers' security context runAsUser, set to `null` to unset |
 | worker.dnsConfig.nameservers | list | `[]` | optional list of IP addresses that will be used as dns servers for the Pod |
 | worker.dnsConfig.options | list | `[]` | optional list of dns options for the Pod |
 | worker.dnsConfig.searches | list | `[]` | optional list of dns search domains for hostname lookup in the Pod |
@@ -393,7 +393,7 @@ worker:
 | worker.initContainer.containerSecurityContext.capabilities | object | `{}` | set init container's security context capabilities |
 | worker.initContainer.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | set init containers' security context readOnlyRootFilesystem |
 | worker.initContainer.containerSecurityContext.runAsNonRoot | bool | `true` | set init containers' security context runAsNonRoot |
-| worker.initContainer.containerSecurityContext.runAsUser | int | `1001` | set init containers' security context runAsUser |
+| worker.initContainer.containerSecurityContext.runAsUser | int | `1001` | set init containers' security context runAsUser, set to `null` to unset |
 | worker.initContainer.extraContainers | list | `[]` | additional sidecar containers |
 | worker.initContainer.resources | object | `{}` | the resource specifications for the sync-base-job-template initContainer Defaults to the resources defined for the worker container |
 | worker.livenessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
@@ -405,9 +405,9 @@ worker:
 | worker.nodeSelector | object | `{}` | node labels for worker pods assignment |
 | worker.podAnnotations | object | `{}` | extra annotations for worker pod |
 | worker.podLabels | object | `{}` | extra labels for worker pod |
-| worker.podSecurityContext.fsGroup | int | `1001` | set worker pod's security context fsGroup |
+| worker.podSecurityContext.fsGroup | int | `1001` | set worker pod's security context fsGroup, set to `null` to unset |
 | worker.podSecurityContext.runAsNonRoot | bool | `true` | set worker pod's security context runAsNonRoot |
-| worker.podSecurityContext.runAsUser | int | `1001` | set worker pod's security context runAsUser |
+| worker.podSecurityContext.runAsUser | int | `1001` | set worker pod's security context runAsUser, set to `null` to unset |
 | worker.podSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | set worker pod's seccomp profile |
 | worker.priorityClassName | string | `""` | priority class name to use for the worker pods; if the priority class is empty or doesn't exist, the worker pods are scheduled without a priority class |
 | worker.replicaCount | int | `1` | number of worker replicas to deploy |

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -334,6 +334,30 @@ tests:
           path: .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: true
 
+  - it: Should unset the security context
+    set:
+      worker:
+        podSecurityContext:
+          runAsUser: null
+          fsGroup: null
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.securityContext.runAsUser
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.securityContext.fsGroup
+
+  - it: Should unset the container security context
+    set:
+      worker:
+        containerSecurityContext:
+          runAsUser: null
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.containers[0].securityContext.runAsUser
+
   - it: Should set pod annotations
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -154,7 +154,7 @@
                   "description": "set init containers' security context runAsNonRoot"
                 },
                 "runAsUser": {
-                  "type": "integer",
+                  "type": ["integer", "null"],
                   "title": "Run As User",
                   "description": "set init containers' security context runAsUser"
                 },
@@ -552,7 +552,7 @@
           "additionalProperties": false,
           "properties": {
             "fsGroup": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "title": "FS Group",
               "description": "set worker pod's security context fsGroup"
             },
@@ -562,7 +562,7 @@
               "description": "set worker pod's security context runAsNonRoot"
             },
             "runAsUser": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "title": "Run As User",
               "description": "set worker pod's security context runAsUser"
             },
@@ -653,7 +653,7 @@
               "description": "set worker containers' security context runAsNonRoot"
             },
             "runAsUser": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "title": "Run As User",
               "description": "set worker containers' security context runAsUser"
             },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -44,7 +44,7 @@ worker:
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
     # -- security context for the sync-base-job-template initContainer
     containerSecurityContext:
-      # -- set init containers' security context runAsUser
+      # -- set init containers' security context runAsUser, set to `null` to unset
       runAsUser: 1001
       # -- set init containers' security context runAsNonRoot
       runAsNonRoot: true
@@ -228,11 +228,11 @@ worker:
 
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext:
-    # -- set worker pod's security context runAsUser
+    # -- set worker pod's security context runAsUser, set to `null` to unset
     runAsUser: 1001
     # -- set worker pod's security context runAsNonRoot
     runAsNonRoot: true
-    # -- set worker pod's security context fsGroup
+    # -- set worker pod's security context fsGroup, set to `null` to unset
     fsGroup: 1001
     # -- set worker pod's seccomp profile
     seccompProfile:
@@ -246,7 +246,7 @@ worker:
 
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext:
-    # -- set worker containers' security context runAsUser
+    # -- set worker containers' security context runAsUser, set to `null` to unset
     runAsUser: 1001
     # -- set worker containers' security context runAsNonRoot
     runAsNonRoot: true


### PR DESCRIPTION
### Summary


Allows omitting podSecurityContext and containerSecurityContext settings by providing `null` as a value.

Closes https://github.com/PrefectHQ/prefect-helm/issues/505


<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
