### PR TITLE
feat(prefect-server): support database URL components

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -398,7 +398,7 @@ the HorizontalPodAutoscaler.
 | commonLabels | object | `{}` | labels to add to all deployed objects |
 | externalDatabase.connectionString | string | `""` | literal database connection URL. Takes precedence over component settings |
 | externalDatabase.connectionStringSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the full database connection URL |
-| externalDatabase.driver | string | `"postgresql+asyncpg"` | database driver used when composing a connection URL from components |
+| externalDatabase.driver | string | `""` | database driver used when composing a connection URL from components (e.g. `postgresql+asyncpg`) |
 | externalDatabase.driverSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database driver |
 | externalDatabase.existingSecret | string | `""` | name of an existing Secret to read database settings from |
 | externalDatabase.host | string | `""` | database host used when composing a connection URL from components |
@@ -407,7 +407,7 @@ the HorizontalPodAutoscaler.
 | externalDatabase.nameSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database name |
 | externalDatabase.password | string | `""` | database password used when composing a connection URL from components |
 | externalDatabase.passwordSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database password |
-| externalDatabase.port | string | `"5432"` | database port used when composing a connection URL from components |
+| externalDatabase.port | string | `""` | database port used when composing a connection URL from components (e.g. `5432`) |
 | externalDatabase.portSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database port |
 | externalDatabase.username | string | `""` | database username used when composing a connection URL from components |
 | externalDatabase.usernameSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database username |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -185,9 +185,7 @@ Two secrets are created when not providing an existing secret name:
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 
-The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
-
-Database connection configuration is applied in this order:
+The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`. Database connection configuration is applied in this order:
 
 1. `sqlite.enabled=true` uses the embedded SQLite database.
 2. `externalDatabase.connectionString` uses a literal external database connection URL.

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -185,6 +185,16 @@ Two secrets are created when not providing an existing secret name:
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 
+The `database` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
+
+Database connection configuration is applied in this order:
+
+1. `sqlite.enabled=true` uses the embedded SQLite database.
+2. `database.connectionString` uses a literal external database connection URL.
+3. `database.existingSecret` with `database.connectionStringSecretKey` reads a full external database connection URL from an existing Secret.
+4. `database` component fields and Secret keys compose an external database connection URL from driver, username, password, host, port, and name.
+5. Existing `secret`/`postgresql` behavior is used when none of the above `database` options are set.
+
 ```yaml
 postgresql:
   enabled: false

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -183,9 +183,9 @@ Two secrets are created when not providing an existing secret name:
 
 #### Using an external instance of PostgreSQL
 
-If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
+If you want to disable the bundled PostgreSQL chart and use an external instance, use the `externalDatabase` block. It is only for external databases; for databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
 
-The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`. Database connection configuration is applied in this order:
+Database connection configuration is applied in this order:
 
 1. `sqlite.enabled=true` uses the embedded SQLite database.
 2. `externalDatabase.connectionString` uses a literal external database connection URL.

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -185,15 +185,15 @@ Two secrets are created when not providing an existing secret name:
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 
-The `database` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
+The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
 
 Database connection configuration is applied in this order:
 
 1. `sqlite.enabled=true` uses the embedded SQLite database.
-2. `database.connectionString` uses a literal external database connection URL.
-3. `database.existingSecret` with `database.connectionStringSecretKey` reads a full external database connection URL from an existing Secret.
-4. `database` component fields and Secret keys compose an external database connection URL from driver, username, password, host, port, and name.
-5. Existing `secret`/`postgresql` behavior is used when none of the above `database` options are set.
+2. `externalDatabase.connectionString` uses a literal external database connection URL.
+3. `externalDatabase.existingSecret` with `externalDatabase.connectionStringSecretKey` reads a full external database connection URL from an existing Secret.
+4. `externalDatabase` component fields and Secret keys compose an external database connection URL from driver, username, password, host, port, and name.
+5. Existing `secret`/`postgresql` behavior is used when none of the above `externalDatabase` options are set.
 
 ```yaml
 postgresql:
@@ -213,13 +213,13 @@ secret:
   database: mydb
 ```
 
-If your external database credentials are split across Secret keys and values, use the `database` block instead. This is useful for operators that create immutable credential Secrets, such as the Zalando Postgres Operator.
+If your external database credentials are split across Secret keys and values, use the `externalDatabase` block instead. This is useful for operators that create immutable credential Secrets, such as the Zalando Postgres Operator.
 
 ```yaml
 postgresql:
   enabled: false
 
-database:
+externalDatabase:
   existingSecret: user.clustername.credentials.postgresql.acid.zalan.do
   driver: postgresql+asyncpg
   usernameSecretKey: username
