### PR TITLE
fix(ci): run chart tests safely for forked PRs

### DIFF
--- a/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
+++ b/.github/workflows/prometheus-prefect-exporter-lint-and-test.yaml
@@ -2,7 +2,7 @@
 name: Lint and Test Prometheus Prefect Exporter Chart
 
 "on":
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -26,9 +26,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/server-lint-and-test.yaml
+++ b/.github/workflows/server-lint-and-test.yaml
@@ -2,7 +2,7 @@
 name: Lint and Test Prefect Server Chart
 
 "on":
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -12,8 +12,6 @@ permissions:
 
 jobs:
   lint_test:
-    environment: ${{
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'Acceptance Tests (External)' || '' }}
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
     strategy:
@@ -28,9 +26,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -2,7 +2,7 @@
 name: Lint and Test Prefect Worker Chart
 
 "on":
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -12,8 +12,6 @@ permissions:
 
 jobs:
   lint_test:
-    environment: ${{
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'Acceptance Tests (External)' || '' }}
     name: "lint-test (${{ matrix.kubernetes }})"
     runs-on: ubuntu-latest
     strategy:
@@ -28,9 +26,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v5
@@ -46,11 +41,14 @@ jobs:
         with:
           node_image: "kindest/node:v${{ matrix.kubernetes }}"
 
-      - name: Create API Secret for Worker Chart
+      - name: Install Prefect Server
         run: |
-          kubectl create ns prefect
-          kubectl create secret generic prefect-api-key  --from-literal=key=${{ secrets.PREFECT_CLOUD_API_KEY }} -n prefect
+          helm dependency build ./charts/prefect-server/
+          helm install prefect-server -n default ./charts/prefect-server/ \
+            --set=postgresql.auth.password=TESTING \
+            --wait \
+            --timeout 5m
 
       - name: Run chart-testing (install)
         run: |
-          ct install --config .github/linters/worker-ct.yaml --helm-extra-set-args "--set=worker.config.workPool=repo-prefect-helm-gha-workflow-tests --set=worker.cloudApiConfig.accountId=${{ secrets.PREFECT_CLOUD_ACCOUNT_ID }} --set=worker.cloudApiConfig.workspaceId=${{ secrets.PREFECT_CLOUD_WORKSPACE_ID }} --set=worker.cloudApiConfig.cloudUrl=${{ secrets.PREFECT_CLOUD_API_URL }}"
+          ct install --config .github/linters/worker-ct.yaml --helm-extra-set-args "--set=worker.config.workPool=repo-prefect-helm-gha-workflow-tests --set=worker.apiConfig=selfHostedServer --set=worker.selfHostedServerApiConfig.apiUrl=http://prefect-server.default.svc.cluster.local:4200/api"

--- a/.github/workflows/worker-lint-and-test.yaml
+++ b/.github/workflows/worker-lint-and-test.yaml
@@ -41,6 +41,9 @@ jobs:
         with:
           node_image: "kindest/node:v${{ matrix.kubernetes }}"
 
+      - name: Create worker namespace
+        run: kubectl create namespace prefect
+
       - name: Install Prefect Server
         run: |
           helm dependency build ./charts/prefect-server/


### PR DESCRIPTION
### Summary

Related to #643

Forked PR chart checks use `pull_request_target` and check out contributor code. `actions/checkout` now rejects that combination, so checks stop before lint or install.

This runs all chart checks under `pull_request` with read-only repository access. The worker install test now starts Prefect Server in kind and uses `selfHostedServer`, so it no longer requires Prefect Cloud secrets.

Local action and YAML linting, chart linting, Helm unit tests, and manifest rendering pass. This draft lets GitHub Actions validate the full Kubernetes matrix.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [ ] Added/modified configuration includes a descriptive comment for documentation generation
- [ ] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

PR #643 exposed the failure when `actions/checkout` refused to check out code from a fork. We rejected `allow-unsafe-pr-checkout` because these chart tests can run without trusted secrets. The worker now tests against a temporary Prefect Server instead of Prefect Cloud. This PR runs both the old and new workflow triggers; only `pull_request` remains after merge.

</details>
