### PR TITLE
feat(prefect-server): use PREFECT_SERVER_DATABASE_* env vars

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -245,7 +245,7 @@ Database migrations are handled differently depending on your deployment mode.
 
 **Single deployment (default):** Prefect automatically runs database migrations on server startup. No additional configuration is needed because there is only one server process managing the database.
 
-**Separate deployment mode (`backgroundServices.runAsSeparateDeployment: true`):** The chart creates a dedicated Kubernetes Job as a Helm pre-upgrade/post-install hook to run migrations before the deployments start. This prevents multiple server processes (API server and background services) from racing to migrate the database simultaneously. Both deployments set `PREFECT_API_DATABASE_MIGRATE_ON_START=false` so that only the Job handles migrations.
+**Separate deployment mode (`backgroundServices.runAsSeparateDeployment: true`):** The chart creates a dedicated Kubernetes Job as a Helm pre-upgrade/post-install hook to run migrations before the deployments start. This prevents multiple server processes (API server and background services) from racing to migrate the database simultaneously. Both deployments set `PREFECT_SERVER_DATABASE_MIGRATE_ON_START=false` so that only the Job handles migrations.
 
 The migration Job will:
 
@@ -335,9 +335,9 @@ the HorizontalPodAutoscaler.
 | backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | backgroundServices.messaging.broker | string | `"prefect_redis.messaging"` | messaging broker class to use for background services |
 | backgroundServices.messaging.cache | string | `"prefect_redis.messaging"` | messaging cache class to use for background services |
-| backgroundServices.messaging.docket.existingSecret | string | `""` | name of an existing Kubernetes secret containing the Docket URL takes precedence over the url field above the secret should contain a key with the full Redis URL including any credentials |
+| backgroundServices.messaging.docket.existingSecret | string | `""` | name of an existing Kubernetes secret containing the Docket URL. Takes precedence over the url field above. The secret should contain a key with the full Redis URL including any credentials. |
 | backgroundServices.messaging.docket.existingSecretKey | string | `"docket-url"` | key within the existing secret that contains the Docket URL |
-| backgroundServices.messaging.docket.url | string | `""` | URL for the Docket scheduler backend examples: redis://host:6379/0, rediss://host:6379/0 (TLS), redis://user:pass@host:6379/0 leave empty to use the default in-memory backend (memory://) |
+| backgroundServices.messaging.docket.url | string | `""` | URL for the Docket scheduler backend. Examples: redis://host:6379/0, redis://host:6379/0 (TLS), redis://user:pass@host:6379/0. Leave empty to use the default in-memory backend (memory://). |
 | backgroundServices.messaging.redis | object | `{"db":0,"existingSecret":"","existingSecretPasswordKey":"redis-password","host":"","password":"","port":6379,"ssl":false,"username":""}` | settings for redis broker/cache change these if not using the built-in redis subchart |
 | backgroundServices.messaging.redis.db | int | `0` | redis database number |
 | backgroundServices.messaging.redis.existingSecret | string | `""` | name of an existing Kubernetes secret containing the redis password takes precedence over the password field above |
@@ -368,6 +368,7 @@ the HorizontalPodAutoscaler.
 | fullnameOverride | string | `"prefect-server"` | fully override common.names.fullname |
 | gateway.annotations | object | `{}` | additional annotations for the Gateway resource |
 | gateway.className | string | `""` | GatewayClass that will be used to implement the Gateway This must match an existing GatewayClass in your cluster |
+| gateway.create | bool | `true` | whether to create a Gateway resource or just the associated HTTPRoute (if enabled) Can be disabled if you want to create the Gateway manually (or is already present) and just have the chart create the HTTPRoute with the correct parentRefs |
 | gateway.enabled | bool | `false` | enable Gateway API resources (mutually exclusive with ingress) |
 | gateway.infrastructure | object | `{}` | infrastructure configuration for Gateway ref: https://gateway-api.sigs.k8s.io/guides/infrastructure/ |
 | gateway.labels | object | `{}` | additional labels for the Gateway resource |
