### PR TITLE
feat(worker): add extraEnvVars support for sync-base-job-template initContainer

### DIFF
--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -386,6 +386,7 @@ worker:
 | worker.initContainer.containerSecurityContext.runAsNonRoot | bool | `true` | set init containers' security context runAsNonRoot |
 | worker.initContainer.containerSecurityContext.runAsUser | int | `1001` | set init containers' security context runAsUser, set to `null` to unset |
 | worker.initContainer.extraContainers | list | `[]` | additional sidecar containers |
+| worker.initContainer.extraEnvVars | list | `[]` | additional environment variables for the sync-base-job-template initContainer |
 | worker.initContainer.resources | object | `{}` | the resource specifications for the sync-base-job-template initContainer Defaults to the resources defined for the worker container |
 | worker.livenessProbe.config.failureThreshold | int | `3` | The number of consecutive failures allowed before considering the probe as failed. |
 | worker.livenessProbe.config.initialDelaySeconds | int | `10` | The number of seconds to wait before starting the first probe. |

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
                   key:  {{ .Values.worker.customerManagedCloudApiConfig.apiKeySecret.key }}
             {{- end }}
             {{- if .Values.worker.initContainer.extraEnvVars }}
-            {{- include "common.yplvalues.render" (dict "value" .Values.worker.initContainer.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainer.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- with .Values.worker }}
           resources: {{ coalesce .initContainer.resources .resources | toYaml | nindent 12 }}

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -156,6 +156,9 @@ spec:
                   name: {{ .Values.worker.customerManagedCloudApiConfig.apiKeySecret.name }}
                   key:  {{ .Values.worker.customerManagedCloudApiConfig.apiKeySecret.key }}
             {{- end }}
+            {{- if .Values.worker.initContainer.extraEnvVars }}
+            {{- include "common.yplvalues.render" (dict "value" .Values.worker.initContainer.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           {{- with .Values.worker }}
           resources: {{ coalesce .initContainer.resources .resources | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -439,6 +439,25 @@ tests:
           path: .spec.template.spec.initContainers[0].securityContext.seccompProfile.localhostProfile
           value: /profiles/restricted.json
 
+  - it: Should render extraEnv in sync-base-job-template initContainer
+    set:
+      worker:
+        config:
+          baseJobTemplate:
+            configuration: |
+              {}
+        initContainer:
+          extraEnvVars:
+            - name: PREFECT_API_KEY
+              value: my-api-key
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: .spec.template.spec.initContainers[0].env
+          content:
+            name: PREFECT_API_KEY
+            value: my-api-key
+
   - it: Should set pod annotations
     set:
       worker:

--- a/charts/prefect-worker/values.schema.json
+++ b/charts/prefect-worker/values.schema.json
@@ -183,6 +183,15 @@
                 }
               }
             },
+            "extraEnvVars": {
+              "type": "array",
+              "title": "Extra Env Vars",
+              "description": "additional environment variables for the sync-base-job-template initContainer",
+              "default": [],
+              "items": {
+                "type": "object"
+              }
+            },
             "extraContainers": {
               "type": "array",
               "title": "Extra Containers",

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -54,8 +54,8 @@ worker:
       allowPrivilegeEscalation: false
       # -- set init container's security context capabilities
       capabilities: {}
-      # -- additional environment variables for the sync-base-job-template initContainer
-      extraEnvVars: []
+    # -- additional environment variables for the sync-base-job-template initContainer
+    extraEnvVars: []
     # -- additional sidecar containers
     extraContainers: []
 

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -54,6 +54,8 @@ worker:
       allowPrivilegeEscalation: false
       # -- set init container's security context capabilities
       capabilities: {}
+      # -- additional environment variables for the sync-base-job-template initContainer
+      extraEnvVars: []
     # -- additional sidecar containers
     extraContainers: []
 


### PR DESCRIPTION
### Summary

Adds `worker.initContainer.extraEnvVars` to allow users to inject additional environment variables into the `sync-base-job-template` initContainer.

The initContainer currently supports environment variables only for `cloud` and `customerManagedCloud` API settings (where `PREFECT_API_KEY` is injected automatically). Users on `selfHostedServer` or those needing to pass custom environment variables to the initContainer have no native way to do so. This change adds parity with the existing `worker.extraEnvVars` field on the main worker container.

Example use case - injecting an API key from a Kubernetes Secret:

```yaml
worker:
  apiConfig: selfHostedServer
  initContainer:
    extraEnvVars:
      - name: PREFECT_API_KEY
        valueFrom:
          secretKeyRef:
            name: prefect-api-key
            key: token
```

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
