### PR TITLE
chore(redis): use bitnamilegacy/redis repository

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -113,7 +113,7 @@ If you want to use the bundled Redis chart but need to customize the configurati
 ```yaml
 redis:
   enabled: true
- 
+
   auth:
     # set a custom password for the Redis instance
     password: "dontpanic!"
@@ -283,7 +283,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.messaging.redis | object | `{"db":0,"host":"","password":"","port":6379,"ssl":false,"username":""}` | settings for redis broker/cache change these if not using the built-in redis subchart |
 | backgroundServices.messaging.redis.db | int | `0` | redis database number |
 | backgroundServices.messaging.redis.host | string | `""` | redis hostname if using the built-in redis subchart, this will be automatically set to the redis subchart's service name |
-| backgroundServices.messaging.redis.password | string | `""` | redis password, leave empty to use default  if using the built-in redis subchart, this will be automatically set to the redis subchart's password value |
+| backgroundServices.messaging.redis.password | string | `""` | redis password, leave empty to use default if using the built-in redis subchart, this will be automatically set to the redis subchart's password value |
 | backgroundServices.messaging.redis.port | int | `6379` | redis port |
 | backgroundServices.messaging.redis.ssl | bool | `false` | use TLS for redis connection |
 | backgroundServices.messaging.redis.username | string | `""` | redis username, leave empty to use no authentication if using the built-in redis subchart, this will be automatically set to the redis subchart's username value |
@@ -336,6 +336,7 @@ the HorizontalPodAutoscaler.
 | postgresql.primary.persistence.enabled | bool | `false` | enable PostgreSQL Primary data persistence using PVC |
 | redis.architecture | string | `"standalone"` | Redis architecture Note: Prefect currently only supports standalone Redis deployments. |
 | redis.enabled | bool | `false` | enable use of bitnami/redis subchart if backgroundServices.runAsSeparateDeployment=true, you must set this to true or provide your own redis instance |
+| redis.image.repository | string | `"bitnamilegacy/redis"` | Image repository.  Defaults to legacy bitnami repository for redis 8.2.1 availability. |
 | redis.image.tag | string | `"8.2.1"` | Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/redis/ |
 | secret.create | bool | `true` | whether to create a Secret containing the PostgreSQL connection string |
 | secret.database | string | `""` | database for the PostgreSQL connection string |

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -112,7 +112,7 @@ If you want to use the bundled Redis chart but need to customize the configurati
 ```yaml
 redis:
   enabled: true
-  
+
   auth:
     # set a custom password for the Redis instance
     password: "dontpanic!"

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Make redis subchart context available as a variable in this block
 - name: PREFECT_REDIS_MESSAGING_USERNAME
   value: {{ .Values.backgroundServices.messaging.redis.username | quote }}
 {{- end -}}
-{{- /* 
+{{- /*
 There are three scenarios for passwords:
-    1. If the subchart is enabled, reference the secret from the subchart. 
+    1. If the subchart is enabled, reference the secret from the subchart.
        Setting backgroundServices.messaging.redis.password has no effect here.
     2. If the subchart is not enabled, use the secret defined in the values file. TODO: secret reference
     3. No password is set, so the environment variable is not defined.

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -2,7 +2,7 @@ suite: Background Services configuration
 release:
   name: background-services-test
   namespace: prefect
-  
+
 set:
   global:
     prefect:

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -333,38 +333,38 @@ backgroundServices:
     name: ""
     # -- additional service account annotations (evaluated as a template)
     annotations: {}
-    
-  # Configuration for background service messaging using Redis 
+
+  # Configuration for background service messaging using Redis
   messaging:
     # ref: https://docs.prefect.io/v3/api-ref/settings-ref#messaging-broker
     # -- messaging broker class to use for background services
     broker: prefect_redis.messaging
-    
+
     # ref: https://docs.prefect.io/v3/api-ref/settings-ref#messaging-cache
     # -- messaging cache class to use for background services
     cache: prefect_redis.messaging
-    
+
     # -- settings for redis broker/cache
     # change these if not using the built-in redis subchart
     redis:
       # -- redis hostname
       # if using the built-in redis subchart, this will be automatically set to the redis subchart's service name
       host: ""
-      
+
       # -- redis port
       port: 6379
-      
+
       # -- redis database number
       db: 0
-      
+
       # -- redis username, leave empty to use no authentication
       # if using the built-in redis subchart, this will be automatically set to the redis subchart's username value
       username: ""
-      
-      # -- redis password, leave empty to use default 
+
+      # -- redis password, leave empty to use default
       # if using the built-in redis subchart, this will be automatically set to the redis subchart's password value
       password: ""
-      
+
       # -- use TLS for redis connection
       ssl: false
 
@@ -555,11 +555,13 @@ redis:
   # -- enable use of bitnami/redis subchart
   # if backgroundServices.runAsSeparateDeployment=true, you must set this to true or provide your own redis instance
   enabled: false
-  
+
   # -- Redis architecture
   # Note: Prefect currently only supports standalone Redis deployments.
   architecture: standalone
-  
-  image: 
+
+  image:
+    # -- Image repository.  Defaults to legacy bitnami repository for redis 8.2.1 availability.
+    repository: bitnamilegacy/redis
     # -- Version tag, corresponds to tags at https://hub.docker.com/r/bitnami/redis/
     tag: 8.2.1


### PR DESCRIPTION
### Summary

Set Redis subchart repository value to `bitnamilegacy/redis`

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
