### PR TITLE
fix(prefect-worker): prevent overlapping PDB selectors with multiple workers

### DIFF
--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -10,6 +10,13 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Labels used by the PodDisruptionBudget to select a single worker deployment
+*/}}
+{{- define "worker.labels.pdbSelector" -}}
+prefect.io/worker-name: {{ include "common.names.fullname" . }}
+{{- end -}}
+
+{{/*
 Require Prefect Cloud Account ID
 */}}
 {{- define "cloud.requiredConfig.accountId" -}}

--- a/charts/prefect-worker/templates/_helpers.tpl
+++ b/charts/prefect-worker/templates/_helpers.tpl
@@ -13,7 +13,7 @@ Create the name of the service account to use
 Labels used by the PodDisruptionBudget to select a single worker deployment
 */}}
 {{- define "worker.labels.pdbSelector" -}}
-prefect.io/worker-name: {{ include "common.names.fullname" . }}
+prefect.io/worker-deployment-name: {{ include "common.names.fullname" . }}
 {{- end -}}
 
 {{/*

--- a/charts/prefect-worker/templates/deployment.yaml
+++ b/charts/prefect-worker/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: worker
         prefect-version: {{ .Chart.AppVersion }}
+        {{- if .Values.worker.podDisruptionBudget }}
+        {{- include "worker.labels.pdbSelector" . | nindent 8 }}
+        {{- end }}
         {{- if .Values.worker.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/prefect-worker/templates/pdb.yaml
+++ b/charts/prefect-worker/templates/pdb.yaml
@@ -17,5 +17,6 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: worker
+      {{- include "worker.labels.pdbSelector" . | nindent 6 }}
 {{ toYaml .Values.worker.podDisruptionBudget | indent 2 }}
 {{- end }}

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -1151,6 +1151,9 @@ tests:
       - template: pdb.yaml
         hasDocuments:
           count: 0
+      - template: deployment.yaml
+        notExists:
+          path: .spec.template.metadata.labels["prefect.io/worker-name"]
 
   - it: Should create PDB with maxUnavailable
     set:
@@ -1200,6 +1203,25 @@ tests:
         equal:
           path: .spec.minAvailable
           value: 1
+
+  - it: Should scope PDB to the worker fullname without changing the Deployment selector
+    set:
+      fullnameOverride: custom-prefect-worker
+      worker:
+        podDisruptionBudget:
+          minAvailable: 1
+    asserts:
+      - template: pdb.yaml
+        equal:
+          path: .spec.selector.matchLabels["prefect.io/worker-name"]
+          value: custom-prefect-worker
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.metadata.labels["prefect.io/worker-name"]
+          value: custom-prefect-worker
+      - template: deployment.yaml
+        notExists:
+          path: .spec.selector.matchLabels["prefect.io/worker-name"]
 
   - it: Should create PDB with unhealthyPodEvictionPolicy
     set:

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -1153,7 +1153,7 @@ tests:
           count: 0
       - template: deployment.yaml
         notExists:
-          path: .spec.template.metadata.labels["prefect.io/worker-name"]
+          path: .spec.template.metadata.labels["prefect.io/worker-deployment-name"]
 
   - it: Should create PDB with maxUnavailable
     set:
@@ -1208,20 +1208,26 @@ tests:
     set:
       fullnameOverride: custom-prefect-worker
       worker:
+        podLabels:
+          prefect.io/worker-name: runtime-worker
         podDisruptionBudget:
           minAvailable: 1
     asserts:
       - template: pdb.yaml
         equal:
-          path: .spec.selector.matchLabels["prefect.io/worker-name"]
+          path: .spec.selector.matchLabels["prefect.io/worker-deployment-name"]
+          value: custom-prefect-worker
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.metadata.labels["prefect.io/worker-deployment-name"]
           value: custom-prefect-worker
       - template: deployment.yaml
         equal:
           path: .spec.template.metadata.labels["prefect.io/worker-name"]
-          value: custom-prefect-worker
+          value: runtime-worker
       - template: deployment.yaml
         notExists:
-          path: .spec.selector.matchLabels["prefect.io/worker-name"]
+          path: .spec.selector.matchLabels["prefect.io/worker-deployment-name"]
 
   - it: Should create PDB with unhealthyPodEvictionPolicy
     set:


### PR DESCRIPTION
### Summary

When a parent chart installs multiple aliased `prefect-worker` dependencies in the same Helm release and namespace, each `PodDisruptionBudget` receives a unique resource name through `fullnameOverride`, but their selectors remain identical.  Thus, worker pods can consequently match multiple PDBs, causing Kubernetes to reject Eviction API requests during node drains.

This change adds a `prefect.io/worker-deployment-name` label, derived from `common.names.fullname`, to the worker pod template and PDB selector when a PDB is enabled.  This now enables worker pods to match a single PDB.

The change is additive: existing Deployment selectors remain unchanged, avoiding immutable-selector upgrade failures. Installations without a PDB enabled do not receive the additional label.

Tests verify that:

- The pod and PDB use the value from `fullnameOverride`
- The Deployment selector remains unchanged
- The label is absent when the PDB is disabled

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available — no related issue was found
- [x] Added/modified configuration includes a descriptive comment for documentation generation — no configuration added
- [x] Unit tests are added/updated
- [x] Deprecation/removal checks are added in `templates/NOTES.txt` — no deprecation or removal
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review