@@ -229,7 +229,7 @@ database:
   name: prefect
 ```
 
-When `database.connectionString` or `database.connectionStringSecretKey` is set, that full connection string takes precedence over the component settings.
+When `externalDatabase.connectionString` or `externalDatabase.connectionStringSecretKey` is set, that full connection string takes precedence over the component settings.
 
 ### Connecting with SSL configured
 
@@ -396,21 +396,21 @@ the HorizontalPodAutoscaler.
 | backgroundServices.tolerations | list | `[]` | tolerations for background-services pod assignment |
 | commonAnnotations | object | `{}` | annotations to add to all deployed objects |
 | commonLabels | object | `{}` | labels to add to all deployed objects |
-| database.connectionString | string | `""` | literal database connection URL. Takes precedence over component settings |
-| database.connectionStringSecretKey | string | `""` | key in `database.existingSecret` containing the full database connection URL |
-| database.driver | string | `"postgresql+asyncpg"` | database driver used when composing a connection URL from components |
-| database.driverSecretKey | string | `""` | key in `database.existingSecret` containing the database driver |
-| database.existingSecret | string | `""` | name of an existing Secret to read database settings from |
-| database.host | string | `""` | database host used when composing a connection URL from components |
-| database.hostSecretKey | string | `""` | key in `database.existingSecret` containing the database host |
-| database.name | string | `""` | database name used when composing a connection URL from components |
-| database.nameSecretKey | string | `""` | key in `database.existingSecret` containing the database name |
-| database.password | string | `""` | database password used when composing a connection URL from components |
-| database.passwordSecretKey | string | `""` | key in `database.existingSecret` containing the database password |
-| database.port | string | `"5432"` | database port used when composing a connection URL from components |
-| database.portSecretKey | string | `""` | key in `database.existingSecret` containing the database port |
-| database.username | string | `""` | database username used when composing a connection URL from components |
-| database.usernameSecretKey | string | `""` | key in `database.existingSecret` containing the database username |
+| externalDatabase.connectionString | string | `""` | literal database connection URL. Takes precedence over component settings |
+| externalDatabase.connectionStringSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the full database connection URL |
+| externalDatabase.driver | string | `"postgresql+asyncpg"` | database driver used when composing a connection URL from components |
+| externalDatabase.driverSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database driver |
+| externalDatabase.existingSecret | string | `""` | name of an existing Secret to read database settings from |
+| externalDatabase.host | string | `""` | database host used when composing a connection URL from components |
+| externalDatabase.hostSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database host |
+| externalDatabase.name | string | `""` | database name used when composing a connection URL from components |
+| externalDatabase.nameSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database name |
+| externalDatabase.password | string | `""` | database password used when composing a connection URL from components |
+| externalDatabase.passwordSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database password |
+| externalDatabase.port | string | `"5432"` | database port used when composing a connection URL from components |
+| externalDatabase.portSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database port |
+| externalDatabase.username | string | `""` | database username used when composing a connection URL from components |
+| externalDatabase.usernameSecretKey | string | `""` | key in `externalDatabase.existingSecret` containing the database username |
 | fullnameOverride | string | `"prefect-server"` | fully override common.names.fullname |
 | gateway.annotations | object | `{}` | additional annotations for the Gateway resource |
 | gateway.className | string | `""` | GatewayClass that will be used to implement the Gateway This must match an existing GatewayClass in your cluster |

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -203,6 +203,24 @@ secret:
   database: mydb
 ```
 
+If your external database credentials are split across Secret keys and values, use the `database` block instead. This is useful for operators that create immutable credential Secrets, such as the Zalando Postgres Operator.
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  existingSecret: user.clustername.credentials.postgresql.acid.zalan.do
+  driver: postgresql+asyncpg
+  usernameSecretKey: username
+  passwordSecretKey: password
+  host: postgres.internal.svc.cluster.local
+  port: "5432"
+  name: prefect
+```
+
+When `database.connectionString` or `database.connectionStringSecretKey` is set, that full connection string takes precedence over the component settings.
+
 ### Connecting with SSL configured
 
 1. Mount the relevant certificate to `/home/prefect/.postgresql` so that it can be found by `asyncpg`. This is the default location postgresql expects per their [documentation](https://www.postgresql.org/docs/current/libpq-ssl.html).
@@ -368,6 +386,21 @@ the HorizontalPodAutoscaler.
 | backgroundServices.tolerations | list | `[]` | tolerations for background-services pod assignment |
 | commonAnnotations | object | `{}` | annotations to add to all deployed objects |
 | commonLabels | object | `{}` | labels to add to all deployed objects |
+| database.connectionString | string | `""` | literal database connection URL. Takes precedence over component settings |
+| database.connectionStringSecretKey | string | `""` | key in `database.existingSecret` containing the full database connection URL |
+| database.driver | string | `"postgresql+asyncpg"` | database driver used when composing a connection URL from components |
+| database.driverSecretKey | string | `""` | key in `database.existingSecret` containing the database driver |
+| database.existingSecret | string | `""` | name of an existing Secret to read database settings from |
+| database.host | string | `""` | database host used when composing a connection URL from components |
+| database.hostSecretKey | string | `""` | key in `database.existingSecret` containing the database host |
+| database.name | string | `""` | database name used when composing a connection URL from components |
+| database.nameSecretKey | string | `""` | key in `database.existingSecret` containing the database name |
+| database.password | string | `""` | database password used when composing a connection URL from components |
+| database.passwordSecretKey | string | `""` | key in `database.existingSecret` containing the database password |
+| database.port | string | `"5432"` | database port used when composing a connection URL from components |
+| database.portSecretKey | string | `""` | key in `database.existingSecret` containing the database port |
+| database.username | string | `""` | database username used when composing a connection URL from components |
+| database.usernameSecretKey | string | `""` | key in `database.existingSecret` containing the database username |
 | fullnameOverride | string | `"prefect-server"` | fully override common.names.fullname |
 | gateway.annotations | object | `{}` | additional annotations for the Gateway resource |
 | gateway.className | string | `""` | GatewayClass that will be used to implement the Gateway This must match an existing GatewayClass in your cluster |

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -182,9 +182,9 @@ Two secrets are created when not providing an existing secret name:
 
 #### Using an external instance of PostgreSQL
 
-If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
+If you want to disable the bundled PostgreSQL chart and use an external instance, use the `externalDatabase` block. It is only for external databases; for databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
 
-The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`. Database connection configuration is applied in this order:
+Database connection configuration is applied in this order:
 
 1. `sqlite.enabled=true` uses the embedded SQLite database.
 2. `externalDatabase.connectionString` uses a literal external database connection URL.

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -184,15 +184,15 @@ Two secrets are created when not providing an existing secret name:
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 
-The `database` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
+The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
 
 Database connection configuration is applied in this order:
 
 1. `sqlite.enabled=true` uses the embedded SQLite database.
