### PR TITLE
feat(worker): add named template for workpool name and base job template

### DIFF
--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -102,3 +102,19 @@ Determine the name of the ConfigMap for the baseJobTemplate
 {{- else -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  worker.workPoolName
+    Define the workpool name
+*/}}
+{{- define "worker.workPoolName" -}}
+{{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool }}
+{{- end }}
+
+{{/*
+  worker.baseJobTemplate
+    Define the baseJobTemplate used by the worker
+*/}}
+{{- define "worker.baseJobTemplate" -}}
+{{ .Values.worker.config.baseJobTemplate.configuration | toJson }}
+{{- end }}

--- a/charts/prefect-worker/templates/configmap.yaml
+++ b/charts/prefect-worker/templates/configmap.yaml
@@ -13,5 +13,5 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  baseJobTemplate.json: {{ .Values.worker.config.baseJobTemplate.configuration | toJson }}
+  baseJobTemplate.json: {{ include "worker.baseJobTemplate" . }}
 {{- end }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - -c
           args:
             - |
-              work_pool_name={{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool | quote }}
+              work_pool_name={{ include "worker.workPoolName" . | quote }}
 
               # suppress work-pool inspect output, as we're just
               # calling it to check the existence of the work-pool.
@@ -190,7 +190,7 @@ spec:
             - --type
             - {{ .Values.worker.config.type | quote }}
             - --pool
-            - {{ required "A Work Pool Name is required (worker.config.workPool)" .Values.worker.config.workPool | quote }}
+            - {{ include "worker.workPoolName" . | quote }}
             {{- range .Values.worker.config.workQueues }}
             - --work-queue
             - {{ . }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -1168,3 +1168,35 @@ tests:
         equal:
           path: .metadata.annotations.my-annotation
           value: my-value
+
+  - it: Should render work pool name in deployment --pool arg
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].args[6]
+          value: my-work-pool
+
+  - it: Should render work pool name in initContainer script
+    set:
+      worker:
+        config:
+          baseJobTemplate:
+            configuration: |
+              {}
+    asserts:
+      - template: deployment.yaml
+        matchRegex:
+          path: .spec.template.spec.initContainers[0].args[0]
+          pattern: 'work_pool_name="my-work-pool"'
+
+  - it: Should render baseJobTemplate configuration as JSON in configmap
+    set:
+      worker:
+        config:
+          baseJobTemplate:
+            configuration: |
+              {}
+    asserts:
+      - template: configmap.yaml
+        exists:
+          path: .data["baseJobTemplate.json"]

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -306,9 +306,9 @@
                   "description": "the name of an existing ConfigMap containing a base job template. NOTE - the key must be 'baseJobTemplate.json'"
                 },
                 "configuration": {
-                  "type": ["string", "null"],
+                  "type": ["string", "null", "object"],
                   "title": "Base Job Template Configuration",
-                  "description": "JSON formatted base job template. If data is provided here, the chart will generate a configmap and mount it to the worker pod"
+                  "description": "Base job template as a JSON string or a YAML dict. If data is provided here, the chart will generate a configmap and mount it to the worker pod"
                 },
                 "name": {
                   "type": ["string", "null"],


### PR DESCRIPTION
### Summary

Have this use case to be able to deploy the same workpools to different data centers in different regions.
Using argocd at runtime we inject such information which we consume in an internal wrapper chart.
The change introduced in this PR will allow us to redefine the named template in our wrapper chart  so that following in argocd will work:
```
helm template \
 -f values/worker-values.yaml \
 -f values/dev/workers/worker-values.yaml \
 -f values/dev/workers/admin.yaml \
  --set region=amer
```
From this above in our wrapper chart - will be able to build the workpool name dynamically as well allow dictionary merging of baseJobTemplate

Otherwise we have to duplicate per region e.g
```
helm template \
 -f values/amer/worker-values.yaml \
 -f values/amer/dev/workers/worker-values.yaml \
 -f values/amer/dev/workers/admin.yaml \
```



The changes suggested aim to be backward compatible hence why it is wrapped in a named template with the same value reference as before.

### Requirements

- [X] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [X] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [X] Body includes `Closes <issue>`, if available
- [X] Added/modified configuration includes a descriptive comment for documentation generation
- [X] Unit tests are added/updated
- [X] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [X] `Draft` status is used until ready for review
