### PR TITLE
fix(worker): labelling of configmap

### DIFF
--- a/charts/prefect-worker/templates/configmap.yaml
+++ b/charts/prefect-worker/templates/configmap.yaml
@@ -4,8 +4,11 @@ kind: ConfigMap
 metadata:
   name: {{ include "worker.baseJobTemplateName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -801,3 +801,46 @@ tests:
             - prefect
             - worker
             - start
+
+  - it: Should configure additional labels on templated resources
+    set:
+      worker:
+        autoscaling:
+          enabled: true
+        config:
+          baseJobTemplate:
+            configuration: |
+              {}
+      role:
+        create: true
+      rolebinding:
+        create: true
+      serviceAccount:
+        create: true
+      commonLabels:
+        my-label: my-value
+    asserts:
+      - template: configmap.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: deployment.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: hpa.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: role.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: rolebinding.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: serviceaccount.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value


### PR DESCRIPTION
### Summary

common.labels.standard can not be applied to the dict, and it should be applied to the root `.` 

this seems to only affect the configmap template. therefore i copied the labels from the deployment template to match it which i believe is what is intended

<!-- Add a brief description of your change here -->

### Requirements

- [ ] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
