### PR TITLE
fix: override namespace of rolebinding along with role

### DIFF
--- a/charts/prefect-worker/templates/rolebinding.yaml
+++ b/charts/prefect-worker/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.role.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
     prefect-version: {{ .Chart.AppVersion }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -845,12 +845,16 @@ tests:
           path: .metadata.labels.my-label
           value: my-value
 
-  - it: Should allow override of role namespace
+  - it: Should allow override of role and rolebinding namespace
     set:
       role:
         namespace: my-namespace
     asserts:
       - template: role.yaml
+        equal:
+          path: .metadata.namespace
+          value: my-namespace
+      - template: rolebinding.yaml
         equal:
           path: .metadata.namespace
           value: my-namespace


### PR DESCRIPTION
### Summary

as per title. rolebinding has to be in the same namespace as the role for it to take effect. this will allow the namespace to be overwritten with the role resource.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [ ] Relevant labels are added
- [ ] `Draft` status is used until ready for review