-2. `database.connectionString` uses a literal external database connection URL.
-3. `database.existingSecret` with `database.connectionStringSecretKey` reads a full external database connection URL from an existing Secret.
-4. `database` component fields and Secret keys compose an external database connection URL from driver, username, password, host, port, and name.
-5. Existing `secret`/`postgresql` behavior is used when none of the above `database` options are set.
+2. `externalDatabase.connectionString` uses a literal external database connection URL.
+3. `externalDatabase.existingSecret` with `externalDatabase.connectionStringSecretKey` reads a full external database connection URL from an existing Secret.
+4. `externalDatabase` component fields and Secret keys compose an external database connection URL from driver, username, password, host, port, and name.
+5. Existing `secret`/`postgresql` behavior is used when none of the above `externalDatabase` options are set.
 
 ```yaml
 postgresql:
@@ -212,13 +212,13 @@ secret:
   database: mydb
 ```
 
-If your external database credentials are split across Secret keys and values, use the `database` block instead. This is useful for operators that create immutable credential Secrets, such as the Zalando Postgres Operator.
+If your external database credentials are split across Secret keys and values, use the `externalDatabase` block instead. This is useful for operators that create immutable credential Secrets, such as the Zalando Postgres Operator.
 
 ```yaml
 postgresql:
   enabled: false
 
-database:
+externalDatabase:
   existingSecret: user.clustername.credentials.postgresql.acid.zalan.do
   driver: postgresql+asyncpg
   usernameSecretKey: username
@@ -228,7 +228,7 @@ database:
   name: prefect
 ```
 
-When `database.connectionString` or `database.connectionStringSecretKey` is set, that full connection string takes precedence over the component settings.
+When `externalDatabase.connectionString` or `externalDatabase.connectionStringSecretKey` is set, that full connection string takes precedence over the component settings.
 
 ### Connecting with SSL configured
 

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -202,6 +202,24 @@ secret:
   database: mydb
 ```
 
+If your external database credentials are split across Secret keys and values, use the `database` block instead. This is useful for operators that create immutable credential Secrets, such as the Zalando Postgres Operator.
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  existingSecret: user.clustername.credentials.postgresql.acid.zalan.do
+  driver: postgresql+asyncpg
+  usernameSecretKey: username
+  passwordSecretKey: password
+  host: postgres.internal.svc.cluster.local
+  port: "5432"
+  name: prefect
+```
+
+When `database.connectionString` or `database.connectionStringSecretKey` is set, that full connection string takes precedence over the component settings.
+
 ### Connecting with SSL configured
 
 1. Mount the relevant certificate to `/home/prefect/.postgresql` so that it can be found by `asyncpg`. This is the default location postgresql expects per their [documentation](https://www.postgresql.org/docs/current/libpq-ssl.html).

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -184,6 +184,16 @@ Two secrets are created when not providing an existing secret name:
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 
+The `database` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
+
+Database connection configuration is applied in this order:
+
+1. `sqlite.enabled=true` uses the embedded SQLite database.
+2. `database.connectionString` uses a literal external database connection URL.
+3. `database.existingSecret` with `database.connectionStringSecretKey` reads a full external database connection URL from an existing Secret.
+4. `database` component fields and Secret keys compose an external database connection URL from driver, username, password, host, port, and name.
+5. Existing `secret`/`postgresql` behavior is used when none of the above `database` options are set.
+
 ```yaml
 postgresql:
   enabled: false

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -184,9 +184,7 @@ Two secrets are created when not providing an existing secret name:
 
 If you want to disable the bundled PostgreSQL chart and use an external instance, provide the following configuration:
 
-The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`.
-
-Database connection configuration is applied in this order:
+The `externalDatabase` block is only for external databases. For databases managed by this chart, continue to configure the bundled PostgreSQL chart with `postgresql` or the embedded SQLite database with `sqlite`. Database connection configuration is applied in this order:
 
 1. `sqlite.enabled=true` uses the embedded SQLite database.
 2. `externalDatabase.connectionString` uses a literal external database connection URL.

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -251,7 +251,7 @@ Priority:
     Returns true when the new database component configuration is in use.
 */}}
 {{- define "server.database-has-component-config" -}}
