### PR TITLE
feat: support cluster-wide `kopf` observer

### DIFF
--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -230,12 +230,14 @@ spec:
               value: {{ template "worker.apiUrl" . }}
             - name: PREFECT_KUBERNETES_CLUSTER_UID
               value: {{ template "worker.clusterUUID" . }}
+            {{- if not .Values.worker.config.observerClusterWide }}
             - name: PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES
               {{- if .Values.worker.config.jobNamespace }}
               value: {{ .Values.worker.config.jobNamespace }}
               {{- else }}
               value: {{ include "common.names.namespace" . | quote }}
               {{- end }}
+            {{- end }}
             {{- if eq .Values.worker.apiConfig "cloud" }}
             - name: PREFECT_API_KEY
               valueFrom:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -806,9 +806,6 @@ tests:
     asserts:
       - template: deployment.yaml
         notExists:
-          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_CLUSTER_WIDE")]
-      - template: deployment.yaml
-        notExists:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")]
 
   - it: Should set auth string secret environment variables when existingSecret is provided

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -798,6 +798,19 @@ tests:
           path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")].value
           value: job-namespace
 
+  - it: Should set Kubernetes worker observer cluster wide
+    set:
+      worker:
+        config:
+          observerClusterWide: true
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_CLUSTER_WIDE")]
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.containers[0].env[?(@.name == "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES")]
+
   - it: Should set auth string secret environment variables when existingSecret is provided
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -289,6 +289,11 @@
               "title": "Job Namespace",
               "description": "the namespace where the jobs would spawn. If unset, spawns in the same namespace as the worker controller. Requires role.namespace to be set with the same value."
             },
+            "observerClusterWide": {
+              "type": "boolean",
+              "title": "Observer Cluster Wide",
+              "description": "if true, the Kubernetes observer will watch for pod events and job crash detection across the entire cluster. If true, PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES will not be set."
+            },
             "baseJobTemplate": {
               "type": "object",
               "title": "Base Job Template",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -119,6 +119,8 @@ worker:
     limit: null
     # -- the namespace(s) that the Kubernetes observer will watch for pod events and job crash detection. Accepts a comma-separated list (e.g., "default,namespace-2"). If unset, defaults to watching only the namespace where the worker is deployed. This does NOT control where worker jobs are deployed - job deployment namespace is configured via the work pool's base job template.
     jobNamespace: null
+    # -- if true, the Kubernetes observer will watch for pod events and job crash detection across the entire cluster. If true, PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES will not be set.
+    observerClusterWide: false
 
     ##  If unspecified, Prefect will use the default base job template for the given worker type. If the work pool already exists, this will be ignored.
     ## e.g.:


### PR DESCRIPTION
### Summary

Add new `observerClusterWide` variable, which enables cluster wide kopf observer. It is already supported by worker code, but I didn't find how to remove `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES` env var with existing configuration, it is added unconditionally.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [ ] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
