### PR TITLE
feat(worker): allow observer namespace override for running jobs in separate namespaces

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -361,6 +361,7 @@ worker:
 | worker.config.baseJobTemplate.existingConfigMapName | string | `""` | the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json' |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
 | worker.config.installPolicy | string | `"prompt"` | install policy to use workers from Prefect integration packages. |
+| worker.config.jobNamespace | string | `nil` | overrides namespaces where jobs are created on. |
 | worker.config.limit | string | `nil` | maximum number of flow runs to start simultaneously (default: unlimited) |
 | worker.config.name | string | `nil` | the name to give to the started worker. If not provided, a unique name will be generated. |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -229,7 +229,11 @@ spec:
             - name: PREFECT_KUBERNETES_CLUSTER_UID
               value: {{ template "worker.clusterUUID" . }}
             - name: PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES
+              {{- if .Values.worker.config.jobNamespace }}
+              value: {{ .Values.worker.config.jobNamespace }}
+              {{- else }}
               value: {{ include "common.names.namespace" . | quote }}
+              {{- end }}
             {{- if eq .Values.worker.apiConfig "cloud" }}
             - name: PREFECT_API_KEY
               valueFrom:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -760,6 +760,18 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")].value
           value: my-namespace
 
+  - it: Should set Kubernetes worker observer namespaces with job override
+    set:
+      namespaceOverride: my-namespace
+      worker:
+        config:
+          jobNamespace: job-namespace
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")].value
+          value: job-namespace
+
   - it: Should set auth string secret environment variables when existingSecret is provided
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -284,6 +284,11 @@
               "title": "Type",
               "description": "the type of worker to start i.e kubernetes"
             },
+            "jobNamespace": {
+              "type": ["string", "null"],
+              "title": "Job Namespace",
+              "description": "the namespace where the jobs would spawn. If unset, spawns in the same namespace as the worker controller. Requires role.namespace to be set with the same value."
+            },
             "baseJobTemplate": {
               "type": "object",
               "title": "Base Job Template",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -117,6 +117,8 @@ worker:
     name: null
     # -- maximum number of flow runs to start simultaneously (default: unlimited)
     limit: null
+    # -- the namespace where the jobs would spawn. If unset, spawns in the same namespace as the worker controller. Requires role.namespace to be set with the same value.
+    jobNamespace: null
 
     ##  If unspecified, Prefect will use the default base job template for the given worker type. If the work pool already exists, this will be ignored.
     ## e.g.:


### PR DESCRIPTION
### Summary

In the usecases where we would like jobs to be spun up in a insolated namespace from the worker controller, we find that the 
'PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES' directly interferes with the worker controller and tries to spin up jobs within the same namespace, even if we configured an override within prefect.yaml in our prefect deployment repo.

I found that modifying this has allowed the jobs to be spun up without issues, otherwise it would give permission errors with the SA/Role not having permissions within the same namespace.

I'm proposing having a new config to override that specific env var

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