-{{- $db := .Values.database | default dict -}}
+{{- $db := .Values.externalDatabase | default dict -}}
 {{- if or $db.username $db.usernameSecretKey $db.password $db.passwordSecretKey $db.host $db.hostSecretKey $db.name $db.nameSecretKey $db.driverSecretKey $db.portSecretKey -}}
 true
 {{- end -}}
@@ -262,8 +262,8 @@ true
     Returns the Secret name for database settings loaded from secret keys.
 */}}
 {{- define "server.database-secret-name" -}}
-{{- $db := .Values.database | default dict -}}
-{{- $db.existingSecret | required ".Values.database.existingSecret is required when using database secret keys." -}}
+{{- $db := .Values.externalDatabase | default dict -}}
+{{- $db.existingSecret | required ".Values.externalDatabase.existingSecret is required when using database secret keys." -}}
 {{- end -}}
 
 {{/*
@@ -282,7 +282,7 @@ true
       name: {{ include "server.database-secret-name" $ctx }}
       key: {{ $secretKey }}
   {{- else }}
-  value: {{ $value | required (printf ".Values.database.%s or .Values.database.%sSecretKey is required." .field .field) | toString | quote }}
+  value: {{ $value | required (printf ".Values.externalDatabase.%s or .Values.externalDatabase.%sSecretKey is required." .field .field) | toString | quote }}
   {{- end }}
 {{- end -}}
 
@@ -294,7 +294,7 @@ true
 {{- if .secretKey -}}
 {{- printf "$(%s)" .envName -}}
 {{- else -}}
-{{- .value | required (printf ".Values.database.%s or .Values.database.%sSecretKey is required." .field .field) | toString -}}
+{{- .value | required (printf ".Values.externalDatabase.%s or .Values.externalDatabase.%sSecretKey is required." .field .field) | toString -}}
 {{- end -}}
 {{- end -}}
 
@@ -303,7 +303,7 @@ true
     Renders database component env vars and composes the Prefect connection URL.
 */}}
 {{- define "server.database-component-env" -}}
-{{- $db := .Values.database | default dict -}}
+{{- $db := .Values.externalDatabase | default dict -}}
 {{- $driver := $db.driver | default "postgresql+asyncpg" -}}
 {{- $port := $db.port | default "5432" -}}
 {{- $driverRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_DRIVER" "field" "driver" "value" $driver "secretKey" $db.driverSecretKey) -}}
@@ -327,7 +327,7 @@ true
     Renders database env vars for server, background services, and migrations.
 */}}
 {{- define "server.database-env" -}}
-{{- $db := .Values.database | default dict -}}
+{{- $db := .Values.externalDatabase | default dict -}}
 {{- if .Values.sqlite.enabled }}
 - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
   value: "sqlite+aiosqlite:////data/prefect.db"

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -246,6 +246,111 @@ Priority:
 {{- end -}}
 {{- end -}}
 
