### PR TITLE
fix(server): set HOME and podSecuritycontext for migration job

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -408,6 +408,9 @@ the HorizontalPodAutoscaler.
 | migrations.extraVolumeMounts | list | `[]` | additional volume mounts for the migration job |
 | migrations.extraVolumes | list | `[]` | additional volumes for the migration job |
 | migrations.nodeSelector | object | `{}` | node labels for migration job pods assignment |
+| migrations.podSecurityContext.fsGroup | int | `1001` | set background-services pod's security context fsGroup |
+| migrations.podSecurityContext.runAsNonRoot | bool | `true` | set background-services pod's security context runAsNonRoot |
+| migrations.podSecurityContext.runAsUser | int | `1001` | set background-services pod's security context runAsUser |
 | migrations.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | job resources configuration |
 | migrations.restartPolicy | string | `"Never"` | job restart policy |
 | migrations.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1001}` | job security context configuration |

--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -82,7 +82,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-    {{- with .Values.backgroundServices.podSecurityContext }}
-    {{- include . | nindent 4 }}
-    {{- end }}
+      {{- with .Values.migrations.podSecurityContext }}
+      securityContext: {{- . | toYaml | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -48,6 +48,8 @@ spec:
             secretKeyRef:
               name: {{ include "server.postgres-string-secret-name" . }}
               key: connection-string
+        - name: HOME
+          value: /home/prefect
         {{- if .Values.global.prefect.env }}
         {{- include "common.tplvalues.render" (dict "value" .Values.global.prefect.env "context" $) | nindent 8 }}
         {{- end }}
@@ -80,4 +82,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+    {{- with .Values.backgroundServices.podSecurityContext }}
+    {{- include . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -280,3 +280,23 @@ tests:
         equal:
           path: .spec.template.spec.tolerations[0].key
           value: key1
+
+  - it: Should contain HOME env variable for pre-upgrade hook
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: HOME
+            value: /home/prefect
+
+    - it: Should set correct pod security context for pre-upgrade hook
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        equal:
+          path: .spec.template.spec.securityContext
+          value:
+            runAsUser: 1001
+            fsGroup: 1001
+            runAsNonRoot: true
+

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -290,7 +290,10 @@ tests:
             name: HOME
             value: /home/prefect
 
-    - it: Should set correct pod security context for pre-upgrade hook
+  - it: Should set correct pod security context for pre-upgrade hook
+    set:
+      backgroundServices:
+        runAsSeparateDeployment: true
     asserts:
       - template: pre-upgrade-hook.yaml
         equal:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -141,6 +141,14 @@
             }
           }
         },
+        "podSecurityContext": {
+          "type": "object",
+          "properties": {
+            "runAsUser": { "type": ["integer", "null"] },
+            "runAsNonRoot": { "type": "boolean" },
+            "fsGroup": { "type": ["integer", "null"] }
+          }
+        },
         "securityContext": {
           "type": "object",
           "title": "Security Context",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -240,6 +240,14 @@ migrations:
     limits:
       cpu: 500m
       memory: 256Mi
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    # -- set background-services pod's security context runAsUser
+    runAsUser: 1001
+    # -- set background-services pod's security context runAsNonRoot
+    runAsNonRoot: true
+    # -- set background-services pod's security context fsGroup
+    fsGroup: 1001
   # -- job security context configuration
   securityContext:
     runAsUser: 1001

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -244,11 +244,11 @@ migrations:
     # ephemeral-storage:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext:
-    # -- set background-services pod's security context runAsUser
+    # -- set migration job's pod security context runAsUser
     runAsUser: 1001
-    # -- set background-services pod's security context runAsNonRoot
+    # -- set migration job's pod security context runAsNonRoot
     runAsNonRoot: true
-    # -- set background-services pod's security context fsGroup
+    # -- set migration job's pod security context fsGroup
     fsGroup: 1001
   # -- job security context configuration
   securityContext:


### PR DESCRIPTION
### Summary

Closes https://github.com/PrefectHQ/prefect-helm/issues/605

This change adds the following to the separate migrations job: 
* HOME env variable
* `podSecurityContext`, as specified in the `backgroundServices` section

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
