### PR TITLE
chore(CI): bump Kubernetes versions in tests

### DIFF
--- a/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
+++ b/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         kubernetes:
-          - "1.26.0"
-          - "1.27.0"
-          - "1.28.0"
-          - "1.29.0"
+          - "1.31.0"
+          - "1.32.0"
+          - "1.33.0"
+          - "1.34.0"
       fail-fast: false
 
     steps:

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         kubernetes:
-          - "1.26.0"
-          - "1.27.0"
-          - "1.28.0"
-          - "1.29.0"
+          - "1.31.0"
+          - "1.32.0"
+          - "1.33.0"
+          - "1.34.0"
       fail-fast: false
 
     steps:

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         kubernetes:
-          - "1.26.0"
-          - "1.27.0"
-          - "1.28.0"
-          - "1.29.0"
+          - "1.31.0"
+          - "1.32.0"
+          - "1.33.0"
+          - "1.34.0"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
### Summary

Bumps the Kubernetes versions to match the currently-supported versions: https://endoflife.date/kubernetes

Related to https://linear.app/prefect/issue/PLA-2034/cycle-1-catch-all

Note that because of the use of `pull_request_target`, this won't pick up the changes until they're merged to `main`. I tested manually on K8s 1.33.4 as the latest available in Rancher Desktop at the time of this writing and it passed.

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
