### PR TITLE
feat: add extraInitContainers, lifecycle, and terminationGracePeriodSeconds to prefect-server

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -330,8 +330,10 @@ the HorizontalPodAutoscaler.
 | backgroundServices.extraContainers | list | `[]` | additional sidecar containers |
 | backgroundServices.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to background-services pod |
 | backgroundServices.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to background-services pod |
+| backgroundServices.extraInitContainers | list | `[]` | additional init containers for the background-services pod |
 | backgroundServices.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the background-services pod |
 | backgroundServices.extraVolumes | list | `[]` | array with extra volumes for the background-services pod |
+| backgroundServices.lifecycle | object | `{}` | lifecycle hooks for the background-services container |
 | backgroundServices.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | backgroundServices.messaging.broker | string | `"prefect_redis.messaging"` | messaging broker class to use for background services |
 | backgroundServices.messaging.cache | string | `"prefect_redis.messaging"` | messaging cache class to use for background services |
@@ -362,6 +364,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
 | backgroundServices.serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | backgroundServices.serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template with "-background-services" appended |
+| backgroundServices.terminationGracePeriodSeconds | string | `nil` | duration in seconds the background-services pod needs to terminate gracefully |
 | backgroundServices.tolerations | list | `[]` | tolerations for background-services pod assignment |
 | commonAnnotations | object | `{}` | annotations to add to all deployed objects |
 | commonLabels | object | `{}` | labels to add to all deployed objects |
@@ -482,8 +485,10 @@ the HorizontalPodAutoscaler.
 | server.extraContainers | list | `[]` | additional sidecar containers |
 | server.extraEnvVarsCM | string | `""` | name of existing ConfigMap containing extra env vars to add to server nodes |
 | server.extraEnvVarsSecret | string | `""` | name of existing Secret containing extra env vars to add to server nodes |
+| server.extraInitContainers | list | `[]` | additional init containers for the server pod |
 | server.extraVolumeMounts | list | `[]` | array with extra volumeMounts for the server pod |
 | server.extraVolumes | list | `[]` | array with extra volumes for the server pod |
+| server.lifecycle | object | `{}` | lifecycle hooks for the server container |
 | server.livenessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | server.livenessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |
 | server.livenessProbe.config.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |
@@ -509,6 +514,7 @@ the HorizontalPodAutoscaler.
 | server.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the server container |
 | server.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the server container |
 | server.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
