### PR TITLE
feat(prefect-server): add replicaCount for backgroundServices

### DIFF
--- a/charts/prefect-server/templates/background-services/deployment.yaml
+++ b/charts/prefect-server/templates/background-services/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.backgroundServices.revisionHistoryLimit }}
-  replicas: 1
+  replicas: {{ .Values.backgroundServices.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: background-services

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -14,6 +14,23 @@ set:
     enabled: true
 
 tests:
+  - it: Should default to 1 replica
+    asserts:
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.replicas
+          value: 1
+
+  - it: Should set custom replica count
+    set:
+      backgroundServices:
+        replicaCount: 3
+    asserts:
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.replicas
+          value: 3
+
   - it: Should set the correct image
     asserts:
       - template: background-services/deployment.yaml

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -762,6 +762,11 @@
           "type": "boolean",
           "description": "Run background services (like scheduling) in a separate deployment"
         },
+        "replicaCount": {
+          "type": "integer",
+          "description": "number of background-services replicas to deploy",
+          "minimum": 1
+        },
         "priorityClassName": {
           "type": "string",
           "description": "priority class name to use for the background-services pods"

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -279,6 +279,9 @@ backgroundServices:
   # - Run background services (like scheduling) in a separate deployment.
   runAsSeparateDeployment: false
 
+  # -- number of background-services replicas to deploy
+  replicaCount: 1
+
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   # -- priority class name to use for the background-services pods; if the priority class is empty or doesn't exist, the background-services pods are scheduled without a priority class
   priorityClassName: ""


### PR DESCRIPTION
## Summary
Adds the ability to configure the number of replicas for the background services deployment via `backgroundServices.replicaCount`.

## Why this is safe now

Previously, background services were hardcoded to 1 replica because the loop services (scheduler, foreman, late runs handler, etc.) were not designed for horizontal scaling - running multiple instances would cause duplicate work or race conditions.

As of Prefect 3.6.6, background services have been migrated to use **docket** (https://github.com/PrefectHQ/docket), a distributed task queue that uses Redis for coordination. The key changes that enable horizontal scaling:

1. **Distributed locking via Redis**: Docket uses Redis to ensure that perpetual tasks (like the scheduler) only run on one worker at a time, even when multiple replicas are running
2. **`Perpetual` dependency**: Services are decorated with `@perpetual_service` and use `Perpetual` dependencies that handle distributed scheduling - tasks are automatically rescheduled after completion with leader election
3. **Redis-based messaging**: The `backgroundServices.runAsSeparateDeployment` feature already requires Redis for pub/sub messaging between the API server and background services

With these architectural changes, multiple background service replicas can safely run concurrently - docket's Redis-based coordination prevents duplicate execution of scheduled tasks.

## Changes
- Added `backgroundServices.replicaCount` to values.yaml (default: 1)
- Added `replicaCount` to values.schema.json  
- Updated deployment template to use the value instead of hardcoded 1
- Added tests for default and custom replica count

## Usage
```yaml
backgroundServices:
  runAsSeparateDeployment: true
  replicaCount: 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)