+{{/*
+  server.database-has-component-config:
+    Returns true when the new database component configuration is in use.
+*/}}
+{{- define "server.database-has-component-config" -}}
+{{- $db := .Values.database | default dict -}}
+{{- if or $db.username $db.usernameSecretKey $db.password $db.passwordSecretKey $db.host $db.hostSecretKey $db.name $db.nameSecretKey $db.driverSecretKey $db.portSecretKey -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+  server.database-secret-name:
+    Returns the Secret name for database settings loaded from secret keys.
+*/}}
+{{- define "server.database-secret-name" -}}
+{{- $db := .Values.database | default dict -}}
+{{- $db.existingSecret | required ".Values.database.existingSecret is required when using database secret keys." -}}
+{{- end -}}
+
+{{/*
+  server.database-env-var:
+    Renders one database environment variable from a literal value or a Secret key.
+*/}}
+{{- define "server.database-env-var" -}}
+{{- $ctx := .context -}}
+{{- $name := .name -}}
+{{- $value := .value -}}
+{{- $secretKey := .secretKey -}}
+- name: {{ $name }}
+  {{- if $secretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "server.database-secret-name" $ctx }}
+      key: {{ $secretKey }}
+  {{- else }}
+  value: {{ $value | required (printf ".Values.database.%s or .Values.database.%sSecretKey is required." .field .field) | toString | quote }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+  server.database-component-ref:
+    Returns either the literal component value or a Kubernetes env expansion.
+*/}}
+{{- define "server.database-component-ref" -}}
+{{- if .secretKey -}}
+{{- printf "$(%s)" .envName -}}
+{{- else -}}
+{{- .value | required (printf ".Values.database.%s or .Values.database.%sSecretKey is required." .field .field) | toString -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  server.database-component-env:
+    Renders database component env vars and composes the Prefect connection URL.
+*/}}
+{{- define "server.database-component-env" -}}
+{{- $db := .Values.database | default dict -}}
+{{- $driver := $db.driver | default "postgresql+asyncpg" -}}
+{{- $port := $db.port | default "5432" -}}
+{{- $driverRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_DRIVER" "field" "driver" "value" $driver "secretKey" $db.driverSecretKey) -}}
+{{- $usernameRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_USER" "field" "username" "value" $db.username "secretKey" $db.usernameSecretKey) -}}
+{{- $passwordRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_PASSWORD" "field" "password" "value" $db.password "secretKey" $db.passwordSecretKey) -}}
+{{- $hostRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_HOST" "field" "host" "value" $db.host "secretKey" $db.hostSecretKey) -}}
+{{- $portRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_PORT" "field" "port" "value" $port "secretKey" $db.portSecretKey) -}}
+{{- $nameRef := include "server.database-component-ref" (dict "envName" "PREFECT_SERVER_DATABASE_NAME" "field" "name" "value" $db.name "secretKey" $db.nameSecretKey) -}}
+{{- include "server.database-env-var" (dict "context" . "name" "PREFECT_SERVER_DATABASE_DRIVER" "field" "driver" "value" $driver "secretKey" $db.driverSecretKey) }}
+{{ include "server.database-env-var" (dict "context" . "name" "PREFECT_SERVER_DATABASE_USER" "field" "username" "value" $db.username "secretKey" $db.usernameSecretKey) }}
+{{ include "server.database-env-var" (dict "context" . "name" "PREFECT_SERVER_DATABASE_PASSWORD" "field" "password" "value" $db.password "secretKey" $db.passwordSecretKey) }}
+{{ include "server.database-env-var" (dict "context" . "name" "PREFECT_SERVER_DATABASE_HOST" "field" "host" "value" $db.host "secretKey" $db.hostSecretKey) }}
+{{ include "server.database-env-var" (dict "context" . "name" "PREFECT_SERVER_DATABASE_PORT" "field" "port" "value" $port "secretKey" $db.portSecretKey) }}
+{{ include "server.database-env-var" (dict "context" . "name" "PREFECT_SERVER_DATABASE_NAME" "field" "name" "value" $db.name "secretKey" $db.nameSecretKey) }}
+- name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+  value: {{ printf "%s://%s:%s@%s:%s/%s" $driverRef $usernameRef $passwordRef $hostRef $portRef $nameRef | quote }}
+{{- end -}}
+
+{{/*
+  server.database-env:
+    Renders database env vars for server, background services, and migrations.
+*/}}
+{{- define "server.database-env" -}}
+{{- $db := .Values.database | default dict -}}
+{{- if .Values.sqlite.enabled }}
+- name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+  value: "sqlite+aiosqlite:////data/prefect.db"
+{{- else if $db.connectionString }}
+- name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+  value: {{ $db.connectionString | quote }}
+{{- else if $db.connectionStringSecretKey }}
+- name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "server.database-secret-name" . }}
+      key: {{ $db.connectionStringSecretKey }}
+{{- else if include "server.database-has-component-config" . }}
+{{- include "server.database-component-env" . }}
+{{- else }}
+- name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "server.postgres-string-secret-name" . }}
+      key: connection-string
+{{- end -}}
+{{- end -}}
+
 {{/* ----- End connection string templates ----- */}}
 
 {{- define "server.uiUrl" -}}

--- a/charts/prefect-server/templates/_helpers.tpl
+++ b/charts/prefect-server/templates/_helpers.tpl
@@ -252,7 +252,7 @@ Priority:
 */}}
 {{- define "server.database-has-component-config" -}}
 {{- $db := .Values.externalDatabase | default dict -}}
-{{- if or $db.username $db.usernameSecretKey $db.password $db.passwordSecretKey $db.host $db.hostSecretKey $db.name $db.nameSecretKey $db.driverSecretKey $db.portSecretKey -}}
+{{- if or $db.driver $db.driverSecretKey $db.username $db.usernameSecretKey $db.password $db.passwordSecretKey $db.host $db.hostSecretKey $db.port $db.portSecretKey $db.name $db.nameSecretKey -}}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/prefect-server/templates/background-services/deployment.yaml
+++ b/charts/prefect-server/templates/background-services/deployment.yaml
@@ -92,15 +92,7 @@ spec:
               value: {{ .Values.backgroundServices.loggingLevel | quote }}
             - name: PREFECT_UI_ENABLED
               value: 'false'
-            - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
-              {{- if .Values.sqlite.enabled }}
-              value: "sqlite+aiosqlite:////data/prefect.db"
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "server.postgres-string-secret-name" . }}
-                  key: connection-string
-              {{- end -}}
+            {{- include "server.database-env" . | nindent 12 }}
             {{- if .Values.backgroundServices.runAsSeparateDeployment }}
             {{- include "backgroundServices.envVars" . | nindent 12 }}
             {{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -111,15 +111,7 @@ spec:
               value: {{ .Values.server.uiConfig.prefectUiApiUrl | quote }}
             - name: PREFECT_UI_STATIC_DIRECTORY
               value: {{ .Values.server.uiConfig.prefectUiStaticDirectory | quote }}
-            - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
-              {{- if .Values.sqlite.enabled }}
-              value: "sqlite+aiosqlite:////data/prefect.db"
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "server.postgres-string-secret-name" . }}
-                  key: connection-string
-              {{- end }}
+            {{- include "server.database-env" . | nindent 12 }}
             {{- if .Values.server.basicAuth.enabled }}
             - name: PREFECT_SERVER_API_AUTH_STRING
             {{- if .Values.server.basicAuth.existingSecret }}

--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -43,11 +43,7 @@ spec:
           echo "Starting database migration..."
           {{- tpl .Values.migrations.command . | nindent 10 }}
         env:
-        - name: PREFECT_SERVER_DATABASE_CONNECTION_URL
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "server.postgres-string-secret-name" . }}
-              key: connection-string
+        {{- include "server.database-env" . | nindent 8 }}
         - name: HOME
           value: /home/prefect
         {{- with (include "server.migrations.envVars" . | trim) }}