+| server.terminationGracePeriodSeconds | string | `nil` | duration in seconds the server pod needs to terminate gracefully |
 | server.tolerations | list | `[]` | tolerations for server pods assignment |
 | server.uiConfig.prefectUiApiUrl | string | `"http://localhost:4200/api"` | sets PREFECT_UI_API_URL; If you want to connect to the UI from somewhere external to the cluster (i.e. via an ingress), you need to set this value to the ingress URL (e.g. http://app.internal.prefect.com/api). You can find additional documentation on this here - https://docs.prefect.io/v3/manage/self-host#ui |
 | server.uiConfig.prefectUiStaticDirectory | string | `"/ui_build"` | sets PREFECT_UI_STATIC_DIRECTORY |

--- a/charts/prefect-server/templates/background-services/deployment.yaml
+++ b/charts/prefect-server/templates/background-services/deployment.yaml
@@ -53,6 +53,13 @@ spec:
       {{- if .Values.backgroundServices.priorityClassName }}
       priorityClassName: {{ .Values.backgroundServices.priorityClassName }}
       {{- end }}
+      {{- with .Values.backgroundServices.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- if .Values.backgroundServices.extraInitContainers }}
+      initContainers:
+      {{- include "common.tplvalues.render" (dict "value" .Values.backgroundServices.extraInitContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: prefect-background-services
           image: "{{ .Values.global.prefect.image.repository }}:{{ .Values.global.prefect.image.prefectTag }}"
@@ -119,6 +126,9 @@ spec:
           {{- end }}
           {{- with .Values.backgroundServices.containerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backgroundServices.lifecycle }}
+          lifecycle: {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /home/prefect

--- a/charts/prefect-server/templates/background-services/deployment.yaml
+++ b/charts/prefect-server/templates/background-services/deployment.yaml
@@ -53,8 +53,8 @@ spec:
       {{- if .Values.backgroundServices.priorityClassName }}
       priorityClassName: {{ .Values.backgroundServices.priorityClassName }}
       {{- end }}
-      {{- with .Values.backgroundServices.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ . }}
+      {{- if not (kindIs "invalid" .Values.backgroundServices.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.backgroundServices.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if .Values.backgroundServices.extraInitContainers }}
       initContainers:

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -55,6 +55,13 @@ spec:
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName }}
       {{- end }}
+      {{- with .Values.server.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- if .Values.server.extraInitContainers }}
+      initContainers:
+      {{- include "common.tplvalues.render" (dict "value" .Values.server.extraInitContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: prefect-server
           image: "{{ .Values.global.prefect.image.repository }}:{{ .Values.global.prefect.image.prefectTag }}"
@@ -163,6 +170,9 @@ spec:
               path: {{ .Values.server.apiBasePath }}/ready
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.readinessProbe.config | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.lifecycle }}
+          lifecycle: {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /home/prefect

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -55,8 +55,8 @@ spec:
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName }}
       {{- end }}
-      {{- with .Values.server.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ . }}
+      {{- if not (kindIs "invalid" .Values.server.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if .Values.server.extraInitContainers }}
       initContainers:

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -109,6 +109,16 @@ tests:
           path: .spec.template.spec.terminationGracePeriodSeconds
           value: 180
 
+  - it: Should render terminationGracePeriodSeconds when explicitly set to 0
+    set:
+      backgroundServices:
+        terminationGracePeriodSeconds: 0
+    asserts:
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.template.spec.terminationGracePeriodSeconds
+          value: 0
+
   - it: Should not set lifecycle by default
     asserts:
       - template: background-services/deployment.yaml

--- a/charts/prefect-server/tests/background_services_test.yaml
+++ b/charts/prefect-server/tests/background_services_test.yaml
@@ -93,6 +93,41 @@ tests:
           path: .spec.template.spec.priorityClassName
           value: high-priority
 
+  - it: Should not set terminationGracePeriodSeconds by default
+    asserts:
+      - template: background-services/deployment.yaml
+        notExists:
+          path: .spec.template.spec.terminationGracePeriodSeconds
+
+  - it: Should set a custom terminationGracePeriodSeconds
+    set:
+      backgroundServices:
+        terminationGracePeriodSeconds: 180
+    asserts:
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.template.spec.terminationGracePeriodSeconds
+          value: 180
+
+  - it: Should not set lifecycle by default
+    asserts:
+      - template: background-services/deployment.yaml
+        notExists:
+          path: .spec.template.spec.containers[0].lifecycle
+
+  - it: Should set a custom lifecycle preStop hook
+    set:
+      backgroundServices:
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 30"]
+    asserts:
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 30"]
+
   - it: Should set the correct debug mode
     asserts:
       - template: background-services/deployment.yaml
@@ -391,6 +426,29 @@ tests:
         equal:
           path: .spec.template.spec.containers[1].name
           value: sidecar
+
+  - it: Should not set initContainers by default
+    asserts:
+      - template: background-services/deployment.yaml
+        notExists:
+          path: .spec.template.spec.initContainers
+
+  - it: Should set extra init containers as native sidecars
+    set:
+      backgroundServices:
+        extraInitContainers:
+          - name: redis-proxy
+            image: my-redis-proxy:latest
+            restartPolicy: Always
+    asserts:
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].name
+          value: redis-proxy
+      - template: background-services/deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].restartPolicy
+          value: Always
 
   - it: Should set extra volumes
     set:

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -104,6 +104,41 @@ tests:
           path: .spec.template.spec.priorityClassName
           value: high-priority
 
+  - it: Should not set terminationGracePeriodSeconds by default
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.terminationGracePeriodSeconds
+
+  - it: Should set a custom terminationGracePeriodSeconds
+    set:
+      server:
+        terminationGracePeriodSeconds: 120
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.terminationGracePeriodSeconds
+          value: 120
+
+  - it: Should not set lifecycle by default
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.containers[0].lifecycle
+
+  - it: Should set a custom lifecycle preStop hook
+    set:
+      server:
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 15"]
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 15"]
+
   - it: Should set the correct debug mode
     asserts:
       - template: deployment.yaml
@@ -524,6 +559,29 @@ tests:
         equal:
           path: .spec.template.spec.containers[1].name
           value: sidecar
+
+  - it: Should not set initContainers by default
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.spec.initContainers
+
+  - it: Should set extra init containers as native sidecars
+    set:
+      server:
+        extraInitContainers:
+          - name: redis-proxy
+            image: my-redis-proxy:latest
+            restartPolicy: Always
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].name
+          value: redis-proxy
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.initContainers[0].restartPolicy
+          value: Always
 
   - it: Should set extra volumes
     set:

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -120,6 +120,16 @@ tests:
           path: .spec.template.spec.terminationGracePeriodSeconds
           value: 120
 
+  - it: Should render terminationGracePeriodSeconds when explicitly set to 0
+    set:
+      server:
+        terminationGracePeriodSeconds: 0
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.terminationGracePeriodSeconds
+          value: 0
+
   - it: Should not set lifecycle by default
     asserts:
       - template: deployment.yaml

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -759,7 +759,7 @@
         "extraInitContainers": {
           "type": "array",
           "title": "Extra Init Containers",
-          "description": "additional init containers for the server pod",
+          "description": "additional init containers for the server pod (use `restartPolicy: Always` for native sidecars)",
           "items": {
             "type": "object"
           }

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -808,11 +808,13 @@
         },
         "terminationGracePeriodSeconds": {
           "type": ["integer", "null"],
+          "title": "Termination Grace Period Seconds",
           "description": "duration in seconds the background-services pod needs to terminate gracefully",
           "minimum": 0
         },
         "lifecycle": {
           "type": "object",
+          "title": "Lifecycle",
           "description": "lifecycle hooks for the background-services container"
         },
         "debug": {

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -307,6 +307,17 @@
           "title": "Priority Class Name",
           "description": "priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class"
         },
+        "terminationGracePeriodSeconds": {
+          "type": ["integer", "null"],
+          "title": "Termination Grace Period Seconds",
+          "description": "duration in seconds the server pod needs to terminate gracefully",
+          "minimum": 0
+        },
+        "lifecycle": {
+          "type": "object",
+          "title": "Lifecycle",
+          "description": "lifecycle hooks for the server container"
+        },
         "apiBasePath": {
           "type": "string",
           "title": "API Base Path",
@@ -745,6 +756,14 @@
             "type": "object"
           }
         },
+        "extraInitContainers": {
+          "type": "array",
+          "title": "Extra Init Containers",
+          "description": "additional init containers for the server pod",
+          "items": {
+            "type": "object"
+          }
+        },
         "extraVolumes": {
           "type": "array",
           "title": "Extra Volumes",
@@ -786,6 +805,15 @@
         "priorityClassName": {
           "type": "string",
           "description": "priority class name to use for the background-services pods"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": ["integer", "null"],
+          "description": "duration in seconds the background-services pod needs to terminate gracefully",
+          "minimum": 0
+        },
+        "lifecycle": {
+          "type": "object",
+          "description": "lifecycle hooks for the background-services container"
         },
         "debug": {
           "type": "boolean",
@@ -920,6 +948,11 @@
         "extraEnvVarsCM": { "type": "string" },
         "extraEnvVarsSecret": { "type": "string" },
         "extraContainers": { "type": "array" },
+        "extraInitContainers": {
+          "type": "array",
+          "description": "additional init containers for the background-services pod (use `restartPolicy: Always` for native sidecars)",
+          "items": { "type": "object" }
+        },
         "extraVolumes": { "type": "array" },
         "extraVolumeMounts": { "type": "array" },
         "serviceAccount": {

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -53,6 +53,14 @@ server:
   # -- priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class
   priorityClassName: ""
 
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  # -- duration in seconds the server pod needs to terminate gracefully. Increase if Prefect needs more time to drain in-flight requests or close connections to backing services (e.g. Redis, Postgres) before SIGKILL. Leave null to use Kubernetes' default (30s).
+  terminationGracePeriodSeconds: null
+
+  # ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  # -- lifecycle hooks for the server container. A common use case is a `preStop` sleep so the kube-proxy/load-balancer endpoints deregister before the server starts shutting down.
+  lifecycle: {}
+
   # ref: https://docs.prefect.io/v3/develop/settings-ref#base-path
   # -- sets PREFECT_SERVER_API_BASE_PATH
   apiBasePath: "/api"
@@ -211,6 +219,10 @@ server:
   # -- additional sidecar containers
   extraContainers: []
 
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  # -- additional init containers for the server pod. Set `restartPolicy: Always` on an entry to use the native sidecar pattern (Kubernetes 1.29+), which guarantees the sidecar starts before, and is terminated after, the main container — useful for connection proxies (e.g. redis-iam-proxy, cloud-sql-proxy) so the main container can drain its connections cleanly during shutdown.
+  extraInitContainers: []
+
   # -- array with extra volumes for the server pod
   extraVolumes: []
 
@@ -299,6 +311,14 @@ backgroundServices:
   # -- priority class name to use for the background-services pods; if the priority class is empty or doesn't exist, the background-services pods are scheduled without a priority class
   priorityClassName: ""
 
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  # -- duration in seconds the background-services pod needs to terminate gracefully. Increase if background services need more time to finish in-flight work or close connections to backing services (e.g. Redis, Postgres) before SIGKILL. Leave null to use Kubernetes' default (30s).
+  terminationGracePeriodSeconds: null
+
+  # ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  # -- lifecycle hooks for the background-services container. Useful for adding a `preStop` hook that gives the worker time to wind down before SIGTERM.
+  lifecycle: {}
+
   # ref: https://docs.prefect.io/v3/develop/settings-ref#debug-mode
   # -- sets PREFECT_DEBUG_MODE
   debug: false
@@ -385,6 +405,10 @@ backgroundServices:
 
   # -- additional sidecar containers
   extraContainers: []
+
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  # -- additional init containers for the background-services pod. Set `restartPolicy: Always` on an entry to use the native sidecar pattern (Kubernetes 1.29+), which guarantees the sidecar starts before, and is terminated after, the main container — useful for connection proxies (e.g. redis-iam-proxy, cloud-sql-proxy) so background services can drain their connections cleanly during shutdown.
+  extraInitContainers: []
 
   # -- array with extra volumes for the background-services pod
   extraVolumes: []


### PR DESCRIPTION
### Summary

This change adds `extraInitContainers`, `lifecycle`, and `terminationGracePeriodSeconds` to the prefect-server helm chart, for the server and background services.

In my case, this is helpful because we run a small proxy sidecar that injects auth to our redis connections, and when using it with `extraContainers`, it responds to the SIGTERM much faster than the prefect server does, leading to ~30s-1min of errors. Using `extraInitContainers` along with `restartPolicy: Always` should fix this.

Thanks for taking a look!

### Requirements

- [X] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [X] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [X] Added/modified configuration includes a descriptive comment for documentation generation
- [X] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [X] `Draft` status is used until ready for review
