### PR TITLE
feat(prefect-server): add support for PREFECT_SERVER_DOCKET_URL

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -335,6 +335,9 @@ the HorizontalPodAutoscaler.
 | backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | backgroundServices.messaging.broker | string | `"prefect_redis.messaging"` | messaging broker class to use for background services |
 | backgroundServices.messaging.cache | string | `"prefect_redis.messaging"` | messaging cache class to use for background services |
+| backgroundServices.messaging.docket.existingSecret | string | `""` | name of an existing Kubernetes secret containing the Docket URL takes precedence over the url field above the secret should contain a key with the full Redis URL including any credentials |
+| backgroundServices.messaging.docket.existingSecretKey | string | `"docket-url"` | key within the existing secret that contains the Docket URL |
+| backgroundServices.messaging.docket.url | string | `""` | URL for the Docket scheduler backend examples: redis://host:6379/0, rediss://host:6379/0 (TLS), redis://user:pass@host:6379/0 leave empty to use the default in-memory backend (memory://) |
 | backgroundServices.messaging.redis | object | `{"db":0,"existingSecret":"","existingSecretPasswordKey":"redis-password","host":"","password":"","port":6379,"ssl":false,"username":""}` | settings for redis broker/cache change these if not using the built-in redis subchart |
 | backgroundServices.messaging.redis.db | int | `0` | redis database number |
 | backgroundServices.messaging.redis.existingSecret | string | `""` | name of an existing Kubernetes secret containing the redis password takes precedence over the password field above |

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -87,6 +87,23 @@ There are four scenarios for passwords:
   value: {{ .Values.backgroundServices.messaging.redis.password | quote }}
 {{- end }}
 {{- end }}
+{{- /*
+Docket URL for background service coordination (scheduler, late runs, automations).
+Priority:
+    1. existingSecret - reference a Kubernetes secret containing the full URL.
+    2. url - use the plain-text URL from values.
+    3. Not set - Docket defaults to memory:// (single-server only).
+*/ -}}
+{{- if not (.Values.backgroundServices.messaging.docket.existingSecret | empty) }}
+- name: PREFECT_SERVER_DOCKET_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backgroundServices.messaging.docket.existingSecret }}
+      key: {{ .Values.backgroundServices.messaging.docket.existingSecretKey | default "docket-url" }}
+{{- else if not (.Values.backgroundServices.messaging.docket.url | empty) }}
+- name: PREFECT_SERVER_DOCKET_URL
+  value: {{ .Values.backgroundServices.messaging.docket.url | quote }}
+{{- end }}
 {{- end -}}
 
 {{/* ----- Connection string templates ------ */}}

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -720,3 +720,94 @@ tests:
           content:
             name: PREFECT_REDIS_MESSAGING_PASSWORD
             value: plain-text-password
+
+  - it: Should not set PREFECT_SERVER_DOCKET_URL by default
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    asserts:
+      - notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DOCKET_URL
+          any: true
+
+  - it: Should set PREFECT_SERVER_DOCKET_URL when docket.url is provided
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          docket:
+            url: "redis://redis-host:6379/1"
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DOCKET_URL
+            value: "redis://redis-host:6379/1"
+
+  - it: Should set PREFECT_SERVER_DOCKET_URL from existingSecret
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          docket:
+            existingSecret: my-docket-secret
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DOCKET_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-docket-secret
+                key: docket-url
+
+  - it: Should use custom existingSecretKey for docket URL
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          docket:
+            existingSecret: my-docket-secret
+            existingSecretKey: custom-docket-key
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DOCKET_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-docket-secret
+                key: custom-docket-key
+
+  - it: Should prefer docket existingSecret over plain URL
+    templates:
+      - deployment.yaml
+      - background-services/deployment.yaml
+    set:
+      backgroundServices:
+        messaging:
+          docket:
+            url: "redis://redis-host:6379/1"
+            existingSecret: my-docket-secret
+    asserts:
+      - contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DOCKET_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-docket-secret
+                key: docket-url
+      - notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DOCKET_URL
+            value: "redis://redis-host:6379/1"

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -1012,6 +1012,31 @@
                   "optional": true
                 }
               }
+            },
+            "docket": {
+              "type": "object",
+              "title": "Docket settings",
+              "description": "Docket scheduler configuration for background service coordination",
+              "additionalProperties": false,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "title": "Docket URL",
+                  "description": "URL for the Docket scheduler backend (e.g. redis://host:6379/0). Defaults to memory:// when empty."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "title": "Existing Secret",
+                  "description": "name of an existing secret containing the Docket URL. Takes precedence over url.",
+                  "optional": true
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "title": "Existing Secret Key",
+                  "description": "key within the existing secret that contains the Docket URL",
+                  "optional": true
+                }
+              }
             }
           }
         }

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -454,9 +454,9 @@ backgroundServices:
       # leave empty to use the default in-memory backend (memory://)
       url: ""
 
