### PR TITLE
feature: #572 Allow to customize service port name.

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -487,6 +487,7 @@ the HorizontalPodAutoscaler.
 | service.externalTrafficPolicy | string | `"Cluster"` | service external traffic policy |
 | service.extraPorts | list | `[]` |  |
 | service.nodePort | string | `""` | service port if defining service as type nodeport |
+| service.portName | string | `"server-svc-port"` | service port name |
 | service.port | int | `4200` | service port |
 | service.targetPort | int | `4200` | target port of the server pod; also sets PREFECT_SERVER_API_PORT |
 | service.type | string | `"ClusterIP"` | service type |

--- a/charts/prefect-server/templates/service.yaml
+++ b/charts/prefect-server/templates/service.yaml
@@ -27,7 +27,7 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
-    - name: server-svc-port
+    - name: {{ .Values.service.portName }}
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: {{ .Values.service.targetPort }}

--- a/charts/prefect-server/tests/service_test.yaml
+++ b/charts/prefect-server/tests/service_test.yaml
@@ -1,0 +1,23 @@
+---
+suite: Service API Configuration
+release:
+  name: service-test
+  namespace: prefect
+
+tests:
+  - it: Service default port name is server-svc-port
+    asserts:
+      - template: service.yaml
+        equal:
+          path: spec.ports[0].name
+          value: "server-svc-port"
+
+  - it: Service port name is the customized one
+    set:
+      service:
+        portName: my-custom-port-name
+    asserts:
+      - template: service.yaml
+        equal:
+          path: spec.ports[0].name
+          value: "my-custom-port-name"

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -1232,6 +1232,11 @@
           "title": "Type",
           "description": "service type"
         },
+        "portName": {
+          "type": "string",
+          "title": "Port name",
+          "description": "service port name"
+        },
         "port": {
           "type": [
             "integer",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -428,6 +428,8 @@ serviceAccount:
 
 ## Service configuration
 service:
+  # -- servive port name
+  portName: server-svc-port
   # -- service port
   port: 4200
   # -- target port of the server pod; also sets PREFECT_SERVER_API_PORT

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -428,7 +428,7 @@ serviceAccount:
 
 ## Service configuration
 service:
-  # -- servive port name
+  # -- service port name
   portName: server-svc-port
   # -- service port
   port: 4200


### PR DESCRIPTION
### Summary

Allow to customise service port name.
In some cases, an organisation will enforce a naming convention for service ports, rendering the Chart unusable.
Allowing to change this name shouldn't cause any issues and will help in those edge cases.

Closes #572 

### Requirements

- [X] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [X] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [X] Body includes `Closes <issue>`, if available
- [X] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in templates/NOTES.txt
- [ ] Relevant labels are added
- [X] `Draft` status is used until ready for review
