### PR TITLE
fix(prefect-worker,prefect-server): omit replica in deployment spec if autoscale is enabled

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -345,17 +345,16 @@ the HorizontalPodAutoscaler.
 | gateway.infrastructure | object | `{}` | infrastructure configuration for Gateway ref: https://gateway-api.sigs.k8s.io/guides/infrastructure/ |
 | gateway.labels | object | `{}` | additional labels for the Gateway resource |
 | gateway.listeners | list | `[{"hostname":"","name":"http","port":80,"protocol":"HTTP"},{"hostname":"","name":"https","port":443,"protocol":"HTTPS","tls":{"certificateRefs":[{"kind":"Secret","name":"","namespace":""}],"mode":"Terminate"}}]` | Gateway listeners configuration |
+| gateway.listeners[0] | object | `{"hostname":"","name":"http","port":80,"protocol":"HTTP"}` | listener name |
 | gateway.listeners[0].hostname | string | `""` | hostname pattern for this listener (e.g., "*.example.com") |
-| gateway.listeners[0].name | string | `"http"` | listener name |
 | gateway.listeners[0].port | int | `80` | listener port |
 | gateway.listeners[0].protocol | string | `"HTTP"` | listener protocol (HTTP, HTTPS, TCP, TLS) |
 | gateway.listeners[1].hostname | string | `""` | hostname pattern for this listener |
-| gateway.listeners[1].name | string | `"https"` | listener name |
 | gateway.listeners[1].port | int | `443` | listener port |
 | gateway.listeners[1].protocol | string | `"HTTPS"` | listener protocol |
 | gateway.listeners[1].tls | object | `{"certificateRefs":[{"kind":"Secret","name":"","namespace":""}],"mode":"Terminate"}` | TLS configuration for HTTPS listener |
 | gateway.listeners[1].tls.certificateRefs | list | `[{"kind":"Secret","name":"","namespace":""}]` | certificate references (Secrets containing TLS cert/key) |
-| gateway.listeners[1].tls.certificateRefs[0].kind | string | `"Secret"` | kind of resource (usually Secret) |
+| gateway.listeners[1].tls.certificateRefs[0] | object | `{"kind":"Secret","name":"","namespace":""}` | kind of resource (usually Secret) |
 | gateway.listeners[1].tls.certificateRefs[0].name | string | `""` | name of the Secret (defaults to ingress pattern if not set) |
 | gateway.listeners[1].tls.certificateRefs[0].namespace | string | `""` | namespace of the Secret (optional, defaults to same namespace) |
 | gateway.listeners[1].tls.mode | string | `"Terminate"` | TLS mode (Terminate or Passthrough) |
@@ -372,7 +371,7 @@ the HorizontalPodAutoscaler.
 | httproute.labels | object | `{}` | additional labels for the HTTPRoute resource |
 | httproute.name | string | `""` | HTTPRoute resource name (defaults to chart fullname if not set) |
 | httproute.parentRefs | list | `[{"name":"","namespace":"","port":null,"sectionName":"https"}]` | parent Gateway references |
-| httproute.parentRefs[0].name | string | `""` | name of the Gateway to attach to (defaults to gateway.name) |
+| httproute.parentRefs[0] | object | `{"name":"","namespace":"","port":null,"sectionName":"https"}` | name of the Gateway to attach to (defaults to gateway.name) |
 | httproute.parentRefs[0].namespace | string | `""` | namespace of the Gateway (optional) |
 | httproute.parentRefs[0].port | string | `nil` | port number (optional) |
 | httproute.parentRefs[0].sectionName | string | `"https"` | specific listener name to attach to (optional, defaults to "https") |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -474,7 +474,7 @@ the HorizontalPodAutoscaler.
 | server.readinessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | server.readinessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
 | server.readinessProbe.enabled | bool | `false` |  |