--- a/charts/prefect-server/templates/secret.yaml
+++ b/charts/prefect-server/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- $db := .Values.database | default dict -}}
+{{- $db := .Values.externalDatabase | default dict -}}
 {{- if and .Values.secret.create (not .Values.sqlite.enabled) (not $db.connectionString) (not $db.connectionStringSecretKey) (not (include "server.database-has-component-config" .)) }}
 apiVersion: v1
 kind: Secret

--- a/charts/prefect-server/templates/secret.yaml
+++ b/charts/prefect-server/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if and  .Values.secret.create (not .Values.sqlite.enabled) }}
+{{- $db := .Values.database | default dict -}}
+{{- if and .Values.secret.create (not .Values.sqlite.enabled) (not $db.connectionString) (not $db.connectionStringSecretKey) (not (include "server.database-has-component-config" .)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prefect-server/tests/database_test.yaml
+++ b/charts/prefect-server/tests/database_test.yaml
@@ -180,3 +180,132 @@ tests:
         equal:
           path: *envSecretPath
           value: my-pg-secret
+
+  - it: Should build the database connection URL from mixed values and existing secret keys
+    set:
+      postgresql:
+        enabled: false
+      sqlite:
+        enabled: false
+      database:
+        existingSecret: zalando-pg-credentials
+        driver: postgresql+asyncpg
+        usernameSecretKey: username
+        passwordSecretKey: password
+        host: postgres.internal.svc.cluster.local
+        port: "5432"
+        name: prefect
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_DRIVER
+            value: postgresql+asyncpg
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: username
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: password
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_HOST
+            value: postgres.internal.svc.cluster.local
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PORT
+            value: "5432"
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_NAME
+            value: prefect
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+            value: postgresql+asyncpg://$(PREFECT_SERVER_DATABASE_USER):$(PREFECT_SERVER_DATABASE_PASSWORD)@postgres.internal.svc.cluster.local:5432/prefect
+
+  - it: Should prefer a literal database connection string over component settings
+    set:
+      postgresql:
+        enabled: false
+      sqlite:
+        enabled: false
+      database:
+        connectionString: postgresql+asyncpg://literal:literal@example.com:5432/literal
+        existingSecret: zalando-pg-credentials
+        usernameSecretKey: username
+        passwordSecretKey: password
+        host: postgres.internal.svc.cluster.local
+        port: "5432"
+        name: prefect
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+            value: postgresql+asyncpg://literal:literal@example.com:5432/literal
+      - template: deployment.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: username
+
+  - it: Should prefer an existing secret connection string over component settings
+    set:
+      postgresql:
+        enabled: false
+      sqlite:
+        enabled: false
+      database:
+        existingSecret: database-connection
+        connectionStringSecretKey: connection-string
+        usernameSecretKey: username
+        passwordSecretKey: password
+        host: postgres.internal.svc.cluster.local
+        port: "5432"
+        name: prefect
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+            valueFrom:
+              secretKeyRef:
+                name: database-connection
+                key: connection-string
+      - template: deployment.yaml
+        notContains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: database-connection
+                key: username

--- a/charts/prefect-server/tests/database_test.yaml
+++ b/charts/prefect-server/tests/database_test.yaml
@@ -309,3 +309,136 @@ tests:
               secretKeyRef:
                 name: database-connection
                 key: username
+
+  - it: Should build the database connection URL from all literal component values
+    set:
+      postgresql:
+        enabled: false
+      sqlite:
+        enabled: false
+      externalDatabase:
+        driver: postgresql+asyncpg
+        username: prefect
+        password: prefect-password
+        host: postgres.internal.svc.cluster.local
+        port: 5432
+        name: prefect
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_DRIVER
+            value: postgresql+asyncpg
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_USER
+            value: prefect
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PASSWORD
+            value: prefect-password
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_HOST
+            value: postgres.internal.svc.cluster.local
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PORT
+            value: "5432"
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_NAME
+            value: prefect
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+            value: postgresql+asyncpg://prefect:prefect-password@postgres.internal.svc.cluster.local:5432/prefect
+
+  - it: Should build the database connection URL from all existing secret keys
+    set:
+      postgresql:
+        enabled: false
+      sqlite:
+        enabled: false
+      externalDatabase:
+        existingSecret: zalando-pg-credentials
+        driverSecretKey: driver
+        usernameSecretKey: username
+        passwordSecretKey: password
+        hostSecretKey: host
+        portSecretKey: port
+        nameSecretKey: dbname
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_DRIVER
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: driver
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: username
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: password
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: host
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PORT
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: port
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: dbname
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+            value: $(PREFECT_SERVER_DATABASE_DRIVER)://$(PREFECT_SERVER_DATABASE_USER):$(PREFECT_SERVER_DATABASE_PASSWORD)@$(PREFECT_SERVER_DATABASE_HOST):$(PREFECT_SERVER_DATABASE_PORT)/$(PREFECT_SERVER_DATABASE_NAME)

--- a/charts/prefect-server/tests/database_test.yaml
+++ b/charts/prefect-server/tests/database_test.yaml
@@ -187,7 +187,7 @@ tests:
         enabled: false
       sqlite:
         enabled: false
-      database:
+      externalDatabase:
         existingSecret: zalando-pg-credentials
         driver: postgresql+asyncpg
         usernameSecretKey: username
@@ -251,7 +251,7 @@ tests:
         enabled: false
       sqlite:
         enabled: false
-      database:
+      externalDatabase:
         connectionString: postgresql+asyncpg://literal:literal@example.com:5432/literal
         existingSecret: zalando-pg-credentials
         usernameSecretKey: username
@@ -282,7 +282,7 @@ tests:
         enabled: false
       sqlite:
         enabled: false
-      database:
+      externalDatabase:
         existingSecret: database-connection
         connectionStringSecretKey: connection-string
         usernameSecretKey: username

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -73,7 +73,7 @@ tests:
         enabled: false
       sqlite:
         enabled: false
-      database:
+      externalDatabase:
         existingSecret: zalando-pg-credentials
         driver: postgresql+asyncpg
         usernameSecretKey: username

--- a/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
+++ b/charts/prefect-server/tests/pre_upgrade_hook_test.yaml
@@ -67,6 +67,46 @@ tests:
           apiVersion: batch/v1
           kind: Job
 
+  - it: Should build the database connection URL from mixed values and existing secret keys
+    set:
+      postgresql:
+        enabled: false
+      sqlite:
+        enabled: false
+      database:
+        existingSecret: zalando-pg-credentials
+        driver: postgresql+asyncpg
+        usernameSecretKey: username
+        passwordSecretKey: password
+        host: postgres.internal.svc.cluster.local
+        port: "5432"
+        name: prefect
+    asserts:
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: username
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: zalando-pg-credentials
+                key: password
+      - template: pre-upgrade-hook.yaml
+        contains:
+          path: .spec.template.spec.containers[0].env
+          content:
+            name: PREFECT_SERVER_DATABASE_CONNECTION_URL
+            value: postgresql+asyncpg://$(PREFECT_SERVER_DATABASE_USER):$(PREFECT_SERVER_DATABASE_PASSWORD)@postgres.internal.svc.cluster.local:5432/prefect
+
   - it: Should not create pre-upgrade hook job when migrations are disabled
     set:
       migrations:
@@ -460,4 +500,3 @@ tests:
           content:
             name: MIGRATIONS_ONLY
             value: m
-

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -1423,7 +1423,7 @@
         }
       }
     },