@@ -392,7 +393,7 @@ the HorizontalPodAutoscaler.
 | global.prefect.image.pullSecrets | list | `[]` | prefect image pull secrets |
 | global.prefect.image.repository | string | `"prefecthq/prefect"` | prefect image repository |
 | httproute.annotations | object | `{}` | additional annotations for the HTTPRoute resource |
-| httproute.enabled | bool | `true` | enable HTTPRoute resource (auto-enabled when gateway.enabled=true) Can be disabled if you want to create HTTPRoutes manually |
+| httproute.enabled | bool | `true` | enable HTTPRoute resource (mutually exclusive with ingress, auto-enabled when gateway.enabled=true) Can be disabled if you want to create HTTPRoutes manually |
 | httproute.extraRules | list | `[]` | additional HTTPRoute rules (advanced usage) Will be merged with auto-generated rules |
 | httproute.hostnames | list | `[]` | hostnames that this HTTPRoute should match |
 | httproute.labels | object | `{}` | additional labels for the HTTPRoute resource |

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -244,7 +244,7 @@ Database migrations are handled differently depending on your deployment mode.
 
 **Single deployment (default):** Prefect automatically runs database migrations on server startup. No additional configuration is needed because there is only one server process managing the database.
 
-**Separate deployment mode (`backgroundServices.runAsSeparateDeployment: true`):** The chart creates a dedicated Kubernetes Job as a Helm pre-upgrade/post-install hook to run migrations before the deployments start. This prevents multiple server processes (API server and background services) from racing to migrate the database simultaneously. Both deployments set `PREFECT_API_DATABASE_MIGRATE_ON_START=false` so that only the Job handles migrations.
+**Separate deployment mode (`backgroundServices.runAsSeparateDeployment: true`):** The chart creates a dedicated Kubernetes Job as a Helm pre-upgrade/post-install hook to run migrations before the deployments start. This prevents multiple server processes (API server and background services) from racing to migrate the database simultaneously. Both deployments set `PREFECT_SERVER_DATABASE_MIGRATE_ON_START=false` so that only the Job handles migrations.
 
 The migration Job will:
 

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Make redis subchart context available as a variable in this block
       "Values"       .Values.redis
       "Chart"        (dict "Name" "redis")
 -}}
-- name: PREFECT_API_DATABASE_MIGRATE_ON_START
+- name: PREFECT_SERVER_DATABASE_MIGRATE_ON_START
   value: "false"
 - name: PREFECT_MESSAGING_BROKER
   value: {{ .Values.backgroundServices.messaging.broker }}

--- a/charts/prefect-server/templates/background-services/deployment.yaml
+++ b/charts/prefect-server/templates/background-services/deployment.yaml
@@ -85,7 +85,7 @@ spec:
               value: {{ .Values.backgroundServices.loggingLevel | quote }}
             - name: PREFECT_UI_ENABLED
               value: 'false'
