### PR TITLE
Add version requirement warning for separated background services

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -78,6 +78,9 @@ you are not having any issues with your setup.
 
 To run background services in a separate deployment:
 
+> [!WARNING]
+> **Version Requirement**: When using `backgroundServices.runAsSeparateDeployment: true`, you must use Prefect 3.4.16 or later. Earlier versions have a bug where the `--no-services` flag doesn't fully disable background services, causing Redis connection errors in the server pod.
+
 ```yaml
 backgroundServices:
   runAsSeparateDeployment: true

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -77,6 +77,9 @@ you are not having any issues with your setup.
 
 To run background services in a separate deployment:
 
+> [!WARNING]
+> **Version Requirement**: When using `backgroundServices.runAsSeparateDeployment: true`, you must use Prefect 3.4.16 or later. Earlier versions have a bug where the `--no-services` flag doesn't fully disable background services, causing Redis connection errors in the server pod.
+
 ```yaml
 backgroundServices:
   runAsSeparateDeployment: true


### PR DESCRIPTION
## Summary
This PR adds a documentation warning about the Prefect version requirement when using separated background services.

## Background
When using `backgroundServices.runAsSeparateDeployment: true`, Prefect 3.4.16+ is required. Earlier versions have a bug where the `--no-services` flag doesn't fully disable background services, causing Redis connection errors in the server pod.

This issue was discovered during a deployment and was fixed in https://github.com/PrefectHQ/prefect/pull/18820.

## Changes
- Added warning to both README.md and README.md.gotmpl about the version requirement
- Clarifies that Prefect 3.4.16+ is required for separated background services configuration

This helps users avoid a confusing error where the server pod shows Redis connection errors even though Redis is properly configured.