-| server.replicaCount | int | `1` | number of server replicas to deploy |
+| server.replicaCount | int | `1` | number of server replicas to deploy, ignored if autoscaling is enabled |
 | server.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the server container |
 | server.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the server container |
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -14,7 +14,9 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.server.revisionHistoryLimit }}
+  {{- if not .Values.server.autoscaling.enabled }}
   replicas: {{ .Values.sqlite.enabled | ternary 1 .Values.server.replicaCount }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -675,6 +675,30 @@ tests:
           path: .spec.metrics[1].resource.target.averageUtilization
           value: 80
 
+  - it: Should omit replicas field from deployment when autoscaling is enabled
+    set:
+      server:
+        autoscaling:
+          enabled: true
+          minReplicas: 2
+          maxReplicas: 5
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.replicas
+
+  - it: Should include replicas field in deployment when autoscaling is disabled
+    set:
+      server:
+        autoscaling:
+          enabled: false
+        replicaCount: 3
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.replicas
+          value: 3
+
   - it: Should configure custom entrypoint and args
     set:
       server:

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -101,6 +101,7 @@ server:
     # -- target Memory utilization percentage
     targetMemory: 80
 
+  # if autoscaling is enabled, this value is ignored
   # -- number of server replicas to deploy
   replicaCount: 1
 
@@ -551,16 +552,16 @@ gateway:
 
   # -- Gateway listeners configuration
   listeners:
-    - # -- listener name
-      name: http
+      # -- listener name
+    - name: http
       # -- listener port
       port: 80
       # -- listener protocol (HTTP, HTTPS, TCP, TLS)
       protocol: HTTP
       # -- hostname pattern for this listener (e.g., "*.example.com")
       hostname: ""
-    - # -- listener name
-      name: https
+      # -- listener name
+    - name: https
       # -- listener port
       port: 443
       # -- listener protocol
@@ -573,8 +574,8 @@ gateway:
         mode: Terminate
         # -- certificate references (Secrets containing TLS cert/key)
         certificateRefs:
-          - # -- kind of resource (usually Secret)
-            kind: Secret
+            # -- kind of resource (usually Secret)
+          - kind: Secret
             # -- name of the Secret (defaults to ingress pattern if not set)
             name: ""
             # -- namespace of the Secret (optional, defaults to same namespace)
@@ -607,8 +608,8 @@ httproute:
 
   # -- parent Gateway references
   parentRefs:
-    - # -- name of the Gateway to attach to (defaults to gateway.name)
-      name: ""
+      # -- name of the Gateway to attach to (defaults to gateway.name)
+    - name: ""
       # -- namespace of the Gateway (optional)
       namespace: ""
       # -- specific listener name to attach to (optional, defaults to "https")

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -101,8 +101,7 @@ server:
     # -- target Memory utilization percentage
     targetMemory: 80
 
-  # if autoscaling is enabled, this value is ignored
-  # -- number of server replicas to deploy
+  # -- number of server replicas to deploy, ignored if autoscaling is enabled
   replicaCount: 1
 
   # requests MUST be specified if using an HPA, otherwise the HPA will not know when to trigger a scale event

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -415,7 +415,7 @@ worker:
 | worker.podSecurityContext.runAsUser | int | `1001` | set worker pod's security context runAsUser, set to `null` to unset |
 | worker.podSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | set worker pod's seccomp profile |
 | worker.priorityClassName | string | `""` | priority class name to use for the worker pods; if the priority class is empty or doesn't exist, the worker pods are scheduled without a priority class |
-| worker.replicaCount | int | `1` | number of worker replicas to deploy |
+| worker.replicaCount | int | `1` | number of worker replicas to deploy, ignored if autoscaling is enabled |
 | worker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | the requested limits for the worker container |
 | worker.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | the requested resources for the worker container |
 | worker.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -14,7 +14,9 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.worker.revisionHistoryLimit }}
+  {{- if not .Values.worker.autoscaling.enabled }}
   replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: worker

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -239,15 +239,41 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_API_KEY")].valueFrom.secretKeyRef.key
           value: api-key
 
-  - it: Should set the correct replica count
+  - it: Should set the correct replica count when autoscaling is disabled
     set:
       worker:
         replicaCount: 3
+        autoscaling:
+          enabled: false
     asserts:
       - template: deployment.yaml
         equal:
           path: .spec.replicas
           value: 3
+
+  - it: Should omit replicas field from deployment when autoscaling is enabled
+    set:
+      worker:
+        autoscaling:
+          enabled: true
+          minReplicas: 2
+          maxReplicas: 5
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.replicas
+
+  - it: Should include replicas field in deployment when autoscaling is disabled
+    set:
+      worker:
+        autoscaling:
+          enabled: false
+        replicaCount: 4
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.replicas
+          value: 4
 
   - it: Should set the correct resource requests and limits
     set:

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -198,6 +198,7 @@ worker:
   # -- the number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10
 
+  # if autoscaling is enabled, this value is ignored
   # -- number of worker replicas to deploy
   replicaCount: 1
 

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -198,8 +198,7 @@ worker:
   # -- the number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10
 
-  # if autoscaling is enabled, this value is ignored
-  # -- number of worker replicas to deploy
+  # -- number of worker replicas to deploy, ignored if autoscaling is enabled
   replicaCount: 1
 
   resources:


### PR DESCRIPTION
### Summary

The presence of `.spec.replica` in `Deployment` causes issues with autoscaling when HPA is configured and applied via a Deployment Controller.

Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling

> When an HPA is enabled, it is recommended that the value of spec.replicas of the Deployment and / or StatefulSet be removed from their [manifest(s)](https://kubernetes.io/docs/reference/glossary/?all=true#term-manifest). If this isn't done, any time a change to that object is applied, for example via kubectl apply -f deployment.yaml, this will instruct Kubernetes to scale the current number of Pods to the value of the spec.replicas key. This may not be desired and could be troublesome when an HPA is active, resulting in thrashing or flapping behavior

Also updates some failing `charttest` linting rules.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
