### PR TITLE
fix: add args and command to worker chart

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -343,6 +343,7 @@ worker:
 | serviceAccount.name | string | `""` | the name of the ServiceAccount to use. if not set and create is true, a name is generated using the common.names.fullname template |
 | worker.affinity | object | `{}` | affinity for worker pods assignment |
 | worker.apiConfig | string | `"cloud"` | one of 'cloud', 'selfManagedCloud', or 'selfHostedServer' |
+| worker.args | list | `[]` | Custom container command arguments |
 | worker.autoscaling.enabled | bool | `false` | enable autoscaling for the worker |
 | worker.autoscaling.maxReplicas | int | `1` | maximum number of replicas to scale up to |
 | worker.autoscaling.minReplicas | int | `1` | minimum number of replicas to scale down to |
@@ -354,6 +355,7 @@ worker:
 | worker.cloudApiConfig.cloudUrl | string | `"https://api.prefect.cloud/api"` | prefect cloud API url; the full URL is constructed as https://cloudUrl/accounts/accountId/workspaces/workspaceId |
 | worker.cloudApiConfig.workspaceId | string | `""` | prefect workspace ID |
 | worker.clusterUid | string | `""` | unique cluster identifier, if none is provided this value will be inferred at time of helm install |
+| worker.command | list | `[]` | Custom container entrypoint |
 | worker.config.baseJobTemplate.configuration | string | `nil` | JSON formatted base job template. If data is provided here, the chart will generate a configmap and mount it to the worker pod |
 | worker.config.baseJobTemplate.existingConfigMapName | string | `""` | the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json' |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -170,11 +170,18 @@ spec:
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.prefectTag }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           command:
+            {{- if .Values.worker.command }}
+            {{- .Values.worker.command | toYaml | nindent 12 }}
+            {{- else }}
             - /usr/bin/tini
             - -g
             - --
             - /opt/prefect/entrypoint.sh
+            {{- end }}
           args:
+            {{- if .Values.worker.args }}
+            {{- .Values.worker.args | toYaml | nindent 12 }}
+            {{- else }}
             - prefect
             - worker
             - start
@@ -205,6 +212,7 @@ spec:
             {{- end }}
             {{- range .Values.worker.extraArgs }}
             - {{ . | toString }}
+            {{- end }}
             {{- end }}
           workingDir: /home/prefect
           env:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -776,3 +776,28 @@ tests:
         equal:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_AUTH_STRING_SECRET_KEY")].value
           value: "auth-string"
+
+  - it: Should configure custom entrypoint and args
+    set:
+      worker:
+        command:
+          - /usr/bin/tini
+          - myentrypoint
+        args:
+          - prefect
+          - worker
+          - start
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].command
+          value:
+            - /usr/bin/tini
+            - myentrypoint
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].args
+          value:
+            - prefect
+            - worker
+            - start

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -154,7 +154,7 @@
                   "description": "set init containers' security context runAsNonRoot"
                 },
                 "runAsUser": {
-                  "type": [ "integer", "null" ],
+                  "type": ["integer", "null"],
                   "title": "Run As User",
                   "description": "set init containers' security context runAsUser"
                 },
@@ -264,12 +264,12 @@
               "description": "connect using HTTP/2 if the server supports it (experimental)"
             },
             "limit": {
-              "type": [ "integer", "null" ],
+              "type": ["integer", "null"],
               "title": "Limit",
               "description": "Maximum number of flow runs to start simultaneously (default: unlimited)"
             },
             "name": {
-              "type": [ "string", "null" ],
+              "type": ["string", "null"],
               "title": "Name",
               "description": "The name to give to the started worker. If not provided, a unique name will be generated."
             },
@@ -277,7 +277,7 @@
               "type": "string",
               "title": "Install Policy",
               "description": "install policy to use workers from Prefect integration packages.",
-              "enum": [ "always", "if-not-present", "never", "prompt" ]
+              "enum": ["always", "if-not-present", "never", "prompt"]
             },
             "type": {
               "type": "string",
@@ -296,12 +296,12 @@
                   "description": "the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json'"
                 },
                 "configuration": {
-                  "type": [ "string", "null" ],
+                  "type": ["string", "null"],
                   "title": "Base Job Template Configuration",
                   "description": "JSON formatted base job template. If data is provided here, the chart will generate a configmap and mount it to the worker pod"
                 },
                 "name": {
-                  "type": [ "string", "null" ],
+                  "type": ["string", "null"],
                   "title": "Name",
                   "description": "optionally override the default name of the generated configmap."
                 }
@@ -313,7 +313,7 @@
           "type": "string",
           "title": "API Config",
           "description": "one of 'cloud', 'selfManagedCloud', or 'selfHostedServer'",
