### PR TITLE
chore(renovate): disable prometheus-prefect-exporter image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,14 @@
       ],
       "datasourceTemplate": "docker"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Do not open update PRs for the prometheus-prefect-exporter image. The release workflow pins the chart to the latest exporter tag at build time, and v2/v3 ship breaking metric changes.",
+      "matchPackageNames": [
+        "prefecthq/prometheus-prefect-exporter"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Disables Renovate PRs for the `prefecthq/prometheus-prefect-exporter` image.

The release workflow (`prometheus-exporter-helm-release.yaml`) rewrites the `values.yaml` tag to the latest exporter git tag at build time, so Renovate bumps to that file are cosmetic. v2/v3 also ship breaking metric changes (`flow_run_info` Gauge→Counter, removed high-cardinality labels).

Supersedes #656 / #670 / #671, which can be closed.