### PR TITLE
feat(prefect-server): support existingSecret for redis password

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -141,6 +141,21 @@ backgroundServices:
       password: paranoid!
 ```
 
+If you want to reference an existing Kubernetes Secret for the Redis password instead of providing it in plain text, use the `existingSecret` field:
+
+```yaml
+backgroundServices:
+  runAsSeparateDeployment: true
+  messaging:
+    redis:
+      host: external.redis.host.example.com
+      username: marvin
+      existingSecret: my-redis-secret
+      existingSecretPasswordKey: redis-password  # default key name
+```
+
+The `existingSecretPasswordKey` field defaults to `redis-password` to match the Bitnami Redis chart convention. Set it to a different value if your secret uses a different key.
+
 ## PostgreSQL Configuration
 
 ### Handling Connection Secrets
@@ -320,8 +335,10 @@ the HorizontalPodAutoscaler.
 | backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | backgroundServices.messaging.broker | string | `"prefect_redis.messaging"` | messaging broker class to use for background services |
 | backgroundServices.messaging.cache | string | `"prefect_redis.messaging"` | messaging cache class to use for background services |
-| backgroundServices.messaging.redis | object | `{"db":0,"host":"","password":"","port":6379,"ssl":false,"username":""}` | settings for redis broker/cache change these if not using the built-in redis subchart |
+| backgroundServices.messaging.redis | object | `{"db":0,"existingSecret":"","existingSecretPasswordKey":"redis-password","host":"","password":"","port":6379,"ssl":false,"username":""}` | settings for redis broker/cache change these if not using the built-in redis subchart |
 | backgroundServices.messaging.redis.db | int | `0` | redis database number |
+| backgroundServices.messaging.redis.existingSecret | string | `""` | name of an existing Kubernetes secret containing the redis password takes precedence over the password field above |
+| backgroundServices.messaging.redis.existingSecretPasswordKey | string | `"redis-password"` | key within the existing secret that contains the redis password |
 | backgroundServices.messaging.redis.host | string | `""` | redis hostname if using the built-in redis subchart, this will be automatically set to the redis subchart's service name |
 | backgroundServices.messaging.redis.password | string | `""` | redis password, leave empty to use default if using the built-in redis subchart, this will be automatically set to the redis subchart's password value |
 | backgroundServices.messaging.redis.port | int | `6379` | redis port |

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -140,6 +140,21 @@ backgroundServices:
       password: paranoid!
 ```
 
+If you want to reference an existing Kubernetes Secret for the Redis password instead of providing it in plain text, use the `existingSecret` field:
+
+```yaml
+backgroundServices:
+  runAsSeparateDeployment: true
+  messaging:
+    redis:
+      host: external.redis.host.example.com
+      username: marvin
+      existingSecret: my-redis-secret
+      existingSecretPasswordKey: redis-password  # default key name
+```
+
+The `existingSecretPasswordKey` field defaults to `redis-password` to match the Bitnami Redis chart convention. Set it to a different value if your secret uses a different key.
+
 ## PostgreSQL Configuration
 
 ### Handling Connection Secrets

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -63,11 +63,12 @@ Make redis subchart context available as a variable in this block
   value: {{ .Values.backgroundServices.messaging.redis.username | quote }}
 {{- end -}}
 {{- /*
-There are three scenarios for passwords:
+There are four scenarios for passwords:
     1. If the subchart is enabled, reference the secret from the subchart.
        Setting backgroundServices.messaging.redis.password has no effect here.
-    2. If the subchart is not enabled, use the secret defined in the values file. TODO: secret reference
-    3. No password is set, so the environment variable is not defined.
+    2. If an existingSecret is provided, reference that secret with the specified key.
+    3. If the subchart is not enabled, use the password defined in the values file.
+    4. No password is set, so the environment variable is not defined.
 */ -}}
 {{- if and (.Values.redis.enabled) (.Values.backgroundServices.messaging.redis.password | empty) }}
 - name: PREFECT_REDIS_MESSAGING_PASSWORD
@@ -75,6 +76,12 @@ There are three scenarios for passwords:
     secretKeyRef:
       name: {{ include "common.names.fullname" $redis }}
       key: redis-password
+{{- else if not (.Values.backgroundServices.messaging.redis.existingSecret | empty) }}
+- name: PREFECT_REDIS_MESSAGING_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backgroundServices.messaging.redis.existingSecret }}
+      key: {{ .Values.backgroundServices.messaging.redis.existingSecretPasswordKey | default "redis-password" }}
 {{- else if not (.Values.backgroundServices.messaging.redis.password | empty) }}
 - name: PREFECT_REDIS_MESSAGING_PASSWORD
   value: {{ .Values.backgroundServices.messaging.redis.password | quote }}

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -647,3 +647,76 @@ tests:
           content:
             name: PREFECT_REDIS_MESSAGING_SSL
             value: "true"
+
+  - it: Should use existingSecret for redis password when provided
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          redis:
+            host: custom-redis-host
+            existingSecret: my-redis-secret
+      redis:
+        enabled: false
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_REDIS_MESSAGING_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-redis-secret
+                key: redis-password
+
+  - it: Should use custom existingSecretPasswordKey when provided
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          redis:
+            host: custom-redis-host
+            existingSecret: my-redis-secret
+            existingSecretPasswordKey: custom-key
+      redis:
+        enabled: false
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_REDIS_MESSAGING_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-redis-secret
+                key: custom-key
+
+  - it: Should prefer existingSecret over plain text password
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          redis:
+            host: custom-redis-host
+            password: plain-text-password
+            existingSecret: my-redis-secret
+      redis:
+        enabled: false
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_REDIS_MESSAGING_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-redis-secret
+                key: redis-password
+      - notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_REDIS_MESSAGING_PASSWORD
+            value: plain-text-password

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -990,6 +990,18 @@
                   "type": "boolean",
                   "title": "SSL",
                   "description": "enable SSL for redis broker connection"
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "title": "Existing Secret",
+                  "description": "name of an existing secret containing the redis password. takes precedence over password",
+                  "optional": true
+                },
+                "existingSecretPasswordKey": {
+                  "type": "string",
+                  "title": "Existing Secret Password Key",
+                  "description": "key within the existing secret that contains the redis password",
+                  "optional": true
                 }
               }
             }

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -427,6 +427,13 @@ backgroundServices:
       # -- use TLS for redis connection
       ssl: false
 
+      # -- name of an existing Kubernetes secret containing the redis password
+      # takes precedence over the password field above
+      existingSecret: ""
+
+      # -- key within the existing secret that contains the redis password
+      existingSecretPasswordKey: "redis-password"
+
 ## Server Service Account configuration
 serviceAccount:
   # -- specifies whether a service account should be created


### PR DESCRIPTION
### Summary

Adds support for referencing a pre-existing Kubernetes Secret for the Redis password, rather than having to provide it in plain text via `backgroundServices.messaging.redis.password`. This follows the same pattern already used for PostgreSQL credentials.

There was actually a `TODO: secret reference` comment in the helpers template for this, so it was on the radar already.

Closes #552

Closes https://linear.app/prefect/issue/PLA-2067/read-redis-connection-information-from-existing-secret

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review