### PR TITLE
fix(server): Add PREFECT_SERVER_EVENTS_CAUSAL_ORDERING env when running background services

### DIFF
--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -38,6 +38,8 @@ Make redis subchart context available as a variable in this block
 - name: PREFECT_MESSAGING_CACHE
   value: {{ .Values.backgroundServices.messaging.cache }}
 {{- if eq .Values.backgroundServices.messaging.broker "prefect_redis.messaging" }}
+- name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
+  value: prefect_redis.ordering
 - name: PREFECT_REDIS_MESSAGING_HOST
 {{- if and (.Values.redis.enabled) (.Values.backgroundServices.messaging.redis.host | empty) }}
   value: {{ printf "%s-headless" (include "common.names.fullname" $redis) }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -504,6 +504,11 @@ tests:
       - contains:
           path: .spec.template.spec.containers[0].env
           content:
+            name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
+            value: prefect_redis.ordering
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
             name: PREFECT_REDIS_MESSAGING_HOST
             value: background-services-test-redis-headless.prefect.svc.cluster.local
       - contains:
@@ -550,6 +555,21 @@ tests:
       redis:
         enabled: false
     asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_MESSAGING_BROKER
+            value: prefect_redis.messaging
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_MESSAGING_CACHE
+            value: prefect_redis.messaging
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
+            value: prefect_redis.ordering
       - contains:
           path: .spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
### Summary

Add `PREFECT_SERVER_EVENTS_CAUSAL_ORDERING=prefect_redis.ordering`

Closes #526 

### Requirements

- [X] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [X] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [X] Body includes `Closes <issue>`, if available
- [X] Added/modified configuration includes a descriptive comment for documentation generation
- [X] Unit tests are added/updated
- [X] Deprecation/removal checks are added in `templates/NOTES.txt`
- [X] Relevant labels are added
- [X] `Draft` status is used until ready for review
