### PR TITLE
feat: allow configuring server probe paths

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -52,6 +52,26 @@ server:
     existingSecret: prefect-basic-auth
 ```
 
+### Server Health Probes
+
+The server chart renders liveness and readiness HTTP probes when enabled. Default
+probe paths follow `server.apiBasePath`: liveness uses `/health` and readiness
+uses `/ready` under that base path.
+
+Override `server.livenessProbe.path` or `server.readinessProbe.path` when a
+deployment needs Kubernetes to check a different endpoint. For example, point
+the liveness probe at `/api/ready` if you want sustained database connectivity
+failures to restart the server pod instead of only removing it from service.
+
+```yaml
+server:
+  livenessProbe:
+    enabled: true
+    path: "/api/ready"
+  readinessProbe:
+    enabled: true
+```
+
 ## Background Services Configuration
 
 The Prefect server includes background services related to scheduling and

--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -536,6 +536,7 @@ the HorizontalPodAutoscaler.
 | server.livenessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | server.livenessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
 | server.livenessProbe.enabled | bool | `false` |  |
+| server.livenessProbe.path | string | `"{{ .Values.server.apiBasePath }}/health"` | HTTP path for the server liveness probe. |
 | server.loggingLevel | string | `"WARNING"` | sets PREFECT_LOGGING_SERVER_LEVEL |
 | server.nodeSelector | object | `{}` | node labels for server pods assignment |
 | server.podAnnotations | object | `{}` | extra annotations for server pod |
@@ -551,6 +552,7 @@ the HorizontalPodAutoscaler.
 | server.readinessProbe.config.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | server.readinessProbe.config.timeoutSeconds | int | `5` | The number of seconds to wait for a probe response before considering it as failed. |
 | server.readinessProbe.enabled | bool | `false` |  |
+| server.readinessProbe.path | string | `"{{ .Values.server.apiBasePath }}/ready"` | HTTP path for the server readiness probe. |
 | server.replicaCount | int | `1` | number of server replicas to deploy, ignored if autoscaling is enabled |
 | server.resources.limits | object | `{"cpu":"1","memory":"1Gi"}` | the requested limits for the server container |
 | server.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | the requested resources for the server container |

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -51,6 +51,26 @@ server:
     existingSecret: prefect-basic-auth
 ```
 
+### Server Health Probes
+
+The server chart renders liveness and readiness HTTP probes when enabled. Default
+probe paths follow `server.apiBasePath`: liveness uses `/health` and readiness
+uses `/ready` under that base path.
+
+Override `server.livenessProbe.path` or `server.readinessProbe.path` when a
+deployment needs Kubernetes to check a different endpoint. For example, point
+the liveness probe at `/api/ready` if you want sustained database connectivity
+failures to restart the server pod instead of only removing it from service.
+
+```yaml
+server:
+  livenessProbe:
+    enabled: true
+    path: "/api/ready"
+  readinessProbe:
+    enabled: true
+```
+
 ## Background Services Configuration
 
 The Prefect server includes background services related to scheduling and

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -152,14 +152,14 @@ spec:
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.server.apiBasePath }}/health
+              path: {{ tpl .Values.server.livenessProbe.path . | quote }}
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.livenessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.server.apiBasePath }}/ready
+              path: {{ tpl .Values.server.readinessProbe.path . | quote }}
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.readinessProbe.config | nindent 12 }}
           {{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -152,14 +152,14 @@ spec:
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ tpl .Values.server.livenessProbe.path . | quote }}
+              path: {{ tpl (.Values.server.livenessProbe.path | default (printf "%s/health" .Values.server.apiBasePath)) . | quote }}
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.livenessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ tpl .Values.server.readinessProbe.path . | quote }}
+              path: {{ tpl (.Values.server.readinessProbe.path | default (printf "%s/ready" .Values.server.apiBasePath)) . | quote }}
               port: {{ .Values.service.targetPort }}
           {{- toYaml .Values.server.readinessProbe.config | nindent 12 }}
           {{- end }}

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -321,6 +321,60 @@ tests:
           path: .spec.template.spec.containers[0].resources.limits.ephemeral-storage
           value: 200Mi
 
+  - it: Should set default probe paths when probes are enabled
+    set:
+      server:
+        livenessProbe:
+          enabled: true
+        readinessProbe:
+          enabled: true
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/health
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/ready
+
+  - it: Should set custom probe paths
+    set:
+      server:
+        livenessProbe:
+          enabled: true
+          path: /api/ready
+        readinessProbe:
+          enabled: true
+          path: /api/health
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/ready
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/health
+
+  - it: Should template default probe paths with a custom API base path
+    set:
+      server:
+        apiBasePath: /custom-api
+        livenessProbe:
+          enabled: true
+        readinessProbe:
+          enabled: true
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /custom-api/health
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /custom-api/ready
+
   - it: Should set the correct security context
     asserts:
       - template: deployment.yaml

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -338,6 +338,26 @@ tests:
           path: .spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /api/ready
 
+  - it: Should fall back to default probe paths when paths are absent
+    set:
+      server:
+        apiBasePath: /custom-api
+        livenessProbe:
+          enabled: true
+          path: null
+        readinessProbe:
+          enabled: true
+          path: null
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /custom-api/health
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /custom-api/ready
+
   - it: Should set custom probe paths
     set:
       server:

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -513,6 +513,11 @@
               "title": "Enabled",
               "description": "enable server liveness probe"
             },
+            "path": {
+              "type": "string",
+              "title": "Path",
+              "description": "HTTP path for the server liveness probe."
+            },
             "config": {
               "type": "object",
               "title": "Liveness Probe",
@@ -558,6 +563,11 @@
               "type": "boolean",
               "title": "Enabled",
               "description": "enable server readiness probe"
+            },
+            "path": {
+              "type": "string",
+              "title": "Path",
+              "description": "HTTP path for the server readiness probe."
             },
             "config": {
               "type": "object",

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -128,6 +128,8 @@ server:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:
     enabled: false
+    # -- HTTP path for the server liveness probe.
+    path: "{{ .Values.server.apiBasePath }}/health"
     config:
       # -- The number of seconds to wait before starting the first probe.
       initialDelaySeconds: 10
@@ -141,6 +143,8 @@ server:
       successThreshold: 1
   readinessProbe:
     enabled: false
+    # -- HTTP path for the server readiness probe.
+    path: "{{ .Values.server.apiBasePath }}/ready"
     config:
       # -- The number of seconds to wait before starting the first probe.
       initialDelaySeconds: 10


### PR DESCRIPTION
### Summary

Closes PrefectHQ/prefect#22412.

This updates the `prefect-server` chart so liveness and readiness HTTP probe paths can be configured independently while preserving the existing defaults. The default paths still follow `server.apiBasePath`, and users can now set `server.livenessProbe.path: "/api/ready"` when they want sustained database connectivity failures to trigger a pod restart.

The chart schema now accepts the new path fields, the deployment template renders them, Helm unit tests cover default, custom, and custom base-path behavior, and the README source includes the generated values plus a short configuration example.

### Requirements

- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [x] `Draft` status is used until ready for review
