### PR TITLE
feat: add commonLabels to prometheus-prefect-exporter

### DIFF
--- a/charts/prometheus-prefect-exporter/README.md
+++ b/charts/prometheus-prefect-exporter/README.md
@@ -93,6 +93,7 @@ basicAuth:
 | basicAuth.authString | string | `"admin:pass"` | basic auth credentials in the format admin:<your-password> (no brackets) |
 | basicAuth.enabled | bool | `false` | enable basic auth for the exporter, for an administrator/password combination. must be enabled on the server as well |
 | basicAuth.existingSecret | string | `""` | name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string |
+| commonLabels | object | `{}` | labels to add to all deployed objects |
 | csrfAuth | bool | `false` | Enable CSRF authentication (Only set to true if Prefect Server has CSRF enabled) |
 | env | object | `{}` | Environment variables to configure application |
 | extraEnvVars | list | `[]` | array with extra environment variables to add to exporter deployment pods |

--- a/charts/prometheus-prefect-exporter/templates/deployment.yaml
+++ b/charts/prometheus-prefect-exporter/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if not .Values.autoscaling.enabled }}

--- a/charts/prometheus-prefect-exporter/templates/hpa.yaml
+++ b/charts/prometheus-prefect-exporter/templates/hpa.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/prometheus-prefect-exporter/templates/pdb.yaml
+++ b/charts/prometheus-prefect-exporter/templates/pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-prefect-exporter/templates/prometheusrule.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- with .Values.prometheusRule.additionalLabels -}}
 {{- toYaml . | nindent 4 -}}
     {{- end }}

--- a/charts/prometheus-prefect-exporter/templates/service.yaml
+++ b/charts/prometheus-prefect-exporter/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-prefect-exporter/templates/serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-prefect-exporter/templates/servicemonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/prometheus-prefect-exporter/tests/exporter_test.yaml
+++ b/charts/prometheus-prefect-exporter/tests/exporter_test.yaml
@@ -300,3 +300,48 @@ tests:
         equal:
           path: .spec.groups[0].rules[0].alert
           value: PrefectServerDown
+
+  - it: Should configure common labels on templated resources
+    set:
+      autoscaling:
+        enabled: true
+      podDisruptionBudget:
+        maxUnavailable: 1
+      prometheusRule:
+        enabled: true
+        rules: []
+      serviceAccount:
+        create: true
+      serviceMonitor:
+        enabled: true
+      commonLabels:
+        my-label: my-value
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: hpa.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: pdb.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: prometheusrule.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: service.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: serviceaccount.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value
+      - template: servicemonitor.yaml
+        equal:
+          path: .metadata.labels.my-label
+          value: my-value

--- a/charts/prometheus-prefect-exporter/values.schema.json
+++ b/charts/prometheus-prefect-exporter/values.schema.json
@@ -3,6 +3,11 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "commonLabels": {
+      "type": "object",
+      "title": "Common Labels",
+      "description": "labels to add to all deployed objects"
+    },
     "revisionHistoryLimit": {
       "type": "integer",
       "title": "Revision History Limit",

--- a/charts/prometheus-prefect-exporter/values.yaml
+++ b/charts/prometheus-prefect-exporter/values.yaml
@@ -1,3 +1,6 @@
+# -- labels to add to all deployed objects
+commonLabels: {}
+
 # -- the number of old ReplicaSets to retain to allow rollback
 revisionHistoryLimit: 10
 


### PR DESCRIPTION
### Summary

Follows the commonLabels convention used on prefect-worker and prefect-server to add
arbitrary labels to prometheus-prefect-exporter. 

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review