### PR TITLE
fix(prefect-server): dedupe env vars on migration Job

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -335,9 +335,9 @@ the HorizontalPodAutoscaler.
 | backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | backgroundServices.messaging.broker | string | `"prefect_redis.messaging"` | messaging broker class to use for background services |
 | backgroundServices.messaging.cache | string | `"prefect_redis.messaging"` | messaging cache class to use for background services |
-| backgroundServices.messaging.docket.existingSecret | string | `""` | name of an existing Kubernetes secret containing the Docket URL takes precedence over the url field above the secret should contain a key with the full Redis URL including any credentials |
+| backgroundServices.messaging.docket.existingSecret | string | `""` | name of an existing Kubernetes secret containing the Docket URL. Takes precedence over the url field above. The secret should contain a key with the full Redis URL including any credentials. |
 | backgroundServices.messaging.docket.existingSecretKey | string | `"docket-url"` | key within the existing secret that contains the Docket URL |
-| backgroundServices.messaging.docket.url | string | `""` | URL for the Docket scheduler backend examples: redis://host:6379/0, rediss://host:6379/0 (TLS), redis://user:pass@host:6379/0 leave empty to use the default in-memory backend (memory://) |
+| backgroundServices.messaging.docket.url | string | `""` | URL for the Docket scheduler backend. Examples: redis://host:6379/0, redis://host:6379/0 (TLS), redis://user:pass@host:6379/0. Leave empty to use the default in-memory backend (memory://). |
 | backgroundServices.messaging.redis | object | `{"db":0,"existingSecret":"","existingSecretPasswordKey":"redis-password","host":"","password":"","port":6379,"ssl":false,"username":""}` | settings for redis broker/cache change these if not using the built-in redis subchart |
 | backgroundServices.messaging.redis.db | int | `0` | redis database number |
 | backgroundServices.messaging.redis.existingSecret | string | `""` | name of an existing Kubernetes secret containing the redis password takes precedence over the password field above |
@@ -368,6 +368,7 @@ the HorizontalPodAutoscaler.
 | fullnameOverride | string | `"prefect-server"` | fully override common.names.fullname |
 | gateway.annotations | object | `{}` | additional annotations for the Gateway resource |
 | gateway.className | string | `""` | GatewayClass that will be used to implement the Gateway This must match an existing GatewayClass in your cluster |
+| gateway.create | bool | `true` | whether to create a Gateway resource or just the associated HTTPRoute (if enabled) Can be disabled if you want to create the Gateway manually (or is already present) and just have the chart create the HTTPRoute with the correct parentRefs |
 | gateway.enabled | bool | `false` | enable Gateway API resources (mutually exclusive with ingress) |
 | gateway.infrastructure | object | `{}` | infrastructure configuration for Gateway ref: https://gateway-api.sigs.k8s.io/guides/infrastructure/ |
 | gateway.labels | object | `{}` | additional labels for the Gateway resource |
@@ -392,7 +393,7 @@ the HorizontalPodAutoscaler.
 | global.prefect.image.pullSecrets | list | `[]` | prefect image pull secrets |
 | global.prefect.image.repository | string | `"prefecthq/prefect"` | prefect image repository |
 | httproute.annotations | object | `{}` | additional annotations for the HTTPRoute resource |
-| httproute.enabled | bool | `true` | enable HTTPRoute resource (auto-enabled when gateway.enabled=true) Can be disabled if you want to create HTTPRoutes manually |
+| httproute.enabled | bool | `true` | enable HTTPRoute resource (mutually exclusive with ingress, auto-enabled when gateway.enabled=true) Can be disabled if you want to create HTTPRoutes manually |
 | httproute.extraRules | list | `[]` | additional HTTPRoute rules (advanced usage) Will be merged with auto-generated rules |
 | httproute.hostnames | list | `[]` | hostnames that this HTTPRoute should match |
 | httproute.labels | object | `{}` | additional labels for the HTTPRoute resource |
@@ -424,7 +425,7 @@ the HorizontalPodAutoscaler.
 | migrations.command | string | `"prefect server database upgrade -y\n"` | commands to run for database migrations (default: prefect server database upgrade -y) |
 | migrations.enabled | bool | `true` | enable the migration Job during chart upgrades (only applies when backgroundServices.runAsSeparateDeployment is true) |
 | migrations.entrypoint | list | `["/bin/sh","-c"]` | custom container entrypoint for the migration job |
-| migrations.env | list | `[]` | additional environment variables for the migration job |
+| migrations.env | list | `[]` | additional environment variables for the migration job; takes precedence over entries of the same name in `global.prefect.env` and `server.env` |
 | migrations.extraVolumeMounts | list | `[]` | additional volume mounts for the migration job |
 | migrations.extraVolumes | list | `[]` | additional volumes for the migration job |
 | migrations.nodeSelector | object | `{}` | node labels for migration job pods assignment |

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -106,6 +106,39 @@ Priority:
 {{- end }}
 {{- end -}}
 
