### PR TITLE
feat: Support configurable task queue backend

### DIFF
--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -21,29 +21,16 @@ Create the name of the service account to associate with the background-services
 {{- end -}}
 
 {{- /*
-    Reusable block for background services environment variables.
+    Shared block for Redis connection environment variables.
+    Used by both the server (for task queue) and background services (for messaging).
 */ -}}
-{{- define "backgroundServices.envVars" -}}
-{{- /*
-Make redis subchart context available as a variable in this block
-*/ -}}
+{{- define "redis.connectionEnvVars" -}}
 {{- $redis := dict
       "Release"      .Release
       "Capabilities" .Capabilities
       "Values"       .Values.redis
       "Chart"        (dict "Name" "redis")
 -}}
-- name: PREFECT_API_DATABASE_MIGRATE_ON_START
-  value: "false"
-- name: PREFECT_MESSAGING_BROKER
-  value: {{ .Values.backgroundServices.messaging.broker }}
-- name: PREFECT_MESSAGING_CACHE
-  value: {{ .Values.backgroundServices.messaging.cache }}
-{{- if eq .Values.backgroundServices.messaging.broker "prefect_redis.messaging" }}
-- name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
-  value: prefect_redis.ordering
-- name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
-  value: prefect_redis.lease_storage
 - name: PREFECT_REDIS_MESSAGING_HOST
 {{- if and (.Values.redis.enabled) (.Values.backgroundServices.messaging.redis.host | empty) }}
   value: {{ printf "%s-headless" (include "common.names.fullname" $redis) }}.{{ .Release.Namespace }}.svc.cluster.local
@@ -86,6 +73,24 @@ There are four scenarios for passwords:
 - name: PREFECT_REDIS_MESSAGING_PASSWORD
   value: {{ .Values.backgroundServices.messaging.redis.password | quote }}
 {{- end }}
+{{- end -}}
+
+{{- /*
+    Reusable block for background services environment variables.
+*/ -}}
+{{- define "backgroundServices.envVars" -}}
+- name: PREFECT_API_DATABASE_MIGRATE_ON_START
+  value: "false"
+- name: PREFECT_MESSAGING_BROKER
+  value: {{ .Values.backgroundServices.messaging.broker }}
+- name: PREFECT_MESSAGING_CACHE
+  value: {{ .Values.backgroundServices.messaging.cache }}
+{{- if eq .Values.backgroundServices.messaging.broker "prefect_redis.messaging" }}
+- name: PREFECT_SERVER_EVENTS_CAUSAL_ORDERING
+  value: prefect_redis.ordering
+- name: PREFECT_SERVER_CONCURRENCY_LEASE_STORAGE
+  value: prefect_redis.lease_storage
+{{ include "redis.connectionEnvVars" . }}
 {{- end }}
 {{- end -}}
 

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -34,8 +34,9 @@
 {{- end -}}
 
 {{- define "prefect-server.validateMessaging" -}}
