### PR TITLE
chore: remove downstream workflow trigger for helm chart version updates

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,14 +4,13 @@ name: Release Prefect Server and Worker Helm Charts
 "on":
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  # GitHub considers creating releases and uploading assets as writing contents.
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      # GitHub considers creating releases and uploading assets as writing contents.
-      contents: write
     outputs:
       releaseVersion: ${{ steps.output_version.outputs.releaseVersion }}
     steps:
@@ -129,17 +128,3 @@ jobs:
             [$PREFECT_VERSION](https://github.com/PrefectHQ/prefect/releases/tag/$PREFECT_VERSION)"
         env:
           GH_TOKEN: ${{ github.token }}
-
-  update_helm_chart_worker_version_downstream:
-    name: Update Helm Chart Worker version in `cluster-deployment`
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run workflow
-        run: |
-          gh workflow run update-prefect-helm-chart-version.yaml \
-            --repo prefecthq/cluster-deployment \
-            --ref main \
-            -f chart_version=${{ needs.release.outputs.releaseVersion }} \
-        env:
-          GH_TOKEN: ${{ secrets.CLUSTER_DEPLOYMENT_ACTIONS_RW }}

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -4,14 +4,13 @@ name: Run Helm Unit Tests
 "on":
   pull_request: {}
 
-permissions: {}
+permissions:
+  # required to read from the repo
+  contents: read
 
 jobs:
   unittest:
     runs-on: ubuntu-latest
-    permissions:
-      # required to read from the repo
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/notify-on-failure.yaml
+++ b/.github/workflows/notify-on-failure.yaml
@@ -11,18 +11,17 @@ name: Notify on Failure
       - Update mise tool versions
     types: [completed]
 
-permissions: {}
+permissions:
+  # required to introspect the workflow run
+  actions: read
+  # required to read from the repo
+  contents: read
 
 jobs:
   notify:
     name: Notify on Failure
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    permissions:
-      # required to introspect the workflow run
-      actions: read
-      # required to read from the repo
-      contents: read
     steps:
       - name: Format date
         run: |

--- a/.github/workflows/prometheus-exporter-helm-release.yaml
+++ b/.github/workflows/prometheus-exporter-helm-release.yaml
@@ -4,14 +4,13 @@ name: Release Prometheus Prefect Exporter Helm Chart
 "on":
   workflow_dispatch: {}
 
-permissions: {}
+permissions:
+  # GitHub considers creating releases and uploading assets as writing contents.
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      # GitHub considers creating releases and uploading assets as writing contents.
-      contents: write
     outputs:
       releaseVersion: ${{ steps.output_version.outputs.releaseVersion }}
     steps:

--- a/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
+++ b/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
@@ -6,15 +6,14 @@ name: Lint and Test Prometheus Prefect Exporter Chart
     branches:
       - main
 
-permissions: {}
+permissions:
+  # required to read from the repo
+  contents: read
 
 jobs:
   lint_test:
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
-    permissions:
-      # required to read from the repo
-      contents: read
     strategy:
       matrix:
         kubernetes:

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -6,7 +6,9 @@ name: Lint and Test Prefect Server Chart
     branches:
       - main
 
-permissions: {}
+permissions:
+  # required to read from the repo
+  contents: read
 
 jobs:
   lint_test:
@@ -14,9 +16,6 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'Acceptance Tests (External)' || '' }}
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
-    permissions:
-      # required to read from the repo
-      contents: read
     strategy:
       matrix:
         kubernetes:

--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -6,17 +6,16 @@ name: Update mise tool versions
     - cron: 0 15 1 * *  # First of the month @ 3pm UTC
   workflow_dispatch: {}
 
-permissions: {}
+permissions:
+  # required to write to the repo
+  contents: write
+  # required to open a pr with changes
+  pull-requests: write
 
 jobs:
   update_mise_tools:
     if: github.repository == 'prefecthq/prefect-helm'
     runs-on: ubuntu-latest
-    permissions:
-      # required to write to the repo
-      contents: write
-      # required to open a pr with changes
-      pull-requests: write
     steps:
       - name: upgrade mise tools
         uses: prefecthq/actions-mise-upgrade@main

--- a/.github/workflows/updatecli-major-versions.yaml
+++ b/.github/workflows/updatecli-major-versions.yaml
@@ -6,17 +6,16 @@ name: Updatecli Major Dependency Updates
     - cron: 0 15 1 * *  # First of the month @ 3pm UTC
   workflow_dispatch: {}
 
-permissions: {}
+permissions:
+  # required to write to the repo
+  contents: write
+  # required to open a pr with updatecli changes
+  pull-requests: write
 
 jobs:
   updatecli_major:
     if: github.repository == 'prefecthq/prefect-helm'
     runs-on: ubuntu-latest
-    permissions:
-      # required to write to the repo
-      contents: write
-      # required to open a pr with updatecli changes
-      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/updatecli-minor-versions.yaml
+++ b/.github/workflows/updatecli-minor-versions.yaml
@@ -6,17 +6,16 @@ name: Updatecli Minor Dependency Updates
     - cron: 0 15 * * 1  # Monday @ 3pm UTC
   workflow_dispatch: {}
 
-permissions: {}
+permissions:
+  # required to write to the repo
+  contents: write
+  # required to open a pr with updatecli changes
+  pull-requests: write
 
 jobs:
   updatecli_minor:
     if: github.repository == 'prefecthq/prefect-helm'
     runs-on: ubuntu-latest
-    permissions:
-      # required to write to the repo
-      contents: write
-      # required to open a pr with updatecli changes
-      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/validate-updatecli-config.yaml
+++ b/.github/workflows/validate-updatecli-config.yaml
@@ -8,14 +8,13 @@ name: Validate Updatecli Config
     paths:
       - .github/updatecli/**
 
-permissions: {}
+permissions:
+  # required to read from the repo
+  contents: read
 
 jobs:
   validate_updatecli_configs:
     runs-on: ubuntu-latest
-    permissions:
-      # required to read from the repo
-      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -6,7 +6,9 @@ name: Lint and Test Prefect Worker Chart
     branches:
       - main
 
-permissions: {}
+permissions:
+  # required to read from the repo
+  contents: read
 
 jobs:
   lint_test:
@@ -14,9 +16,6 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'Acceptance Tests (External)' || '' }}
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
-    permissions:
-      # required to read from the repo
-      contents: read
     strategy:
       matrix:
         kubernetes:


### PR DESCRIPTION
We are handling this automation via updatecli now, removing the need for this workflow trigger

Also, move workflow permissions to the main level, since we only use a single job per workflow.

Relates to PLA-2241