### PR TITLE
fix(server): correct imagePullSecrets format in pre-upgrade hook

### DIFF
--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -67,6 +67,8 @@ spec:
       {{- end }}
       {{- if .Values.global.prefect.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.global.prefect.image.pullSecrets | nindent 8 }}
+      {{- range .Values.global.prefect.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -218,3 +218,21 @@ tests:
         equal:
           path: .spec.template.spec.containers[0].securityContext.runAsUser
           value: 2000
+
+  - it: Should use correct imagePullSecrets format in pre-upgrade hook
+    set:
+      global:
+        prefect:
+          image:
+            pullSecrets:
+              - my-secret-1
+              - my-secret-2
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        equal:
+          path: .spec.template.spec.imagePullSecrets[0].name
+          value: my-secret-1
+      - template: pre-upgrade-hook.yaml
+        equal:
+          path: .spec.template.spec.imagePullSecrets[1].name
+          value: my-secret-2


### PR DESCRIPTION
### Summary

Fixes the imagePullSecrets templating issue in the pre-upgrade hook where Kubernetes was rejecting the Job with the error: "cannot unmarshal string into Go struct field PodSpec.spec.template.spec.imagePullSecrets".

The pre-upgrade hook template was incorrectly using `toYaml` to render `imagePullSecrets`, which expected values in the format `[{name: "secret"}]` but received `["secret"]` from the chart values. This has been corrected to use a range loop that properly formats each secret as `- name: {{ . }}`, matching the format used in other deployment templates.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

Closes #541

🤖 Generated with [Claude Code](https://claude.ai/code)