### PR TITLE
feat(worker): add PodDisruptionBudget

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -361,7 +361,7 @@ worker:
 | worker.config.baseJobTemplate.existingConfigMapName | string | `""` | the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json' |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
 | worker.config.installPolicy | string | `"prompt"` | install policy to use workers from Prefect integration packages. |
-| worker.config.jobNamespace | string | `nil` | overrides namespaces where jobs are created on. |
+| worker.config.jobNamespace | string | `nil` | the namespace where the jobs would spawn. If unset, spawns in the same namespace as the worker controller. Requires role.namespace to be set with the same value. |
 | worker.config.limit | string | `nil` | maximum number of flow runs to start simultaneously (default: unlimited) |
 | worker.config.name | string | `nil` | the name to give to the started worker. If not provided, a unique name will be generated. |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |
@@ -408,6 +408,7 @@ worker:
 | worker.livenessProbe.enabled | bool | `false` |  |
 | worker.nodeSelector | object | `{}` | node labels for worker pods assignment |
 | worker.podAnnotations | object | `{}` | extra annotations for worker pod |
+| worker.podDisruptionBudget | object | `{}` | Limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions |
 | worker.podLabels | object | `{}` | extra labels for worker pod |
 | worker.podSecurityContext.fsGroup | int | `1001` | set worker pod's security context fsGroup, set to `null` to unset |
 | worker.podSecurityContext.runAsNonRoot | bool | `true` | set worker pod's security context runAsNonRoot |

--- a/charts/prefect-worker/templates/pdb.yaml
+++ b/charts/prefect-worker/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.worker.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+    prefect-version: {{ .Chart.AppVersion }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+{{ toYaml .Values.worker.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -870,3 +870,100 @@ tests:
         equal:
           path: .metadata.namespace
           value: my-namespace
+
+  - it: Should not create PDB by default
+    asserts:
+      - template: pdb.yaml
+        hasDocuments:
+          count: 0
+
+  - it: Should create PDB with maxUnavailable
+    set:
+      worker:
+        podDisruptionBudget:
+          maxUnavailable: 1
+    asserts:
+      - template: pdb.yaml
+        hasDocuments:
+          count: 1
+      - template: pdb.yaml
+        equal:
+          path: .apiVersion
+          value: policy/v1
+      - template: pdb.yaml
+        equal:
+          path: .kind
+          value: PodDisruptionBudget
+      - template: pdb.yaml
+        equal:
+          path: .metadata.name
+          value: prefect-worker
+      - template: pdb.yaml
+        equal:
+          path: .metadata.namespace
+          value: prefect
+      - template: pdb.yaml
+        equal:
+          path: .spec.maxUnavailable
+          value: 1
+      - template: pdb.yaml
+        isSubset:
+          path: .spec.selector.matchLabels
+          content:
+            app.kubernetes.io/component: worker
+
+  - it: Should create PDB with minAvailable
+    set:
+      worker:
+        podDisruptionBudget:
+          minAvailable: 1
+    asserts:
+      - template: pdb.yaml
+        hasDocuments:
+          count: 1
+      - template: pdb.yaml
+        equal:
+          path: .spec.minAvailable
+          value: 1
+
+  - it: Should create PDB with unhealthyPodEvictionPolicy
+    set:
+      worker:
+        podDisruptionBudget:
+          maxUnavailable: 1
+          unhealthyPodEvictionPolicy: AlwaysAllow
+    asserts:
+      - template: pdb.yaml
+        equal:
+          path: .spec.maxUnavailable
+          value: 1
+      - template: pdb.yaml
+        equal:
+          path: .spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow
+
+  - it: Should include common labels in PDB
+    set:
+      commonLabels:
+        my-label: my-value
+      worker:
+        podDisruptionBudget:
+          maxUnavailable: 1
+    asserts:
+      - template: pdb.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+
+  - it: Should include common annotations in PDB
+    set:
+      commonAnnotations:
+        my-annotation: my-value
+      worker:
+        podDisruptionBudget:
+          maxUnavailable: 1
+    asserts:
+      - template: pdb.yaml
+        equal:
+          path: .metadata.annotations.my-annotation
+          value: my-value

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -812,6 +812,11 @@
               "description": "a list of DNS resolver options"
             }
           }
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "title": "Pod Disruption Budget",
+          "description": "Limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions"
         }
       }
     },

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -317,6 +317,11 @@ worker:
   # -- array with extra Arguments for the worker container to start with
   extraArgs: []
 
+  # -- Limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 1
+
 ## ServiceAccount configuration
 serviceAccount:
   # -- specifies whether a ServiceAccount should be created

--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -95,7 +95,7 @@ basicAuth:
 | basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
 | csrfAuth | bool | `false` | Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled) |
 | env | object | `{}` | Environment variables to configure application |
-| extraEnvVars | list | `[]` | List of advanced environment variable configs to add to exporter pods |
+| extraEnvVars | list | `[]` | array with extra environment variables to add to exporter deployment pods |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"prefecthq/prometheus-prefect-exporter","tag":"1.1.0"}` | Image registry |
 | imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |


### PR DESCRIPTION
### Summary

Adds Pod Disruption Budget support to the Prefect Worker Helm chart to help maintain availability during voluntary disruptions like node maintenance or cluster upgrades.

The implementation follows the same pattern as the existing PDB in the prometheus-prefect-exporter chart. The PDB is disabled by default and can be enabled by setting `worker.podDisruptionBudget` with fields like `maxUnavailable` or `minAvailable`.

Changes:
- New `pdb.yaml` template with conditional rendering based on `worker.podDisruptionBudget`
- Configuration added to `values.yaml` (empty by default for backwards compatibility)
- Schema validation in `values.schema.json`
- Test coverage for various PDB configurations

All tests pass and the chart lints successfully.

Closes #559

Closes PLA-2084

Related:
- Linear issue: PLA-2084
- [Kubernetes PDB documentation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review