-          "enum": [ "cloud", "selfManagedCloud", "selfHostedServer" ]
+          "enum": ["cloud", "selfManagedCloud", "selfHostedServer"]
         },
         "cloudApiConfig": {
           "type": "object",
@@ -552,7 +552,7 @@
           "additionalProperties": false,
           "properties": {
             "fsGroup": {
-              "type": [ "integer", "null" ],
+              "type": ["integer", "null"],
               "title": "FS Group",
               "description": "set worker pod's security context fsGroup"
             },
@@ -562,7 +562,7 @@
               "description": "set worker pod's security context runAsNonRoot"
             },
             "runAsUser": {
-              "type": [ "integer", "null" ],
+              "type": ["integer", "null"],
               "title": "Run As User",
               "description": "set worker pod's security context runAsUser"
             },
@@ -653,7 +653,7 @@
               "description": "set worker containers' security context runAsNonRoot"
             },
             "runAsUser": {
-              "type": [ "integer", "null" ],
+              "type": ["integer", "null"],
               "title": "Run As User",
               "description": "set worker containers' security context runAsUser"
             },

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -154,7 +154,7 @@
                   "description": "set init containers' security context runAsNonRoot"
                 },
                 "runAsUser": {
-                  "type": ["integer", "null"],
+                  "type": [ "integer", "null" ],
                   "title": "Run As User",
                   "description": "set init containers' security context runAsUser"
                 },
@@ -264,12 +264,12 @@
               "description": "connect using HTTP/2 if the server supports it (experimental)"
             },
             "limit": {
-              "type": ["integer", "null"],
+              "type": [ "integer", "null" ],
               "title": "Limit",
               "description": "Maximum number of flow runs to start simultaneously (default: unlimited)"
             },
             "name": {
-              "type": ["string", "null"],
+              "type": [ "string", "null" ],
               "title": "Name",
               "description": "The name to give to the started worker. If not provided, a unique name will be generated."
             },
@@ -277,7 +277,7 @@
               "type": "string",
               "title": "Install Policy",
               "description": "install policy to use workers from Prefect integration packages.",
-              "enum": ["always", "if-not-present", "never", "prompt"]
+              "enum": [ "always", "if-not-present", "never", "prompt" ]
             },
             "type": {
               "type": "string",
@@ -296,12 +296,12 @@
                   "description": "the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json'"
                 },
                 "configuration": {
-                  "type": ["string", "null"],
+                  "type": [ "string", "null" ],
                   "title": "Base Job Template Configuration",
                   "description": "JSON formatted base job template. If data is provided here, the chart will generate a configmap and mount it to the worker pod"
                 },
                 "name": {
-                  "type": ["string", "null"],
+                  "type": [ "string", "null" ],
                   "title": "Name",
                   "description": "optionally override the default name of the generated configmap."
                 }
@@ -313,7 +313,7 @@
           "type": "string",
           "title": "API Config",
           "description": "one of 'cloud', 'selfManagedCloud', or 'selfHostedServer'",
-          "enum": ["cloud", "selfManagedCloud", "selfHostedServer"]
+          "enum": [ "cloud", "selfManagedCloud", "selfHostedServer" ]
         },
         "cloudApiConfig": {
           "type": "object",
@@ -552,7 +552,7 @@
           "additionalProperties": false,
           "properties": {
             "fsGroup": {
-              "type": ["integer", "null"],
+              "type": [ "integer", "null" ],
               "title": "FS Group",
               "description": "set worker pod's security context fsGroup"
             },
@@ -562,7 +562,7 @@
               "description": "set worker pod's security context runAsNonRoot"
             },
             "runAsUser": {
-              "type": ["integer", "null"],
+              "type": [ "integer", "null" ],
               "title": "Run As User",
               "description": "set worker pod's security context runAsUser"
             },
@@ -653,7 +653,7 @@
               "description": "set worker containers' security context runAsNonRoot"
             },
             "runAsUser": {
-              "type": ["integer", "null"],
+              "type": [ "integer", "null" ],
               "title": "Run As User",
               "description": "set worker containers' security context runAsUser"
             },
@@ -680,6 +680,22 @@
                 }
               }
             }
+          }
+        },
+        "args": {
+          "type": "array",
+          "title": "Custom container command arguments",
+          "description": "array with arguments",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command": {
+          "type": "array",
+          "title": "Custom container entrypoint",
+          "description": "array with container entrypoint",
+          "items": {
+            "type": "string"
           }
         },
         "podLabels": {

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -30,8 +30,7 @@ worker:
   initContainer:
     # -- the resource specifications for the sync-base-job-template initContainer
     # Defaults to the resources defined for the worker container
-    resources:
-      {}
+    resources: {}
       # -- the requested resources for the sync-base-job-template initContainer
       # requests:
       #   memory: 256Mi

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -30,7 +30,8 @@ worker:
   initContainer:
     # -- the resource specifications for the sync-base-job-template initContainer
     # Defaults to the resources defined for the worker container
-    resources: {}
+    resources:
+      {}
       # -- the requested resources for the sync-base-job-template initContainer
       # requests:
       #   memory: 256Mi
@@ -256,6 +257,12 @@ worker:
     allowPrivilegeEscalation: false
     # -- set worker container's security context capabilities
     capabilities: {}
+
+  # -- Custom container command arguments
+  args: []
+
+  # -- Custom container entrypoint
+  command: []
 
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   # -- extra labels for worker pod


### PR DESCRIPTION
### Summary

Adds command and args to worker chart. Just like it has been done for the server chart.

```bash
helm template worker charts/prefect-worker --set="worker.apiConfig=selfHostedServer" --set="worker.selfHostedServerApiConfig.apiUrl=localhost" --set="worker.args={a,b,c}" | yq 'select(.kind == "Deployment") | .spec.template.spec.containers[0].args'
# output
- a
- b
- c
```

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