-{{- if and (.Values.backgroundServices.runAsSeparateDeployment) (and (not .Values.redis.enabled) (.Values.backgroundServices.messaging.redis.host | empty)) -}}
-  {{- fail "You must set redis.enabled=true or provide a redis configuration when backgroundServices.runAsSeparateDeployment=true" -}}
+{{- $needsRedis := or .Values.backgroundServices.runAsSeparateDeployment (not (.Values.server.taskScheduling.backend | empty)) -}}
+{{- if and $needsRedis (and (not .Values.redis.enabled) (.Values.backgroundServices.messaging.redis.host | empty)) -}}
+  {{- fail "You must set redis.enabled=true or provide a redis configuration when backgroundServices.runAsSeparateDeployment=true or server.taskScheduling.backend is set" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -143,6 +143,10 @@ spec:
             - name: PREFECT_SERVER_TASKS_SCHEDULING_MAX_RETRY_QUEUE_SIZE
               value: {{ .Values.server.taskScheduling.maxRetryQueueSize | quote }}
             {{- end }}
+            {{- if gt (int .Values.server.taskScheduling.inflightVisibilityTimeout) 0 }}
+            - name: PREFECT_TASK_SCHEDULING_INFLIGHT_VISIBILITY_TIMEOUT
+              value: {{ .Values.server.taskScheduling.inflightVisibilityTimeout | quote }}
+            {{- end }}
             {{- if .Values.backgroundServices.runAsSeparateDeployment }}
             {{- include "backgroundServices.envVars" . | nindent 12 }}
             {{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -135,6 +135,14 @@ spec:
               value: {{ .Values.server.taskScheduling.backend }}
             {{- include "redis.connectionEnvVars" . | nindent 12 }}
             {{- end }}
+            {{- if gt (int .Values.server.taskScheduling.maxScheduledQueueSize) 0 }}
+            - name: PREFECT_SERVER_TASKS_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE
+              value: {{ .Values.server.taskScheduling.maxScheduledQueueSize | quote }}
+            {{- end }}
+            {{- if gt (int .Values.server.taskScheduling.maxRetryQueueSize) 0 }}
+            - name: PREFECT_SERVER_TASKS_SCHEDULING_MAX_RETRY_QUEUE_SIZE
+              value: {{ .Values.server.taskScheduling.maxRetryQueueSize | quote }}
+            {{- end }}
             {{- if .Values.backgroundServices.runAsSeparateDeployment }}
             {{- include "backgroundServices.envVars" . | nindent 12 }}
             {{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -130,6 +130,11 @@ spec:
             {{- if .Values.server.env }}
             {{- include "common.tplvalues.render" (dict "value" .Values.server.env "context" $) | nindent 12 }}
             {{- end }}
+            {{- if not (.Values.server.taskScheduling.backend | empty) }}
+            - name: PREFECT_TASK_SCHEDULING_BACKEND
+              value: {{ .Values.server.taskScheduling.backend }}
+            {{- include "redis.connectionEnvVars" . | nindent 12 }}
+            {{- end }}
             {{- if .Values.backgroundServices.runAsSeparateDeployment }}
             {{- include "backgroundServices.envVars" . | nindent 12 }}
             {{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -134,6 +134,18 @@ spec:
             - name: PREFECT_TASK_SCHEDULING_BACKEND
               value: {{ .Values.server.taskScheduling.backend }}
             {{- include "redis.connectionEnvVars" . | nindent 12 }}
+            {{- if gt (int .Values.server.taskScheduling.inflightVisibilityTimeout) 0 }}
+            - name: PREFECT_TASK_SCHEDULING_INFLIGHT_VISIBILITY_TIMEOUT
+              value: {{ .Values.server.taskScheduling.inflightVisibilityTimeout | quote }}
+            {{- end }}
+            {{- if gt (int .Values.server.taskScheduling.dequeueBlockMs) 0 }}
+            - name: PREFECT_SERVER_TASKS_SCHEDULING_DEQUEUE_BLOCK_MS
+              value: {{ .Values.server.taskScheduling.dequeueBlockMs | quote }}
+            {{- end }}
+            {{- if not (.Values.server.taskScheduling.dequeueMaxConcurrency | empty) }}
+            - name: PREFECT_SERVER_TASKS_SCHEDULING_DEQUEUE_MAX_CONCURRENCY
+              value: {{ .Values.server.taskScheduling.dequeueMaxConcurrency | quote }}
+            {{- end }}
             {{- end }}
             {{- if gt (int .Values.server.taskScheduling.maxScheduledQueueSize) 0 }}
             - name: PREFECT_SERVER_TASKS_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE
@@ -142,10 +154,6 @@ spec:
             {{- if gt (int .Values.server.taskScheduling.maxRetryQueueSize) 0 }}
             - name: PREFECT_SERVER_TASKS_SCHEDULING_MAX_RETRY_QUEUE_SIZE
               value: {{ .Values.server.taskScheduling.maxRetryQueueSize | quote }}
-            {{- end }}
-            {{- if gt (int .Values.server.taskScheduling.inflightVisibilityTimeout) 0 }}
-            - name: PREFECT_TASK_SCHEDULING_INFLIGHT_VISIBILITY_TIMEOUT
-              value: {{ .Values.server.taskScheduling.inflightVisibilityTimeout | quote }}
             {{- end }}
             {{- if .Values.backgroundServices.runAsSeparateDeployment }}
             {{- include "backgroundServices.envVars" . | nindent 12 }}

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -790,6 +790,13 @@
               "description": "maximum number of retries to queue per task key. 0 uses the server default (100).",
               "minimum": 0,
               "default": 0
+            },
+            "inflightVisibilityTimeout": {
+              "type": "integer",
+              "title": "Inflight Visibility Timeout",
+              "description": "seconds before an in-flight task run is considered stale and re-enqueued. 0 uses the server default (30).",
+              "minimum": 0,
+              "default": 0
             }
           }
         }

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -797,6 +797,20 @@
               "description": "seconds before an in-flight task run is considered stale and re-enqueued. 0 uses the server default (30).",
               "minimum": 0,
               "default": 0
+            },
+            "dequeueBlockMs": {
+              "type": "integer",
+              "title": "Dequeue Block Ms",
+              "description": "milliseconds to block on each XREADGROUP call per task key. 0 uses the server default (1000).",
+              "minimum": 0,
+              "default": 0
+            },
+            "dequeueMaxConcurrency": {
+              "type": ["integer", "null"],
+              "title": "Dequeue Max Concurrency",
+              "description": "maximum concurrent blocking dequeue calls to Redis. Limits connections held by the task queue subsystem. null means uncapped.",
+              "minimum": 1,
+              "default": null
             }
           }
         }

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -776,6 +776,20 @@
               "type": "string",
               "title": "Backend",
               "description": "module path for the task queue backend. Set to 'prefect_redis.task_queue' for distributed queue across server replicas."
+            },
+            "maxScheduledQueueSize": {
+              "type": "integer",
+              "title": "Max Scheduled Queue Size",
+              "description": "maximum number of scheduled tasks to queue per task key. 0 uses the server default (1000).",
+              "minimum": 0,
+              "default": 0
+            },
+            "maxRetryQueueSize": {
+              "type": "integer",
+              "title": "Max Retry Queue Size",
+              "description": "maximum number of retries to queue per task key. 0 uses the server default (100).",
+              "minimum": 0,
+              "default": 0
             }
           }
         }

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -765,6 +765,19 @@
           "type": "array",
           "title": "Extra Container Args",
           "description": "array with extra args for the server container"
