### PR TITLE
docs: document container seccomp profiles

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -52,6 +52,20 @@ server:
     existingSecret: prefect-basic-auth
 ```
 
+### Container seccomp profile
+
+The chart passes `server.containerSecurityContext` to the server container.
+Set `seccompProfile` there when a policy requires a profile on the container.
+For a `Localhost` profile, set `localhostProfile` to a path relative to the kubelet's seccomp profile directory.
+
+```yaml
+server:
+  containerSecurityContext:
+    seccompProfile:
+      type: Localhost
+      localhostProfile: profiles/restricted.json
+```
+
 ### Health Probes
 
 The server enables startup, liveness, and readiness probes by default. Their default paths follow `server.apiBasePath`. The startup and liveness probes call `/health`, which confirms that the HTTP server responds. The readiness probe calls `/ready`, which confirms that Prefect can connect to its database. These endpoints do not check Redis connectivity.

--- a/charts/prefect-server/README.md.gotmpl
+++ b/charts/prefect-server/README.md.gotmpl
@@ -51,6 +51,20 @@ server:
     existingSecret: prefect-basic-auth
 ```
 
+### Container seccomp profile
+
+The chart passes `server.containerSecurityContext` to the server container.
+Set `seccompProfile` there when a policy requires a profile on the container.
+For a `Localhost` profile, set `localhostProfile` to a path relative to the kubelet's seccomp profile directory.
+
+```yaml
+server:
+  containerSecurityContext:
+    seccompProfile:
+      type: Localhost
+      localhostProfile: profiles/restricted.json
+```
+
 ### Health Probes
 
 The server enables startup, liveness, and readiness probes by default. Their default paths follow `server.apiBasePath`. The startup and liveness probes call `/health`, which confirms that the HTTP server responds. The readiness probe calls `/ready`, which confirms that Prefect can connect to its database. These endpoints do not check Redis connectivity.

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -580,6 +580,21 @@ tests:
           path: .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: true
 
+  - it: Should set a Localhost container seccomp profile
+    set:
+      server:
+        containerSecurityContext:
+          seccompProfile:
+            type: Localhost
+            localhostProfile: profiles/restricted.json
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seccompProfile
+          value:
+            type: Localhost
+            localhostProfile: profiles/restricted.json
+
   - it: Should unset security context
     set:
       server:

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -199,6 +199,11 @@ server:
     allowPrivilegeEscalation: false
     # -- set server container's security context capabilities
     capabilities: {}
+    # -- set the server container's seccomp profile
+    # For `Localhost`, use a path relative to the kubelet's seccomp profile directory
+    # seccompProfile:
+    #   type: Localhost
+    #   localhostProfile: profiles/restricted.json
 
   # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
   # -- Specifies the strategy used to replace old Pods by new ones. Type can be "Recreate" or "RollingUpdate".

--- a/charts/prefect-worker/README.md
+++ b/charts/prefect-worker/README.md
@@ -157,6 +157,20 @@ Workers each have a type corresponding to the execution environment to which the
 
 ## Additional Worker Configurations
 
+### Container seccomp profile
+
+The chart passes `worker.containerSecurityContext` to the worker container.
+Set `seccompProfile` there when a policy requires a profile on the container.
+For a `Localhost` profile, set `localhostProfile` to a path relative to the kubelet's seccomp profile directory.
+
+```yaml
+worker:
+  containerSecurityContext:
+    seccompProfile:
+      type: Localhost
+      localhostProfile: profiles/restricted.json
+```
+
 ### Basic Auth
 
 Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)

--- a/charts/prefect-worker/README.md.gotmpl
+++ b/charts/prefect-worker/README.md.gotmpl
@@ -157,6 +157,20 @@ Workers each have a type corresponding to the execution environment to which the
 
 ## Additional Worker Configurations
 
+### Container seccomp profile
+
+The chart passes `worker.containerSecurityContext` to the worker container.
+Set `seccompProfile` there when a policy requires a profile on the container.
+For a `Localhost` profile, set `localhostProfile` to a path relative to the kubelet's seccomp profile directory.
+
+```yaml
+worker:
+  containerSecurityContext:
+    seccompProfile:
+      type: Localhost
+      localhostProfile: profiles/restricted.json
+```
+
 ### Basic Auth
 
 Prefect documentation on [basic auth](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings)

--- a/charts/prefect-worker/tests/worker_test.yaml
+++ b/charts/prefect-worker/tests/worker_test.yaml
@@ -360,6 +360,21 @@ tests:
           path: .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: true
 
+  - it: Should set a Localhost container seccomp profile
+    set:
+      worker:
+        containerSecurityContext:
+          seccompProfile:
+            type: Localhost
+            localhostProfile: profiles/restricted.json
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.containers[0].securityContext.seccompProfile
+          value:
+            type: Localhost
+            localhostProfile: profiles/restricted.json
+
   - it: Should unset the security context
     set:
       worker:

--- a/charts/prefect-worker/values.yaml
+++ b/charts/prefect-worker/values.yaml
@@ -274,6 +274,11 @@ worker:
     allowPrivilegeEscalation: false
     # -- set worker container's security context capabilities
     capabilities: {}
+    # -- set the worker container's seccomp profile
+    # For `Localhost`, use a path relative to the kubelet's seccomp profile directory
+    # seccompProfile:
+    #   type: Localhost
+    #   localhostProfile: profiles/restricted.json
 
   # -- Custom container command arguments
   args: []


### PR DESCRIPTION
### Summary

Related to #634

The server and worker charts already pass arbitrary container security context fields to Kubernetes. This draft documents how to configure a container-level seccomp profile without changing chart defaults.

Dedicated unit tests confirm that each chart renders a `Localhost` profile and its relative `localhostProfile` path.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Added/modified configuration includes a descriptive comment for documentation generation
- [x] Unit tests are added/updated
- [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
- [x] Relevant labels are added
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

PR #634 proposes explicit schema entries for these values. Review showed that both charts already support them through their existing security context pass-through. This PR separates the documentation and unit coverage from the schema validation changes.

</details>