+{{- /*
+    server.migrations.envVars:
+      Merged env vars for the migrations Job, deduplicated by name so the
+      same variable is never emitted twice in the Job spec.
+
+      Precedence (highest wins):
+        1. .Values.migrations.env
+        2. .Values.server.env
+        3. .Values.global.prefect.env
+
+      Iterates highest-precedence first and appends each entry only if its
+      name has not yet been seen, so the emitted list has unique names with
+      the highest-precedence value for each. Order within the output is
+      highest-precedence source first, which is semantically equivalent in
+      Kubernetes (env order does not affect resolution).
+*/ -}}
+{{- define "server.migrations.envVars" -}}
+{{- $sources := list .Values.migrations.env .Values.server.env .Values.global.prefect.env -}}
+{{- $seen := dict -}}
+{{- $merged := list -}}
+{{- range $source := $sources -}}
+  {{- range $entry := $source -}}
+    {{- if not (hasKey $seen $entry.name) -}}
+      {{- $_ := set $seen $entry.name true -}}
+      {{- $merged = append $merged $entry -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $merged -}}
+{{- include "common.tplvalues.render" (dict "value" $merged "context" $) }}
+{{- end -}}
+{{- end -}}
+
 {{/* ----- Connection string templates ------ */}}
 
 {{/*

--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -50,14 +50,8 @@ spec:
               key: connection-string
         - name: HOME
           value: /home/prefect
-        {{- if .Values.global.prefect.env }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.global.prefect.env "context" $) | nindent 8 }}
-        {{- end }}
-        {{- if .Values.server.env }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.server.env "context" $) | nindent 8 }}
-        {{- end }}
-        {{- if .Values.migrations.env }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.migrations.env "context" $) | nindent 8 }}
+        {{- with (include "server.migrations.envVars" . | trim) }}
+        {{- . | nindent 8 }}
         {{- end }}
         resources: {{- toYaml .Values.migrations.resources | nindent 10 }}
         securityContext: {{- toYaml .Values.migrations.securityContext | nindent 10 }}

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -325,3 +325,139 @@ tests:
             fsGroup: 1001
             runAsNonRoot: true
 
+  - it: migrations.env should override server.env for the same name without producing duplicates
+    set:
+      server:
+        env:
+          - name: PREFECT_API_DATABASE_TIMEOUT
+            value: "30"
+      migrations:
+        env:
+          - name: PREFECT_API_DATABASE_TIMEOUT
+            value: "120"
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_API_DATABASE_TIMEOUT
+            value: "120"
+          count: 1
+      - template: pre-upgrade-hook.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_API_DATABASE_TIMEOUT
+            value: "30"
+
+  - it: migrations.env should override global.prefect.env for the same name without producing duplicates
+    set:
+      global:
+        prefect:
+          env:
+            - name: SHARED_VAR
+              value: from_global
+      migrations:
+        env:
+          - name: SHARED_VAR
+            value: from_migrations
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: SHARED_VAR
+            value: from_migrations
+          count: 1
+      - template: pre-upgrade-hook.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: SHARED_VAR
+            value: from_global
+
+  - it: migrations.env should win when the same name is set in all three sources
+    set:
+      global:
+        prefect:
+          env:
+            - name: SHARED_VAR
+              value: from_global
+      server:
+        env:
+          - name: SHARED_VAR
+            value: from_server
+      migrations:
+        env:
+          - name: SHARED_VAR
+            value: from_migrations
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: SHARED_VAR
+            value: from_migrations
+          count: 1
+
+  - it: server.env should override global.prefect.env for the same name when migrations.env does not define it
+    set:
+      global:
+        prefect:
+          env:
+            - name: SHARED_VAR
+              value: from_global
+      server:
+        env:
+          - name: SHARED_VAR
+            value: from_server
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: SHARED_VAR
+            value: from_server
+          count: 1
+      - template: pre-upgrade-hook.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: SHARED_VAR
+            value: from_global
+
+  - it: should preserve distinct env vars from all three sources when names do not collide
+    set:
+      global:
+        prefect:
+          env:
+            - name: GLOBAL_ONLY
+              value: g
+      server:
+        env:
+          - name: SERVER_ONLY
+            value: s
+      migrations:
+        env:
+          - name: MIGRATIONS_ONLY
+            value: m
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ONLY
+            value: g
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: SERVER_ONLY
+            value: s
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: MIGRATIONS_ONLY
+            value: m
+

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -263,7 +263,7 @@ migrations:
   backoffLimit: 5
   # -- job restart policy
   restartPolicy: Never
-  # -- additional environment variables for the migration job
+  # -- additional environment variables for the migration job; takes precedence over entries of the same name in `global.prefect.env` and `server.env`
   env: []
   # -- additional volume mounts for the migration job
   extraVolumeMounts: []


### PR DESCRIPTION
### Summary

The migration Job concatenated env entries from `global.prefect.env`, `server.env`, and `migrations.env`, so setting the same variable in more than one source (e.g. a longer `PREFECT_API_DATABASE_TIMEOUT` for migrations only) produced duplicate entries in the Job spec. Kubernetes tolerated it, but validators and GitOps diffs flagged it as broken.

Merged the three sources in a helper with precedence `migrations.env` > `server.env` > `global.prefect.env`. Kept the fix scoped to the migration Job; the same concat pattern in `deployment.yaml` and `background-services/deployment.yaml` was left alone since the issue is specific to migrations and the blast radius on those templates is larger.

README churn beyond the `migrations.env` row is from running the pre-commit `helm-docs` hook, which caught existing drift between `values.yaml` comments and the generated README.

Closes #602

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes \`Closes <issue>\`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in \`templates/NOTES.txt\`
- [x] Relevant labels are added
- [x] \`Draft\` status is used until ready for review

<details>
<summary>Session context</summary>

Walked through the issue repro in #602, confirmed the root cause was plain list concatenation in `templates/pre-upgrade-hook.yaml`. Considered a dict-based dedupe but went with reverse-iteration-and-skip so output stays a plain list and no Sprig feature beyond `hasKey`/`set` is needed. Verified via `helm template` against the issue's exact values and via a new set of helm-unittest cases covering each pairwise and three-way override.

</details>