### PR TITLE
fix: allow arbitrary fields on security context schemas

### DIFF
--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -381,6 +381,52 @@ tests:
         notExists:
           path: .spec.template.spec.containers[0].securityContext.runAsUser
 
+  - it: Should pass arbitrary containerSecurityContext fields through to the manifest
+    set:
+      server:
+        containerSecurityContext:
+          runAsGroup: 2000
+          procMount: Default
+          seccompProfile:
+            type: RuntimeDefault
+          seLinuxOptions:
+            level: "s0:c123,c456"
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 2000
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.procMount
+          value: Default
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seLinuxOptions.level
+          value: "s0:c123,c456"
+
+  - it: Should pass arbitrary podSecurityContext fields through to the manifest
+    set:
+      server:
+        podSecurityContext:
+          supplementalGroups: [4000]
+          sysctls:
+            - name: net.core.somaxconn
+              value: "1024"
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.securityContext.supplementalGroups[0]
+          value: 4000
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.securityContext.sysctls[0].name
+          value: net.core.somaxconn
+
   - it: Should set pod labels
     set:
       server:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -587,7 +587,7 @@
           "type": "object",
           "title": "Pod Security Context",
           "description": "server pod security context",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "runAsUser": {
               "type": ["integer", "null"],
@@ -652,7 +652,7 @@
           "type": "object",
           "title": "Container Security Context",
           "description": "server container security context",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "runAsUser": {
               "type": ["integer", "null"],

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -384,6 +384,61 @@ tests:
         notExists:
           path: .spec.template.spec.containers[0].securityContext.runAsUser
 
+  - it: Should pass arbitrary containerSecurityContext fields through to the manifest
+    set:
+      worker:
+        containerSecurityContext:
+          runAsGroup: 2000
+          procMount: Default
+          seccompProfile:
+            type: RuntimeDefault
+          seLinuxOptions:
+            level: "s0:c123,c456"
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 2000
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.procMount
+          value: Default
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seLinuxOptions.level
+          value: "s0:c123,c456"
+
+  - it: Should pass arbitrary initContainer containerSecurityContext fields through to the manifest
+    set:
+      worker:
+        config:
+          baseJobTemplate:
+            configuration: |
+              {}
+        initContainer:
+          containerSecurityContext:
+            runAsGroup: 2000
+            seccompProfile:
+              type: Localhost
+              localhostProfile: /profiles/restricted.json
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 2000
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].securityContext.seccompProfile.type
+          value: Localhost
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].securityContext.seccompProfile.localhostProfile
+          value: /profiles/restricted.json
+
   - it: Should set pod annotations
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -136,7 +136,7 @@
               "type": "object",
               "title": "Container Security Context",
               "description": "init container security context configuration",
-              "additionalProperties": false,
+              "additionalProperties": true,
               "properties": {
                 "allowPrivilegeEscalation": {
                   "type": "boolean",
@@ -571,7 +571,7 @@
           "type": "object",
           "title": "Pod Security Context",
           "description": "worker pod security context configuration",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "fsGroup": {
               "type": ["integer", "null"],
@@ -657,7 +657,7 @@
           "type": "object",
           "title": "Container Security Context",
           "description": "worker container security context configuration",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "allowPrivilegeEscalation": {
               "type": "boolean",


### PR DESCRIPTION
### Summary

The `containerSecurityContext` and `podSecurityContext` schemas in both `prefect-worker` and `prefect-server` used `additionalProperties: false` with an enumerated subset of Kubernetes fields, so Helm rejected standard fields like `runAsGroup`, `seccompProfile`, `seLinuxOptions`, and `procMount` at install/upgrade time even though the deployment templates render these blocks unfiltered via `toYaml`.

Rather than adding the specific four fields that one customer needed (and repeating this fix every time Kubernetes adds a new security context field), this flips the affected security-context blocks to `additionalProperties: true` so any valid Kubernetes field passes through. The Kubernetes API server already validates the rendered manifest, which is the correct layer for that check.

This matches the convention used by Bitnami, cert-manager, and Prometheus community charts, which all declare pass-through Kubernetes blocks as open objects.

Reported by a customer trying to set `runAsGroup` for security hardening on AKS (Pylon #6246). Linear issue was scoped to the worker chart; same bug exists in the server chart, so this PR covers both.

Closes [PLA-2656](https://linear.app/prefect/issue/PLA-2656/prefect-worker-add-missing-standard-fields-to-containersecuritycontext).

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

Initial attempt enumerated the four missing fields explicitly. A quick survey of public charts (Bitnami, cert-manager, Prometheus community, ingress-nginx, ArgoCD) showed that enumerating PodSecurityContext fields with `additionalProperties: false` is non-standard. Charts that ship schemas universally leave these pass-through blocks open, and many flagship charts ship no schema at all. Revised to the smaller, more durable fix and extended to `prefect-server` since it had the same bug in two of its five security-context blocks.
</details>