### PR TITLE
feat: deploy HTTPRoute without the need of Gateway creation

### DIFF
--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -43,6 +43,9 @@
 {{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
   {{- fail "Gateway API and Ingress are mutually exclusive. Only one can be enabled at a time. Please set either gateway.enabled=false or ingress.enabled=false." -}}
 {{- end -}}
+{{- if and .Values.httproute.enabled .Values.ingress.enabled -}}
+  {{- fail "HTTPRoute and Ingress are mutually exclusive. Only one can be enabled at a time. Please set either httproute.enabled=false or ingress.enabled=false." -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled (not .Values.gateway.className) -}}
   {{- fail "gateway.className is required when gateway.enabled=true. Please specify a GatewayClass that exists in your cluster." -}}
 {{- end -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -43,13 +43,21 @@
 {{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
   {{- fail "Gateway API and Ingress are mutually exclusive. Only one can be enabled at a time. Please set either gateway.enabled=false or ingress.enabled=false." -}}
 {{- end -}}
-{{- if and .Values.httproute.enabled (not .Values.gateway.create) (eq (len .Values.httproute.parentRefs) 0) -}}
-  {{- fail "When httproute.enabled=true and gateway.create=false, at least one entry in httproute.parentRefs is required. Set one or more parentRefs[].name values to attach the HTTPRoute to an existing Gateway." -}}
+{{- if and .Values.httproute.enabled (not .Values.gateway.create) -}}
+  {{- $hasName := false -}}
+  {{- range .Values.httproute.parentRefs -}}
+    {{- if .name -}}
+      {{- $hasName = true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $hasName -}}
+    {{- fail "When httproute.enabled=true and gateway.create=false, at least one entry in httproute.parentRefs is required. Set one or more parentRefs[].name values to attach the HTTPRoute to an existing Gateway." -}}
+  {{- end -}}
 {{- end -}}
-{{- if and .Values.gateway.enabled (not .Values.gateway.className) -}}
-  {{- fail "gateway.className is required when gateway.enabled=true. Please specify a GatewayClass that exists in your cluster." -}}
+{{- if and .Values.gateway.enabled .Values.gateway.create (not .Values.gateway.className) -}}
+  {{- fail "gateway.className is required when gateway.enabled=true and gateway.create=true. Please specify a GatewayClass that exists in your cluster." -}}
 {{- end -}}
-{{- if and .Values.gateway.enabled (not (include "gateway.apiAvailable" .)) -}}
+{{- if and .Values.gateway.enabled .Values.gateway.create (not (include "gateway.apiAvailable" .)) -}}
   {{- fail "Gateway API (gateway.networking.k8s.io/v1) is not available in this cluster. Please install Gateway API CRDs or disable gateway.enabled." -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prefect-server/templates/_validation.tpl
+++ b/charts/prefect-server/templates/_validation.tpl
@@ -43,8 +43,8 @@
 {{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
   {{- fail "Gateway API and Ingress are mutually exclusive. Only one can be enabled at a time. Please set either gateway.enabled=false or ingress.enabled=false." -}}
 {{- end -}}
-{{- if and .Values.httproute.enabled .Values.ingress.enabled -}}
-  {{- fail "HTTPRoute and Ingress are mutually exclusive. Only one can be enabled at a time. Please set either httproute.enabled=false or ingress.enabled=false." -}}
+{{- if and .Values.httproute.enabled (not .Values.gateway.create) (eq (len .Values.httproute.parentRefs) 0) -}}
+  {{- fail "When httproute.enabled=true and gateway.create=false, at least one entry in httproute.parentRefs is required. Set one or more parentRefs[].name values to attach the HTTPRoute to an existing Gateway." -}}
 {{- end -}}
 {{- if and .Values.gateway.enabled (not .Values.gateway.className) -}}
   {{- fail "gateway.className is required when gateway.enabled=true. Please specify a GatewayClass that exists in your cluster." -}}

--- a/charts/prefect-server/templates/gateway.yaml
+++ b/charts/prefect-server/templates/gateway.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.enabled }}
+{{- if and .Values.gateway.enabled .Values.gateway.create}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/charts/prefect-server/templates/gateway.yaml
+++ b/charts/prefect-server/templates/gateway.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled .Values.gateway.create}}
+{{- if and .Values.gateway.enabled .Values.gateway.create }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/charts/prefect-server/templates/httproute.yaml
+++ b/charts/prefect-server/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled .Values.httproute.enabled }}
+{{- if .Values.httproute.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/prefect-server/templates/httproute.yaml
+++ b/charts/prefect-server/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.httproute.enabled }}
+{{- if and .Values.gateway.enabled .Values.httproute.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/prefect-server/tests/gateway_ingress_exclusivity_test.yaml
+++ b/charts/prefect-server/tests/gateway_ingress_exclusivity_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - template: NOTES.txt
         failedTemplate:
-          errorMessage: "gateway.className is required when gateway.enabled=true. Please specify a GatewayClass that exists in your cluster."
+          errorMessage: "gateway.className is required when gateway.enabled=true and gateway.create=true. Please specify a GatewayClass that exists in your cluster."
 
   - it: Should succeed when only Gateway is enabled with className
     set:

--- a/charts/prefect-server/tests/gateway_test.yaml
+++ b/charts/prefect-server/tests/gateway_test.yaml
@@ -445,8 +445,6 @@ tests:
           path: metadata.annotations["custom-annotation"]
           value: "custom-value"
 
-  # ---- Gateway creation disabled (gateway.create=false) tests ----
-
   - it: Should fail validation when gateway.create=false and no parentRefs name is provided
     set:
       gateway:

--- a/charts/prefect-server/tests/gateway_test.yaml
+++ b/charts/prefect-server/tests/gateway_test.yaml
@@ -185,6 +185,28 @@ tests:
         isKind:
           of: HTTPRoute
 
+  - it: Should create only HTTPRoute when Gateway creation is disabled
+    set:
+      gateway:
+        enabled: true
+        create: false
+        name: "shared-gateway"
+        className: "istio"
+    asserts:
+      - template: gateway.yaml
+        hasDocuments:
+          count: 0
+      - template: httproute.yaml
+        hasDocuments:
+          count: 1
+      - template: httproute.yaml
+        isKind:
+          of: HTTPRoute
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[0].name
+          value: "shared-gateway"
+
   - it: Should configure HTTPRoute parentRefs with default Gateway name
     set:
       gateway:

--- a/charts/prefect-server/tests/gateway_test.yaml
+++ b/charts/prefect-server/tests/gateway_test.yaml
@@ -192,6 +192,10 @@ tests:
         create: false
         name: "shared-gateway"
         className: "istio"
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+            sectionName: https
     asserts:
       - template: gateway.yaml
         hasDocuments:
@@ -440,3 +444,253 @@ tests:
         equal:
           path: metadata.annotations["custom-annotation"]
           value: "custom-value"
+
+  # ---- Gateway creation disabled (gateway.create=false) tests ----
+
+  - it: Should fail validation when gateway.create=false and no parentRefs name is provided
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: ""
+    asserts:
+      - template: NOTES.txt
+        failedTemplate:
+          errorMessage: "When httproute.enabled=true and gateway.create=false, at least one entry in httproute.parentRefs is required. Set one or more parentRefs[].name values to attach the HTTPRoute to an existing Gateway."
+
+  - it: Should fail validation when gateway.create=false and parentRefs is empty list
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs: []
+    asserts:
+      - template: NOTES.txt
+        failedTemplate:
+          errorMessage: "When httproute.enabled=true and gateway.create=false, at least one entry in httproute.parentRefs is required. Set one or more parentRefs[].name values to attach the HTTPRoute to an existing Gateway."
+
+  - it: Should fail validation when gateway.create=false with ingress also enabled
+    set:
+      gateway:
+        enabled: true
+        create: false
+      ingress:
+        enabled: true
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+    asserts:
+      - template: NOTES.txt
+        failedTemplate:
+          errorMessage: "Gateway API and Ingress are mutually exclusive. Only one can be enabled at a time. Please set either gateway.enabled=false or ingress.enabled=false."
+
+  - it: Should not require className when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+        className: ""
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+    asserts:
+      - template: gateway.yaml
+        hasDocuments:
+          count: 0
+      - template: httproute.yaml
+        hasDocuments:
+          count: 1
+
+  - it: Should not create any resources when gateway.create=false and httproute.enabled=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        enabled: false
+    asserts:
+      - template: gateway.yaml
+        hasDocuments:
+          count: 0
+      - template: httproute.yaml
+        hasDocuments:
+          count: 0
+      - template: httproute-tls-redirect.yaml
+        hasDocuments:
+          count: 0
+
+  - it: Should use explicit parentRefs name over gateway.name when create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+        name: "gateway-name-value"
+      httproute:
+        parentRefs:
+          - name: "explicit-gateway"
+            sectionName: https
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[0].name
+          value: "explicit-gateway"
+
+  - it: Should use parentRefs namespace for cross-namespace gateway reference
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+            namespace: "gateway-infra"
+            sectionName: https
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[0].name
+          value: "shared-gateway"
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[0].namespace
+          value: "gateway-infra"
+
+  - it: Should support multiple parentRefs when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: "gateway-a"
+            sectionName: https
+          - name: "gateway-b"
+            namespace: "other-ns"
+            sectionName: http
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[0].name
+          value: "gateway-a"
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[1].name
+          value: "gateway-b"
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[1].namespace
+          value: "other-ns"
+
+  - it: Should create TLS redirect HTTPRoute referencing shared gateway when create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+            sectionName: https
+        tls:
+          redirect: true
+    asserts:
+      - template: httproute-tls-redirect.yaml
+        hasDocuments:
+          count: 1
+      - template: httproute-tls-redirect.yaml
+        equal:
+          path: spec.parentRefs[0].name
+          value: "shared-gateway"
+      - template: httproute-tls-redirect.yaml
+        equal:
+          path: spec.parentRefs[0].sectionName
+          value: "http"
+
+  - it: Should configure HTTPRoute hostnames when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+            sectionName: https
+        hostnames:
+          - "app.example.com"
+          - "api.example.com"
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.hostnames[0]
+          value: "app.example.com"
+      - template: httproute.yaml
+        equal:
+          path: spec.hostnames[1]
+          value: "api.example.com"
+
+  - it: Should configure HTTPRoute backendRefs correctly when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      service:
+        port: 8080
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: "prefect-server"
+      - template: httproute.yaml
+        equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: Should use custom path in HTTPRoute when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+        path: "/prefect"
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.rules[0].matches[0].path.value
+          value: "/prefect"
+
+  - it: Should set custom HTTPRoute name when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        name: "my-custom-route"
+        parentRefs:
+          - name: "shared-gateway"
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: metadata.name
+          value: "my-custom-route"
+
+  - it: Should use parentRef port when gateway.create=false
+    set:
+      gateway:
+        enabled: true
+        create: false
+      httproute:
+        parentRefs:
+          - name: "shared-gateway"
+            port: 8443
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.parentRefs[0].port
+          value: 8443

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -640,7 +640,7 @@ gateway:
 
 # HTTPRoute Configuration
 httproute:
-  # -- enable HTTPRoute resource (auto-enabled when gateway.enabled=true)
+  # -- enable HTTPRoute resource (mutually exclusive with ingress, auto-enabled when gateway.enabled=true)
   # Can be disabled if you want to create HTTPRoutes manually
   enabled: true
 

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -589,7 +589,9 @@ ingress:
 gateway:
   # -- enable Gateway API resources (mutually exclusive with ingress)
   enabled: false
-
+  # -- whether to create a Gateway resource or just the associated HTTPRoute (if enabled)
+  # Can be disabled if you want to create the Gateway manually (or is already present) and just have the chart create the HTTPRoute with the correct parentRefs
+  create: true
   # -- GatewayClass that will be used to implement the Gateway
   # This must match an existing GatewayClass in your cluster
   className: ""


### PR DESCRIPTION
### Summary

Closes #616 

There shall be a way to deploy a new HTTPRoute with an existing Gateway referenced without the need to deploy an additional Gateway for each Prefect deployment.

The code adds the value gateway.create which defaults to true, so that there is no change in the helm charts behavior. If the value gateway.enabled=true and gateway.create=false only a HTTPRoute is deployed. This HTTPRoute MUST reference an existing gateway i. e. an Istio gateway in another namespace which allows HTTPRoutes from other namespaces.

This follows the design principle of the Kubernetes Gateway API and shared responsibility between Cluster Operators and Application Developers. [A high-level overview can be found here.](https://gateway-api.sigs.k8s.io)

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