-    "database": {
+    "externalDatabase": {
       "type": "object",
       "properties": {
         "existingSecret": { "type": "string" },

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -1423,6 +1423,31 @@
         }
       }
     },
+    "database": {
+      "type": "object",
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "connectionString": { "type": "string" },
+        "connectionStringSecretKey": { "type": "string" },
+        "driver": { "type": "string" },
+        "driverSecretKey": { "type": "string" },
+        "username": { "type": "string" },
+        "usernameSecretKey": { "type": "string" },
+        "password": { "type": "string" },
+        "passwordSecretKey": { "type": "string" },
+        "host": { "type": "string" },
+        "hostSecretKey": { "type": "string" },
+        "port": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "portSecretKey": { "type": "string" },
+        "name": { "type": "string" },
+        "nameSecretKey": { "type": "string" }
+      }
+    },
     "secret": {
       "type": "object",
       "properties": {

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -707,7 +707,10 @@ httproute:
     # -- HTTPS port for redirect (defaults to 443)
     redirectPort: 443
 
-# Database configuration
+# Database configuration for external databases only.
+# Use `postgresql` for the bundled PostgreSQL chart or `sqlite` for the embedded SQLite database.
+# Precedence: sqlite.enabled, database.connectionString, database.connectionStringSecretKey,
+# database component fields/secret keys, then legacy secret/postgresql behavior.
 database:
   # -- name of an existing Secret to read database settings from
   existingSecret: ""

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -707,40 +707,40 @@ httproute:
     # -- HTTPS port for redirect (defaults to 443)
     redirectPort: 443
 
-# Database configuration for external databases only.
+# External database configuration.
 # Use `postgresql` for the bundled PostgreSQL chart or `sqlite` for the embedded SQLite database.
-# Precedence: sqlite.enabled, database.connectionString, database.connectionStringSecretKey,
-# database component fields/secret keys, then legacy secret/postgresql behavior.
-database:
+# Precedence: sqlite.enabled, externalDatabase.connectionString, externalDatabase.connectionStringSecretKey,
+# externalDatabase component fields/secret keys, then legacy secret/postgresql behavior.
+externalDatabase:
   # -- name of an existing Secret to read database settings from
   existingSecret: ""
   # -- literal database connection URL. Takes precedence over component settings
   connectionString: ""
-  # -- key in `database.existingSecret` containing the full database connection URL
+  # -- key in `externalDatabase.existingSecret` containing the full database connection URL
   connectionStringSecretKey: ""
   # -- database driver used when composing a connection URL from components
   driver: postgresql+asyncpg
-  # -- key in `database.existingSecret` containing the database driver
+  # -- key in `externalDatabase.existingSecret` containing the database driver
   driverSecretKey: ""
   # -- database username used when composing a connection URL from components
   username: ""
-  # -- key in `database.existingSecret` containing the database username
+  # -- key in `externalDatabase.existingSecret` containing the database username
   usernameSecretKey: ""
   # -- database password used when composing a connection URL from components
   password: ""
-  # -- key in `database.existingSecret` containing the database password
+  # -- key in `externalDatabase.existingSecret` containing the database password
   passwordSecretKey: ""
   # -- database host used when composing a connection URL from components
   host: ""
-  # -- key in `database.existingSecret` containing the database host
+  # -- key in `externalDatabase.existingSecret` containing the database host
   hostSecretKey: ""
   # -- database port used when composing a connection URL from components
   port: "5432"
-  # -- key in `database.existingSecret` containing the database port
+  # -- key in `externalDatabase.existingSecret` containing the database port
   portSecretKey: ""
   # -- database name used when composing a connection URL from components
   name: ""
-  # -- key in `database.existingSecret` containing the database name
+  # -- key in `externalDatabase.existingSecret` containing the database name
   nameSecretKey: ""
 
 # Secret configuration

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -707,6 +707,39 @@ httproute:
     # -- HTTPS port for redirect (defaults to 443)
     redirectPort: 443
 
+# Database configuration
+database:
+  # -- name of an existing Secret to read database settings from
+  existingSecret: ""
+  # -- literal database connection URL. Takes precedence over component settings
+  connectionString: ""
+  # -- key in `database.existingSecret` containing the full database connection URL
+  connectionStringSecretKey: ""
+  # -- database driver used when composing a connection URL from components
+  driver: postgresql+asyncpg
+  # -- key in `database.existingSecret` containing the database driver
+  driverSecretKey: ""
+  # -- database username used when composing a connection URL from components
+  username: ""
+  # -- key in `database.existingSecret` containing the database username
+  usernameSecretKey: ""
+  # -- database password used when composing a connection URL from components
+  password: ""
+  # -- key in `database.existingSecret` containing the database password
+  passwordSecretKey: ""
+  # -- database host used when composing a connection URL from components
+  host: ""
+  # -- key in `database.existingSecret` containing the database host
+  hostSecretKey: ""
+  # -- database port used when composing a connection URL from components
+  port: "5432"
+  # -- key in `database.existingSecret` containing the database port
+  portSecretKey: ""
+  # -- database name used when composing a connection URL from components
+  name: ""
+  # -- key in `database.existingSecret` containing the database name
+  nameSecretKey: ""
+
 # Secret configuration
 secret:
   # -- whether to create a Secret containing the PostgreSQL connection string

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -718,8 +718,8 @@ externalDatabase:
   connectionString: ""
   # -- key in `externalDatabase.existingSecret` containing the full database connection URL
   connectionStringSecretKey: ""
-  # -- database driver used when composing a connection URL from components
-  driver: postgresql+asyncpg
+  # -- database driver used when composing a connection URL from components (e.g. `postgresql+asyncpg`)
+  driver: ""
   # -- key in `externalDatabase.existingSecret` containing the database driver
   driverSecretKey: ""
   # -- database username used when composing a connection URL from components
@@ -734,8 +734,8 @@ externalDatabase:
   host: ""
   # -- key in `externalDatabase.existingSecret` containing the database host
   hostSecretKey: ""
-  # -- database port used when composing a connection URL from components
-  port: "5432"
+  # -- database port used when composing a connection URL from components (e.g. `5432`)
+  port: ""
   # -- key in `externalDatabase.existingSecret` containing the database port
   portSecretKey: ""
   # -- database name used when composing a connection URL from components


### PR DESCRIPTION
### Summary

Some external database operators create immutable credential Secrets with only component keys like `username` and `password`. This adds a `database` values block that can compose the Prefect database connection URL from mixed literal values and Secret keys, including for the migration Job.

Closes #528

Specific context: https://github.com/PrefectHQ/prefect-helm/issues/528#issuecomment-4669272200

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available (using `Related to #528` per PR convention)
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt` (not applicable; no deprecation/removal)
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

The request came from users relying on the Zalando Postgres Operator, which creates credential Secrets that cannot be modified to include a full connection string. The existing `extraEnvVarsSecret` path helps deployments but does not cover the migration Job, so this keeps the database env rendering shared across server, background services, and migrations.

I kept the existing `secret.*` and bundled PostgreSQL behavior as the default path, with `database.connectionString` and `database.connectionStringSecretKey` taking precedence when the new block is used.
</details>