-            - name: PREFECT_API_DATABASE_CONNECTION_URL
+            - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
               {{- if .Values.sqlite.enabled }}
               value: "sqlite+aiosqlite:////data/prefect.db"
               {{- else }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
               value: {{ .Values.server.uiConfig.prefectUiApiUrl | quote }}
             - name: PREFECT_UI_STATIC_DIRECTORY
               value: {{ .Values.server.uiConfig.prefectUiStaticDirectory | quote }}
-            - name: PREFECT_API_DATABASE_CONNECTION_URL
+            - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
               {{- if .Values.sqlite.enabled }}
               value: "sqlite+aiosqlite:////data/prefect.db"
               {{- else }}

--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -43,7 +43,7 @@ spec:
           echo "Starting database migration..."
           {{- tpl .Values.migrations.command . | nindent 10 }}
         env:
-        - name: PREFECT_API_DATABASE_CONNECTION_URL
+        - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
           valueFrom:
             secretKeyRef:
               name: {{ include "server.postgres-string-secret-name" . }}

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -521,7 +521,7 @@ tests:
       - contains:
           path: .spec.template.spec.containers[0].env
           content:
-            name: PREFECT_API_DATABASE_MIGRATE_ON_START
+            name: PREFECT_SERVER_DATABASE_MIGRATE_ON_START
             value: "false"
       - contains:
           path: .spec.template.spec.containers[0].env
@@ -595,7 +595,7 @@ tests:
       - contains:
           path: .spec.template.spec.containers[0].env
           content:
-            name: PREFECT_API_DATABASE_MIGRATE_ON_START
+            name: PREFECT_SERVER_DATABASE_MIGRATE_ON_START
             value: "false"
       - contains:
           path: .spec.template.spec.containers[0].env

--- a/charts/prefect-server/tests/database_test.yaml
+++ b/charts/prefect-server/tests/database_test.yaml
@@ -4,7 +4,7 @@ release:
   namespace: prefect
 
 # Anchors to reuse in the tests
-envSecretPath: &envSecretPath .spec.template.spec.containers[?(@.name == "prefect-server")].env[?(@.name == "PREFECT_API_DATABASE_CONNECTION_URL")].valueFrom.secretKeyRef.name
+envSecretPath: &envSecretPath .spec.template.spec.containers[?(@.name == "prefect-server")].env[?(@.name == "PREFECT_SERVER_DATABASE_CONNECTION_URL")].valueFrom.secretKeyRef.name
 defaultSecretName: &defaultSecretName prefect-server-postgresql-connection
 
 tests:
@@ -20,7 +20,7 @@ tests:
         contains:
           path: .spec.template.spec.containers[0].env
           content:
-            name: PREFECT_API_DATABASE_CONNECTION_URL
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
             value: sqlite+aiosqlite:////data/prefect.db
 
   - it: Should correctly configure SQLite storage settings

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -48,7 +48,7 @@ tests:
                   echo "Starting database migration..."
                   prefect server database upgrade -y
                 env:
-                - name: PREFECT_API_DATABASE_CONNECTION_URL
+                - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
                   valueFrom:
                     secretKeyRef:
                       name: pre-upgrade-hook-test-postgresql-connection


### PR DESCRIPTION
### Summary

Align the chart with the primary names documented in the [Prefect v3 settings reference](https://docs.prefect.io/v3/api-ref/settings-ref). `PREFECT_API_DATABASE_*` still works as an alias, so this is backward compatible for users overriding via `server.env`, `backgroundServices.env`, or `migrations.env`.

Renames cover both hardcoded env vars in templates:

- `PREFECT_API_DATABASE_CONNECTION_URL` → `PREFECT_SERVER_DATABASE_CONNECTION_URL` (server deployment, background-services deployment, pre-upgrade migration hook)
- `PREFECT_API_DATABASE_MIGRATE_ON_START` → `PREFECT_SERVER_DATABASE_MIGRATE_ON_START` (shared background-services helper)

Existing unit tests updated to assert on the new names; all 285 helm-unittest tests pass.

Closes #601

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

Confirmed against the Prefect v3 settings reference that both `PREFECT_SERVER_DATABASE_*` and `PREFECT_API_DATABASE_*` are listed as supported env vars for `connection_url`, `migrate_on_start`, and related settings (`driver`, `host`, `port`, `user`, `name`, `password`, `echo`, `timeout`, `connection_timeout`). The docs do not explicitly tag the `API` variants as deprecated, but `SERVER_*` is the primary/preferred naming. Only `CONNECTION_URL` and `MIGRATE_ON_START` are hardcoded in this chart, so no other renames were needed.

No `templates/NOTES.txt` deprecation note added — the rename has no user-visible effect since Prefect continues to honor both names, and user-provided env via `server.env` is untouched. Happy to add one if reviewers prefer.

</details>