### PR TITLE
feat: Add seccompProfile also to the containerSecurityContext

### DIFF
--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -611,7 +611,8 @@ tests:
           runAsGroup: 2000
           procMount: Default
           seccompProfile:
-            type: RuntimeDefault
+            type: Localhost
+            localhostProfile: /profiles/restricted.json
           seLinuxOptions:
             level: "s0:c123,c456"
     asserts:
@@ -626,7 +627,11 @@ tests:
       - template: deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].securityContext.seccompProfile.type
-          value: RuntimeDefault
+          value: Localhost
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seccompProfile.localhostProfile
+          value: /profiles/restricted.json
       - template: deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].securityContext.seLinuxOptions.level
@@ -640,6 +645,8 @@ tests:
           sysctls:
             - name: net.core.somaxconn
               value: "1024"
+          seccompProfile:
+            type: RuntimeDefault
     asserts:
       - template: deployment.yaml
         equal:
@@ -649,6 +656,10 @@ tests:
         equal:
           path: .spec.template.spec.securityContext.sysctls[0].name
           value: net.core.somaxconn
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
 
   - it: Should set pod labels
     set:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -154,7 +154,49 @@
           "properties": {
             "runAsUser": { "type": ["integer", "null"] },
             "runAsNonRoot": { "type": "boolean" },
-            "fsGroup": { "type": ["integer", "null"] }
+            "fsGroup": { "type": ["integer", "null"] },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the pod",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "securityContext": {
@@ -181,6 +223,48 @@
             "capabilities": {
               "type": "object",
               "description": "capabilities to add or drop"
+            },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the pod",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
+                }
+              }
             }
           }
         },
@@ -763,6 +847,48 @@
                   }
                 }
               }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the pod",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
+                }
+              }
             }
           }
         },
@@ -985,7 +1111,49 @@
           "properties": {
             "runAsUser": { "type": ["integer", "null"] },
             "runAsNonRoot": { "type": "boolean" },
-            "fsGroup": { "type": ["integer", "null"] }
+            "fsGroup": { "type": ["integer", "null"] },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the pod",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "containerSecurityContext": {
@@ -995,7 +1163,49 @@
             "runAsNonRoot": { "type": "boolean" },
             "readOnlyRootFilesystem": { "type": "boolean" },
             "allowPrivilegeEscalation": { "type": "boolean" },
-            "capabilities": { "type": "object" }
+            "capabilities": { "type": "object" },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the container",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "podLabels": { "type": "object" },

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -167,7 +167,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],
@@ -236,7 +236,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],
@@ -767,7 +767,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],
@@ -860,7 +860,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],
@@ -1124,7 +1124,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],
@@ -1176,7 +1176,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -320,6 +320,8 @@ tests:
           runAsUser: 1002
           fsGroup: 1002
           runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
     asserts:
       - template: deployment.yaml
         equal:
@@ -333,6 +335,10 @@ tests:
         equal:
           path: .spec.template.spec.securityContext.runAsNonRoot
           value: false
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
 
   - it: Should set the correct container security context
     set:
@@ -391,7 +397,8 @@ tests:
           runAsGroup: 2000
           procMount: Default
           seccompProfile:
-            type: RuntimeDefault
+            type: Localhost
+            localhostProfile: /profiles/restricted.json
           seLinuxOptions:
             level: "s0:c123,c456"
     asserts:
@@ -406,7 +413,11 @@ tests:
       - template: deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].securityContext.seccompProfile.type
-          value: RuntimeDefault
+          value: Localhost
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seccompProfile.localhostProfile
+          value: /profiles/restricted.json
       - template: deployment.yaml
         equal:
           path: .spec.template.spec.containers[0].securityContext.seLinuxOptions.level

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -180,6 +180,48 @@
                       }
                     }
                   }
+                },
+                "seccompProfile": {
+                  "type": "object",
+                  "title": "Seccomp Profile",
+                  "description": "Seccomp profile settings for the pod",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                    },
+                    "localhostProfile": {
+                      "type": "string",
+                      "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                      "pattern": "^/.*$"
+                    }
+                  },
+                  "required": ["type"],
+                  "dependencies": {
+                    "type": {
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "type": {
+                              "enum": ["RuntimeDefault", "Unconfined"]
+                            }
+                          },
+                          "required": ["type"]
+                        },
+                        {
+                          "properties": {
+                            "type": {
+                              "enum": ["Localhost"]
+                            },
+                            "localhostProfile": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "localhostProfile"]
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             },
@@ -708,6 +750,48 @@
                   "items": {
                     "type": "string"
                   }
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "title": "Seccomp Profile",
+              "description": "Seccomp profile settings for the pod",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+                },
+                "localhostProfile": {
+                  "type": "string",
+                  "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
+                  "pattern": "^/.*$"
+                }
+              },
+              "required": ["type"],
+              "dependencies": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "required": ["type"]
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": ["Localhost"]
+                        },
+                        "localhostProfile": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "localhostProfile"]
+                    }
+                  ]
                 }
               }
             }

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -193,7 +193,7 @@
                     "localhostProfile": {
                       "type": "string",
                       "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                      "pattern": "^/.*$"
+                      "minLength": 1
                     }
                   },
                   "required": ["type"],
@@ -655,7 +655,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": [
@@ -765,7 +765,7 @@
                 "localhostProfile": {
                   "type": "string",
                   "description": "Path to the seccomp profile on the node. Required when type is 'Localhost'",
-                  "pattern": "^/.*$"
+                  "minLength": 1
                 }
               },
               "required": ["type"],


### PR DESCRIPTION
### Summary

This PR is to allow to add the `seccompProfile` also to the `containerSecurityContext`. Our company policy for Kubernetes required this setting.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
