### PR TITLE
feat(worker): allow namespace override for worker role

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -336,6 +336,7 @@ worker:
 | nameOverride | string | `""` | partially overrides common.names.name |
 | namespaceOverride | string | `""` | fully override common.names.namespace |
 | role.create | bool | `true` | specifies whether a Role should be created |
+| role.namespace | string | `nil` | the namespace to deploy the role to. If not provided, deploys to the same namespace as the worker |
 | role.extraPermissions | list | `[]` | array with extra permissions to add to the worker role |
 | rolebinding.create | bool | `true` | specifies whether a RoleBinding should be created |
 | serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |

--- a/charts/prefect-worker/templates/role.yaml
+++ b/charts/prefect-worker/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.role.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
     prefect-version: {{ .Chart.AppVersion }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -801,3 +801,12 @@ tests:
             - prefect
             - worker
             - start
+  - it: Should allow override of role namespace
+    set:
+      role:
+        namespace: my-namespace
+    asserts:
+      - template: role.yaml
+        equal:
+          path: .metadata.namespace
+          value: my-namespace

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -844,6 +844,11 @@
           "title": "Create",
           "description": "create role"
         },
+        "namespace": {
+          "type": ["string", "null"],
+          "title": "Namespace",
+          "description": "the namespace to deploy the role to. If not provided, deploys to the same namespace as the worker"
+        },
         "extraPermissions": {
           "type": "array",
           "title": "Extra Permissions",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -328,6 +328,7 @@ serviceAccount:
 role:
   # -- specifies whether a Role should be created
   create: true
+  # -- the namespace to deploy the role to. If not provided, deploys to the same namespace as the worker
   namespace: null
   ## List of extra role permissions
   ## e.g:

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -328,6 +328,7 @@ serviceAccount:
 role:
   # -- specifies whether a Role should be created
   create: true
+  namespace: null
   ## List of extra role permissions
   ## e.g:
   ## extraPermissions:


### PR DESCRIPTION
### Summary

There is a scenario where I would like my jobs to execute in a different namespace than the worker. As such I believe the role namespace could allow for overrides in order for use cases where users would like to segregate the namespaces where jobs execute and for the worker deployments

closes #516 

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [ ] Relevant labels are added
- [ ] `Draft` status is used until ready for review
