### PR TITLE
fix(prefect-worker): correct jobNamespace parameter description

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -328,6 +328,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.podSecurityContext.runAsNonRoot | bool | `true` | set background-services pod's security context runAsNonRoot |
 | backgroundServices.podSecurityContext.runAsUser | int | `1001` | set background-services pod's security context runAsUser |
 | backgroundServices.priorityClassName | string | `""` | priority class name to use for the background-services pods; if the priority class is empty or doesn't exist, the background-services pods are scheduled without a priority class |
+| backgroundServices.replicaCount | int | `1` | number of background-services replicas to deploy |
 | backgroundServices.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the background-services container |
 | backgroundServices.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the background-services container |
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -361,7 +361,7 @@ worker:
 | worker.config.baseJobTemplate.existingConfigMapName | string | `""` | the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json' |
 | worker.config.http2 | bool | `true` | connect using HTTP/2 if the server supports it (experimental) |
 | worker.config.installPolicy | string | `"prompt"` | install policy to use workers from Prefect integration packages. |
-| worker.config.jobNamespace | string | `nil` | the namespace where the jobs would spawn. If unset, spawns in the same namespace as the worker controller. Requires role.namespace to be set with the same value. |
+| worker.config.jobNamespace | string | `nil` | the namespace(s) that the Kubernetes observer will watch for pod events and job crash detection. Accepts a comma-separated list (e.g., "default,namespace-2"). If unset, defaults to watching only the namespace where the worker is deployed. This does NOT control where worker jobs are deployed - job deployment namespace is configured via the work pool's base job template. |
 | worker.config.limit | string | `nil` | maximum number of flow runs to start simultaneously (default: unlimited) |
 | worker.config.name | string | `nil` | the name to give to the started worker. If not provided, a unique name will be generated. |
 | worker.config.prefetchSeconds | int | `10` | when querying for runs, how many seconds in the future can they be scheduled |

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -117,7 +117,7 @@ worker:
     name: null
     # -- maximum number of flow runs to start simultaneously (default: unlimited)
     limit: null
-    # -- the namespace where the jobs would spawn. If unset, spawns in the same namespace as the worker controller. Requires role.namespace to be set with the same value.
+    # -- the namespace(s) that the Kubernetes observer will watch for pod events and job crash detection. Accepts a comma-separated list (e.g., "default,namespace-2"). If unset, defaults to watching only the namespace where the worker is deployed. This does NOT control where worker jobs are deployed - job deployment namespace is configured via the work pool's base job template.
     jobNamespace: null
 
     ##  If unspecified, Prefect will use the default base job template for the given worker type. If the work pool already exists, this will be ignored.


### PR DESCRIPTION
## Summary

Corrects the documentation for the `worker.config.jobNamespace` parameter, which was incorrectly described as controlling where worker jobs are deployed.

The parameter actually configures `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES`, which tells the Kubernetes observer which namespace(s) to watch for pod events and job crash detection.

## Changes

- Updated `values.yaml` description to clarify the parameter configures observer namespace watching
- Updated `README.md` with the same corrected description
- Added guidance that job deployment namespace is configured via the work pool's base job template

Resolves #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)