### PR TITLE
maintenance(prefect-server): migrate to bitnami legacy postgres registry by default

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -274,7 +274,7 @@ the HorizontalPodAutoscaler.
 | postgresql.auth.username | string | `"prefect"` | name for a custom user |
 | postgresql.enabled | bool | `true` | enable use of bitnami/postgresql subchart |
 | postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | Image repository.  Defaults to legacy bitnami repository for postgres 14.13.0 availability. |
-| postgresql.image.tag | string | `"14.13.0"` | Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/ |
+| postgresql.image.tag | string | `"14.13.0"` | Version tag, corresponds to tags at https://hub.docker.com/layers/bitnamilegacy/postgresql/ |
 | postgresql.primary.initdb.user | string | `"postgres"` | specify the PostgreSQL username to execute the initdb scripts |
 | postgresql.primary.persistence.enabled | bool | `false` | enable PostgreSQL Primary data persistence using PVC |
 | secret.create | bool | `true` | whether to create a Secret containing the PostgreSQL connection string |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -273,6 +273,7 @@ the HorizontalPodAutoscaler.
 | postgresql.auth.password | string | `"prefect-rocks"` | password for the custom user. Ignored if `auth.existingSecret` with key `password` is provided |
 | postgresql.auth.username | string | `"prefect"` | name for a custom user |
 | postgresql.enabled | bool | `true` | enable use of bitnami/postgresql subchart |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | Image repository.  Defaults to legacy bitnami repository for postgres 14.13.0 availability. |
 | postgresql.image.tag | string | `"14.13.0"` | Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/ |
 | postgresql.primary.initdb.user | string | `"postgres"` | specify the PostgreSQL username to execute the initdb scripts |
 | postgresql.primary.persistence.enabled | bool | `false` | enable PostgreSQL Primary data persistence using PVC |

--- a/charts/prefect-server/UPGRADING.md
+++ b/charts/prefect-server/UPGRADING.md
@@ -1,4 +1,9 @@
 # Upgrade guidelines
+## > 2025.7.31204438
+
+After version 2025.7.31204438, we have migrated the `postgresql` image from the existing `bitnami` repo image to the `bitnamilegacy` repo image.
+This change should not have any breaking change implications unless there is a need to whitelist that new docker registry.
+The change is required per https://github.com/bitnami/charts/issues/35164.
 
 ## > 2025.3.7033449
 

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -513,5 +513,5 @@ postgresql:
   image:
     # -- Image repository.  Defaults to legacy bitnami repository for postgres 14.13.0 availability.
     repository: bitnamilegacy/postgresql
-    # -- Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/
+    # -- Version tag, corresponds to tags at https://hub.docker.com/layers/bitnamilegacy/postgresql/
     tag: 14.13.0

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -511,5 +511,7 @@ postgresql:
       enabled: false
 
   image:
+    # -- Image repository.  Defaults to legacy bitnami repository for postgres 14.13.0 availability.
+    repository: bitnamilegacy/postgresql
     # -- Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/postgresql/
     tag: 14.13.0


### PR DESCRIPTION
### Summary

As a result of bitnami migrating to maintaining onlly "secure images" per https://github.com/bitnami/containers/issues/83267,  we are going to migrate the default image registry for bitnami postgres to `bitnamilegacy`.  We will continue to follow and identify upgrade paths to the `bitnamisecure` registry in the future, but since information is sparse on this front for different postgres versions, we are prioritizing maintaining chart functionality.

I have tested and confirmed that the `bitnamilegacy` postgres image works as expected.

Resolves: https://linear.app/prefect/issue/PLA-1994/situation-with-bitnami-docker-images

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
