### PR TITLE
fix(server): only run db migration hook in multi-server mode

### DIFF
--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.sqlite.enabled) .Values.migrations.enabled -}}
+{{- if and .Values.backgroundServices.runAsSeparateDeployment (not .Values.sqlite.enabled) .Values.migrations.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -4,6 +4,16 @@ release:
   name: pre-upgrade-hook-test
   namespace: prefect
 
+set:
+  global:
+    prefect:
+      image:
+        prefectTag: 3.1.13-python3.11-kubernetes
+  backgroundServices:
+    runAsSeparateDeployment: true
+  redis:
+    enabled: true
+
 tests:
   - it: Should create pre-upgrade hook job for PostgreSQL deployments
     set:
@@ -13,8 +23,6 @@ tests:
           password: testpass
       sqlite:
         enabled: false
-      migrations:
-        enabled: true
     asserts:
       - template: pre-upgrade-hook.yaml
         containsDocument:
@@ -52,8 +60,6 @@ tests:
         enabled: false
       sqlite:
         enabled: true
-      migrations:
-        enabled: true
     asserts:
       - template: pre-upgrade-hook.yaml
         not: true
@@ -63,12 +69,6 @@ tests:
 
   - it: Should not create pre-upgrade hook job when migrations are disabled
     set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
       migrations:
         enabled: false
     asserts:
@@ -79,15 +79,6 @@ tests:
           kind: Job
 
   - it: Should use correct service account for pre-upgrade hook
-    set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
-      migrations:
-        enabled: true
     asserts:
       - template: pre-upgrade-hook.yaml
         equal:
@@ -96,14 +87,6 @@ tests:
 
   - it: Should include global environment variables in pre-upgrade hook
     set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
-      migrations:
-        enabled: true
       global:
         prefect:
           env:
@@ -119,14 +102,6 @@ tests:
 
   - it: Should include server environment variables in pre-upgrade hook
     set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
-      migrations:
-        enabled: true
       server:
         env:
           - name: SERVER_VAR
@@ -140,15 +115,6 @@ tests:
             value: server_value
 
   - it: Should set correct resource limits for pre-upgrade hook
-    set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
-      migrations:
-        enabled: true
     asserts:
       - template: pre-upgrade-hook.yaml
         equal:
@@ -162,15 +128,6 @@ tests:
               memory: 256Mi
 
   - it: Should set correct security context for pre-upgrade hook
-    set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
-      migrations:
-        enabled: true
     asserts:
       - template: pre-upgrade-hook.yaml
         equal:
@@ -184,12 +141,6 @@ tests:
 
   - it: Should not create pre-upgrade hook job when migrations are completely disabled
     set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
       migrations:
         enabled: false
     asserts:
@@ -199,16 +150,20 @@ tests:
           apiVersion: batch/v1
           kind: Job
 
+  - it: Should not create pre-upgrade hook job when backgroundServices.runAsSeparateDeployment is false
+    set:
+      backgroundServices:
+        runAsSeparateDeployment: false
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        not: true
+        containsDocument:
+          apiVersion: batch/v1
+          kind: Job
+
   - it: Should use custom migration configuration when provided
     set:
-      postgresql:
-        enabled: true
-        auth:
-          password: testpass
-      sqlite:
-        enabled: false
       migrations:
-        enabled: true
         command: "custom-migration-command"
         entrypoint: ["/bin/bash", "-c"]
         timeoutSeconds: 600


### PR DESCRIPTION
### Summary

Ensures the database migration hook only runs when multi-server mode is enabled.

Closes #539 

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
