### PR TITLE
feat(prefect-server): add appProtocol to service port

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -507,6 +507,7 @@ the HorizontalPodAutoscaler.
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | server.updateStrategy | object | `{"type":"RollingUpdate"}` | Specifies the strategy used to replace old Pods by new ones. Type can be "Recreate" or "RollingUpdate". Setting this to "Recreate" is useful when database is on a mounted volume that can only be attached to a single node at a time. |
 | service.annotations | object | `{}` | additional custom annotations for server service |
+| service.appProtocol | string | `"http"` | application protocol of the port |
 | service.clusterIP | string | `""` | service Cluster IP |
 | service.externalTrafficPolicy | string | `"Cluster"` | service external traffic policy |
 | service.extraPorts | list | `[]` |  |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -507,7 +507,7 @@ the HorizontalPodAutoscaler.
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |
 | server.updateStrategy | object | `{"type":"RollingUpdate"}` | Specifies the strategy used to replace old Pods by new ones. Type can be "Recreate" or "RollingUpdate". Setting this to "Recreate" is useful when database is on a mounted volume that can only be attached to a single node at a time. |
 | service.annotations | object | `{}` | additional custom annotations for server service |
-| service.appProtocol | string | `"http"` | application protocol of the port |
+| service.appProtocol | string | `""` | application protocol of the port (e.g. "http") |
 | service.clusterIP | string | `""` | service Cluster IP |
 | service.externalTrafficPolicy | string | `"Cluster"` | service external traffic policy |
 | service.extraPorts | list | `[]` |  |

--- a/charts/prefect-server/templates/service.yaml
+++ b/charts/prefect-server/templates/service.yaml
@@ -38,6 +38,9 @@ spec:
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: {{ .Values.service.targetPort }}
+      {{- if .Values.service.appProtocol }}
+      appProtocol: {{ .Values.service.appProtocol }}
+      {{- end }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}

--- a/charts/prefect-server/tests/service_test.yaml
+++ b/charts/prefect-server/tests/service_test.yaml
@@ -76,3 +76,19 @@ tests:
           value:
             - IPv6
             - IPv4
+
+  - it: appProtocol is not rendered by default
+    asserts:
+      - template: service.yaml
+        isNull:
+          path: spec.ports[0].appProtocol
+
+  - it: appProtocol is rendered when set
+    set:
+      service:
+        appProtocol: "http"
+    asserts:
+      - template: service.yaml
+        equal:
+          path: spec.ports[0].appProtocol
+          value: "http"

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -1276,6 +1276,10 @@
           "title": "Port",
           "description": "service port"
         },
+        "appProtocol": {
+          "type": "string",
+          "description": "application protocol of the port"
+        },
         "extraPorts": {
           "type": "array",
           "items": {

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -1278,7 +1278,8 @@
         },
         "appProtocol": {
           "type": "string",
-          "description": "application protocol of the port"
+          "description": "application protocol of the port",
+          "default": ""
         },
         "extraPorts": {
           "type": "array",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -451,6 +451,8 @@ service:
   port: 4200
   # -- target port of the server pod; also sets PREFECT_SERVER_API_PORT
   targetPort: 4200
+  # -- application protocol of the port
+  appProtocol: http
   # -- service port if defining service as type nodeport
   nodePort: ""
 

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -451,8 +451,8 @@ service:
   port: 4200
   # -- target port of the server pod; also sets PREFECT_SERVER_API_PORT
   targetPort: 4200
-  # -- application protocol of the port
-  appProtocol: http
+  # -- application protocol of the port (e.g. "http")
+  appProtocol: ""
   # -- service port if defining service as type nodeport
   nodePort: ""
 


### PR DESCRIPTION
### Summary

This is an optional field that sometimes enables additional capabilities by addons like Istio.

Docs: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol

I tried to make the usage optional in the template, not sure if this is correct actually.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [ ] Relevant labels are added
- [ ] `Draft` status is used until ready for review