+        },
+        "taskScheduling": {
+          "type": "object",
+          "title": "Task Scheduling",
+          "description": "task queue backend configuration for the server",
+          "additionalProperties": false,
+          "properties": {
+            "backend": {
+              "type": "string",
+              "title": "Backend",
+              "description": "module path for the task queue backend. Set to 'prefect_redis.task_queue' for distributed queue across server replicas."
+            }
+          }
         }
       }
     },

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -83,6 +83,10 @@ server:
     # -- module path for the task queue backend
     # set to "prefect_redis.task_queue" for distributed queue across server replicas
     backend: ""
+    # -- maximum number of scheduled tasks to queue per task key (0 = use server default of 1000)
+    maxScheduledQueueSize: 0
+    # -- maximum number of retries to queue per task key (0 = use server default of 100)
+    maxRetryQueueSize: 0
 
   # -- Custom container command arguments
   args: []

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -78,6 +78,12 @@ server:
   ##   - name: PREFECT_API_ENABLE_HTTP2
   ##     value: false
 
+  # Configuration for the task queue backend used by the server for background tasks
+  taskScheduling:
+    # -- module path for the task queue backend
+    # set to "prefect_redis.task_queue" for distributed queue across server replicas
+    backend: ""
+
   # -- Custom container command arguments
   args: []
 

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -89,6 +89,10 @@ server:
     maxRetryQueueSize: 0
     # -- seconds before an in-flight task run is considered stale and re-enqueued (0 = use server default of 30)
     inflightVisibilityTimeout: 0
+    # -- milliseconds to block on each XREADGROUP call per task key (0 = use server default of 1000)
+    dequeueBlockMs: 0
+    # -- maximum concurrent blocking dequeue calls to Redis; limits connections held by the task queue subsystem (null = uncapped)
+    dequeueMaxConcurrency: null
 
   # -- Custom container command arguments
   args: []

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -87,6 +87,8 @@ server:
     maxScheduledQueueSize: 0
     # -- maximum number of retries to queue per task key (0 = use server default of 100)
     maxRetryQueueSize: 0
+    # -- seconds before an in-flight task run is considered stale and re-enqueued (0 = use server default of 30)
+    inflightVisibilityTimeout: 0
 
   # -- Custom container command arguments
   args: []


### PR DESCRIPTION

### Summary

supports https://github.com/PrefectHQ/prefect/issues/21218

- Add flag to allow task-queue backend selection
- Ensure redis params available to server when used

### Requirements

- [X] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [ ] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [X] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [ ] Relevant labels are added
- [ ] `Draft` status is used until ready for review