-      # -- name of an existing Kubernetes secret containing the Docket URL
-      # takes precedence over the url field above
-      # the secret should contain a key with the full Redis URL including any credentials
+      # -- name of an existing Kubernetes secret containing the Docket URL.
+      # Takes precedence over the url field above.
+      # The secret should contain a key with the full Redis URL including any credentials.
       existingSecret: ""
 
       # -- key within the existing secret that contains the Docket URL

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -449,9 +449,9 @@ backgroundServices:
     # which only works for single-server deployments.
     # For high-availability deployments, configure Docket to use Redis.
     docket:
-      # -- URL for the Docket scheduler backend
-      # examples: redis://host:6379/0, redis://host:6379/0 (TLS), redis://user:pass@host:6379/0
-      # leave empty to use the default in-memory backend (memory://)
+      # -- URL for the Docket scheduler backend.
+      # Examples: redis://host:6379/0, redis://host:6379/0 (TLS), redis://user:pass@host:6379/0.
+      # Leave empty to use the default in-memory backend (memory://).
       url: ""
 
       # -- name of an existing Kubernetes secret containing the Docket URL.

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -443,7 +443,7 @@ backgroundServices:
       existingSecretPasswordKey: "redis-password"
 
     # Docket configuration for background service coordination
-    # ref: https://docs.prefect.io/v3/advanced/self-hosted#redis-setup
+    # ref: https://docs.prefect.io/v3/advanced/self-hosted#docket-url-for-background-services
     # Docket coordinates background services like the scheduler, late run detection,
     # and automation triggers. By default it uses in-memory storage (memory://),
     # which only works for single-server deployments.

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -442,6 +442,26 @@ backgroundServices:
       # -- key within the existing secret that contains the redis password
       existingSecretPasswordKey: "redis-password"
 
+    # Docket configuration for background service coordination
+    # ref: https://docs.prefect.io/v3/advanced/self-hosted#redis-setup
+    # Docket coordinates background services like the scheduler, late run detection,
+    # and automation triggers. By default it uses in-memory storage (memory://),
+    # which only works for single-server deployments.
+    # For high-availability deployments, configure Docket to use Redis.
+    docket:
+      # -- URL for the Docket scheduler backend
+      # examples: redis://host:6379/0, rediss://host:6379/0 (TLS), redis://user:pass@host:6379/0
+      # leave empty to use the default in-memory backend (memory://)
+      url: ""
+
+      # -- name of an existing Kubernetes secret containing the Docket URL
+      # takes precedence over the url field above
+      # the secret should contain a key with the full Redis URL including any credentials
+      existingSecret: ""
+
+      # -- key within the existing secret that contains the Docket URL
+      existingSecretKey: "docket-url"
+
 ## Server Service Account configuration
 serviceAccount:
   # -- specifies whether a service account should be created

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -450,7 +450,7 @@ backgroundServices:
     # For high-availability deployments, configure Docket to use Redis.
     docket:
       # -- URL for the Docket scheduler backend
-      # examples: redis://host:6379/0, rediss://host:6379/0 (TLS), redis://user:pass@host:6379/0
+      # examples: redis://host:6379/0, redis://host:6379/0 (TLS), redis://user:pass@host:6379/0
       # leave empty to use the default in-memory backend (memory://)
       url: ""
 


### PR DESCRIPTION
## Summary

- Add first-class Helm values for configuring `PREFECT_SERVER_DOCKET_URL`, which Prefect uses to coordinate background services (scheduler, late run detection, automation triggers)
- Support reading the Docket URL from an existing Kubernetes secret via `existingSecret` / `existingSecretKey`, following the same pattern as Redis password secret support
- Backwards compatible: when no docket values are configured (the default), no env var is injected and Prefect falls back to its built-in `memory://` backend

### Configuration Options

```yaml
backgroundServices:
  messaging:
    docket:
      # Option 1: plain-text URL
      url: "redis://redis-host:6379/1"

      # Option 2: from a Kubernetes secret (takes precedence over url)
      existingSecret: "my-docket-secret"
      existingSecretKey: "docket-url"  # default key name
```

Closes #613

## Test plan

- [x] `helm template` renders correctly with no docket config (env var absent)
- [x] `helm template` renders correctly with `docket.url` set (plain value)
- [x] `helm template` renders correctly with `docket.existingSecret` set (secretKeyRef)
- [x] `helm template` renders correctly with custom `existingSecretKey`
- [x] `existingSecret` takes precedence over `url` when both are set
- [x] Env var appears in both server and background-services deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)