### PR TITLE
fix: adjust helm-docs comment alignment

### DIFF
--- a/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
+++ b/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -29,15 +29,15 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/linters/server-ct.yaml

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -345,17 +345,16 @@ the HorizontalPodAutoscaler.
 | gateway.infrastructure | object | `{}` | infrastructure configuration for Gateway ref: https://gateway-api.sigs.k8s.io/guides/infrastructure/ |
 | gateway.labels | object | `{}` | additional labels for the Gateway resource |
 | gateway.listeners | list | `[{"hostname":"","name":"http","port":80,"protocol":"HTTP"},{"hostname":"","name":"https","port":443,"protocol":"HTTPS","tls":{"certificateRefs":[{"kind":"Secret","name":"","namespace":""}],"mode":"Terminate"}}]` | Gateway listeners configuration |
+| gateway.listeners[0] | object | `{"hostname":"","name":"http","port":80,"protocol":"HTTP"}` | listener name |
 | gateway.listeners[0].hostname | string | `""` | hostname pattern for this listener (e.g., "*.example.com") |
-| gateway.listeners[0].name | string | `"http"` | listener name |
 | gateway.listeners[0].port | int | `80` | listener port |
 | gateway.listeners[0].protocol | string | `"HTTP"` | listener protocol (HTTP, HTTPS, TCP, TLS) |
 | gateway.listeners[1].hostname | string | `""` | hostname pattern for this listener |
-| gateway.listeners[1].name | string | `"https"` | listener name |
 | gateway.listeners[1].port | int | `443` | listener port |
 | gateway.listeners[1].protocol | string | `"HTTPS"` | listener protocol |
 | gateway.listeners[1].tls | object | `{"certificateRefs":[{"kind":"Secret","name":"","namespace":""}],"mode":"Terminate"}` | TLS configuration for HTTPS listener |
 | gateway.listeners[1].tls.certificateRefs | list | `[{"kind":"Secret","name":"","namespace":""}]` | certificate references (Secrets containing TLS cert/key) |
-| gateway.listeners[1].tls.certificateRefs[0].kind | string | `"Secret"` | kind of resource (usually Secret) |
+| gateway.listeners[1].tls.certificateRefs[0] | object | `{"kind":"Secret","name":"","namespace":""}` | kind of resource (usually Secret) |
 | gateway.listeners[1].tls.certificateRefs[0].name | string | `""` | name of the Secret (defaults to ingress pattern if not set) |
 | gateway.listeners[1].tls.certificateRefs[0].namespace | string | `""` | namespace of the Secret (optional, defaults to same namespace) |
 | gateway.listeners[1].tls.mode | string | `"Terminate"` | TLS mode (Terminate or Passthrough) |
@@ -372,7 +371,7 @@ the HorizontalPodAutoscaler.
 | httproute.labels | object | `{}` | additional labels for the HTTPRoute resource |
 | httproute.name | string | `""` | HTTPRoute resource name (defaults to chart fullname if not set) |
 | httproute.parentRefs | list | `[{"name":"","namespace":"","port":null,"sectionName":"https"}]` | parent Gateway references |
-| httproute.parentRefs[0].name | string | `""` | name of the Gateway to attach to (defaults to gateway.name) |
+| httproute.parentRefs[0] | object | `{"name":"","namespace":"","port":null,"sectionName":"https"}` | name of the Gateway to attach to (defaults to gateway.name) |
 | httproute.parentRefs[0].namespace | string | `""` | namespace of the Gateway (optional) |
 | httproute.parentRefs[0].port | string | `nil` | port number (optional) |
 | httproute.parentRefs[0].sectionName | string | `"https"` | specific listener name to attach to (optional, defaults to "https") |

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -551,16 +551,16 @@ gateway:
 
   # -- Gateway listeners configuration
   listeners:
-    - # -- listener name
-      name: http
+      # -- listener name
+    - name: http
       # -- listener port
       port: 80
       # -- listener protocol (HTTP, HTTPS, TCP, TLS)
       protocol: HTTP
       # -- hostname pattern for this listener (e.g., "*.example.com")
       hostname: ""
-    - # -- listener name
-      name: https
+      # -- listener name
+    - name: https
       # -- listener port
       port: 443
       # -- listener protocol
@@ -573,8 +573,8 @@ gateway:
         mode: Terminate
         # -- certificate references (Secrets containing TLS cert/key)
         certificateRefs:
-          - # -- kind of resource (usually Secret)
-            kind: Secret
+            # -- kind of resource (usually Secret)
+          - kind: Secret
             # -- name of the Secret (defaults to ingress pattern if not set)
             name: ""
             # -- namespace of the Secret (optional, defaults to same namespace)
@@ -607,8 +607,8 @@ httproute:
 
   # -- parent Gateway references
   parentRefs:
-    - # -- name of the Gateway to attach to (defaults to gateway.name)
-      name: ""
+      # -- name of the Gateway to attach to (defaults to gateway.name)
+    - name: ""
       # -- namespace of the Gateway (optional)
       namespace: ""
       # -- specific listener name to attach to (optional, defaults to "https")


### PR DESCRIPTION
Fixes the helm-docs comments alignment, which was causing errors in the server linting.

Closes https://linear.app/prefect/issue/PLA-2201/fix-helm-docs-comment-alignment-and-pull-request-target-checkout

Looks like this was introduced in https://github.com/PrefectHQ/prefect-helm/pull/565, but the CI job was configured to check out `main` due to the use of `pull_request_target`. So we noticed the failures in a future PR, https://github.com/PrefectHQ/prefect-helm/pull/570.

Note that CI will still fail in this PR because the CI changes won't take effect until they're merged to `main` due to the use of `pull_request_target`. Testing locally:

```
$ ./scripts/helm_charttest.sh
Linting charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 prefect-worker => (version: "0.0.0", path: "charts/prefect-worker")
------------------------------------------------------------------------------------------------------------------------

... etc ...

------------------------------------------------------------------------------------------------------------------------
 ✔︎ prefect-worker => (version: "0.0.0", path: "charts/prefect-worker")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
Linting charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 prefect-server => (version: "0.0.0", path: "charts/prefect-server")
------------------------------------------------------------------------------------------------------------------------

... etc ...

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ prefect-server => (version: "0.0.0", path: "charts/prefect-server")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully

~/code/github.com/prefecthq/prefect-helm/fix-yaml-comment-spacing on  fix-yaml-comment-spacing took 23s
$ echo $?
0
```

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
