### PR TITLE
Add `PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE` environment variable to use Redis for concurrency lease storage

### DIFF
--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -42,6 +42,8 @@ Make redis subchart context available as a variable in this block
 {{- if eq .Values.backgroundServices.messaging.broker "prefect_redis.messaging" }}
 - name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
   value: prefect_redis.ordering
+- name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
+  value: prefect_redis.lease_storage
 - name: PREFECT_REDIS_MESSAGING_HOST
 {{- if and (.Values.redis.enabled) (.Values.backgroundServices.messaging.redis.host | empty) }}
   value: {{ printf "%s-headless" (include "common.names.fullname" $redis) }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -515,7 +515,7 @@ tests:
           path: .spec.template.spec.containers[0].env
           content:
             name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
-            value: prefect_redis.least_storage
+            value: prefect_redis.lease_storage
       - contains:
           path: .spec.template.spec.containers[0].env
           content:
@@ -589,7 +589,7 @@ tests:
           path: .spec.template.spec.containers[0].env
           content:
             name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
-            value: prefect_redis.least_storage
+            value: prefect_redis.lease_storage
       - contains:
           path: .spec.template.spec.containers[0].env
           content:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -466,7 +466,7 @@ tests:
         enabled: false
     asserts:
       - template: NOTES.txt
-        notFailedTemplate: { }
+        notFailedTemplate: {}
 
   - it: Should deploy standalone redis instance by default
     asserts:
@@ -511,6 +511,11 @@ tests:
           content:
             name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
             value: prefect_redis.ordering
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
+            value: prefect_redis.least_storage
       - contains:
           path: .spec.template.spec.containers[0].env
           content:
@@ -580,6 +585,11 @@ tests:
           content:
             name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
             value: prefect_redis.ordering
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
+            value: prefect_redis.least_storage
       - contains:
           path: .spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
This setting is necessary to ensure concurrency leases work correctly in a multi-server deployment.