### PR TITLE
fix(pr ci): set Acceptance Tests (External) environment for server and worker lint and test workflows

### DIFF
--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   lint_test:
+    environment: ${{
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'Acceptance Tests (External)' || '' }}
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   lint_test:
+    environment: ${{
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'Acceptance Tests (External)' || '' }}
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Summary

To help avoid external bad actors from running arbitrary code in our CI jobs, we are adding a github `environment` which will require approval from a Platform engineer prior to these actions running when the PR is coming from a forked repository.

Related to: https://linear.app/prefect/issue/PLA-2076/validate-potential-remote-code-execution-bug-in-github-actions

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
