### PR TITLE
feat(exporter): more flexible configuration of env vars on deployment

### DIFF
--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -95,6 +95,7 @@ basicAuth:
 | basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | csrfAuth | bool | `false` | Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled) |
 | env | object | `{}` | Environment variables to configure application |
+| extraEnvVars | list | `[]` | List of advanced environment variable configs to add to exporter pods |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.1.0"}` | Image registry |
 | imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -95,6 +95,9 @@ spec:
             value: {{ .Values.basicAuth.authString | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/prometheus-prefect-exporter/tests/exporter_test.yaml
+++ b/charts/prometheus-prefect-exporter/tests/exporter_test.yaml
@@ -144,6 +144,24 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "CUSTOM_ENV")].value
           value: custom_value
 
+  - it: Should set advanced custom environment variables
+    set:
+      extraEnvVars:
+        - name: CUSTOM_ENV
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: my-secret-key
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "CUSTOM_ENV")].valueFrom.secretKeyRef.name
+          value: my-secret
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "CUSTOM_ENV")].valueFrom.secretKeyRef.key
+          value: my-secret-key
+
   - it: Should set the correct pod security context
     set:
       podSecurityContext:

--- a/charts/prometheus-prefect-exporter/values.schema.json
+++ b/charts/prometheus-prefect-exporter/values.schema.json
@@ -126,6 +126,11 @@
       "title": "Environment Variables",
       "description": "Environment variables"
     },
+    "extraEnvVars": {
+      "type": "array",
+      "title": "Extra Env Vars",
+      "description": "Extra environment variables to add to exporter deployment pods"
+    },
     "podDisruptionBudget": {
       "type": "object",
       "title": "Pod Disruption Budget",

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -55,6 +55,9 @@ env: {}
   # foo: bar
   # my_env: my_value
 
+# -- array with extra environment variables to add to exporter deployment pods
+extraEnvVars: []
+
 # -- Limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions
 podDisruptionBudget: {}
   # maxUnavailable: 0


### PR DESCRIPTION
### Summary

I have a use case to add an env var from a secret, but the current chart does not allow me to do so easily, hence I'm using the current mechanism that is available on prefect-worker charts to allow myself to do the same on the exporter charts.

I noticed that there is already an `env` variable, but it is insufficient for me to work with secrets. I left the existing logic in place to avoid a breaking change here

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
