### PR TITLE
feat(prefect-server): allow disabling service account token automount

### DIFF
--- a/charts/prefect-server/README.md
+++ b/charts/prefect-server/README.md
@@ -377,6 +377,7 @@ the HorizontalPodAutoscaler.
 |-----|------|---------|-------------|
 | backgroundServices.affinity | object | `{}` | affinity for background-services pod assignment |
 | backgroundServices.args | list | `[]` | Custom container command arguments |
+| backgroundServices.automountServiceAccountToken | bool | `true` | whether the background services pod mounts a service account API token. background services do not call the kubernetes api, so this can be set to false |
 | backgroundServices.command | list | `[]` | Custom container entrypoint |
 | backgroundServices.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | set background-services containers' security context allowPrivilegeEscalation |
 | backgroundServices.containerSecurityContext.capabilities | object | `{}` | set background-services container's security context capabilities |
@@ -420,6 +421,7 @@ the HorizontalPodAutoscaler.
 | backgroundServices.revisionHistoryLimit | int | `10` | the number of old ReplicaSets to retain to allow rollback |
 | backgroundServices.runAsSeparateDeployment | bool | `false` |  |
 | backgroundServices.serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
+| backgroundServices.serviceAccount.automountServiceAccountToken | bool | `true` | whether the created service account allows automounting of its API token |
 | backgroundServices.serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | backgroundServices.serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template with "-background-services" appended |
 | backgroundServices.terminationGracePeriodSeconds | string | `nil` | duration in seconds the background-services pod needs to terminate gracefully. Increase if background services need more time to finish in-flight work or close connections to backing services (e.g. Redis, Postgres) before SIGKILL. Leave null to use Kubernetes' default (30s). |
@@ -538,6 +540,7 @@ the HorizontalPodAutoscaler.
 | server.affinity | object | `{}` | affinity for server pods assignment |
 | server.apiBasePath | string | `"/api"` | sets PREFECT_SERVER_API_BASE_PATH |
 | server.args | list | `[]` | Custom container command arguments |
+| server.automountServiceAccountToken | bool | `true` | whether the server pod mounts a service account API token. the server does not call the kubernetes api, so this can be set to false |
 | server.autoscaling.enabled | bool | `false` | enable autoscaling for server |
 | server.autoscaling.maxReplicas | int | `100` | maximum number of server replicas |
 | server.autoscaling.minReplicas | int | `1` | minimum number of server replicas |
@@ -613,6 +616,7 @@ the HorizontalPodAutoscaler.
 | service.targetPort | int | `4200` | target port of the server pod; also sets PREFECT_SERVER_API_PORT |
 | service.type | string | `"ClusterIP"` | service type |
 | serviceAccount.annotations | object | `{}` | additional service account annotations (evaluated as a template) |
+| serviceAccount.automountServiceAccountToken | bool | `true` | whether the created service account allows automounting of its API token |
 | serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | the name of the service account to use. if not set and create is true, a name is generated using the common.names.fullname template |
 | sqlite.enabled | bool | `false` | enable use of the embedded SQLite database |

--- a/charts/prefect-server/templates/background-services/deployment.yaml
+++ b/charts/prefect-server/templates/background-services/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ if .Values.backgroundServices.serviceAccount.create }}{{ template "backgroundServices.serviceAccountName" . }}{{ else if .Values.backgroundServices.serviceAccount.name }}{{ .Values.backgroundServices.serviceAccount.name }}{{ else }}{{ template "server.serviceAccountName" . }}{{ end }}
+      automountServiceAccountToken: {{ .Values.backgroundServices.automountServiceAccountToken }}
       {{- if .Values.backgroundServices.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.backgroundServices.affinity "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/prefect-server/templates/background-services/serviceaccount.yaml
+++ b/charts/prefect-server/templates/background-services/serviceaccount.yaml
@@ -19,4 +19,5 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.backgroundServices.serviceAccount.annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.backgroundServices.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/prefect-server/templates/deployment.yaml
+++ b/charts/prefect-server/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ template "server.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
       {{- if .Values.server.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.server.affinity "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/prefect-server/templates/pre-upgrade-hook.yaml
+++ b/charts/prefect-server/templates/pre-upgrade-hook.yaml
@@ -29,6 +29,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "server.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
       restartPolicy: {{ .Values.migrations.restartPolicy }}
       containers:
       - name: pre-upgrade-migration

--- a/charts/prefect-server/templates/serviceaccount.yaml
+++ b/charts/prefect-server/templates/serviceaccount.yaml
@@ -19,4 +19,5 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/prefect-server/tests/server_test.yaml
+++ b/charts/prefect-server/tests/server_test.yaml
@@ -1044,3 +1044,30 @@ tests:
             - prefect
             - worker
             - start
+
+  - it: Should mount the service account token by default
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.automountServiceAccountToken
+          value: true
+      - template: serviceaccount.yaml
+        equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: Should not mount the service account token when disabled
+    set:
+      server:
+        automountServiceAccountToken: false
+      serviceAccount:
+        automountServiceAccountToken: false
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: .spec.template.spec.automountServiceAccountToken
+          value: false
+      - template: serviceaccount.yaml
+        equal:
+          path: automountServiceAccountToken
+          value: false

--- a/charts/prefect-server/values.schema.json
+++ b/charts/prefect-server/values.schema.json
@@ -302,6 +302,11 @@
             }
           }
         },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "title": "Automount Service Account Token",
+          "description": "mount a service account API token in the server pod"
+        },
         "priorityClassName": {
           "type": "string",
           "title": "Priority Class Name",
@@ -858,6 +863,11 @@
           "description": "number of background-services replicas to deploy",
           "minimum": 1
         },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "title": "Automount Service Account Token",
+          "description": "mount a service account API token in the background services pod"
+        },
         "priorityClassName": {
           "type": "string",
           "description": "priority class name to use for the background-services pods"
@@ -1033,6 +1043,11 @@
               "type": "object",
               "title": "Annotations",
               "description": "annotations to add to the background services service account"
+            },
+            "automountServiceAccountToken": {
+              "type": "boolean",
+              "title": "Automount Service Account Token",
+              "description": "allow automounting of the API token on the created service account"
             }
           }
         },
@@ -1373,6 +1388,11 @@
           "type": "object",
           "title": "Annotations",
           "description": "annotations to add to the server service account"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "title": "Automount Service Account Token",
+          "description": "allow automounting of the API token on the created service account"
         }
       }
     },

--- a/charts/prefect-server/values.yaml
+++ b/charts/prefect-server/values.yaml
@@ -49,6 +49,9 @@ server:
     # -- name of existing secret containing basic auth credentials. takes precedence over authString. must contain a key `auth-string` with the value of the auth string
     existingSecret: ""
 
+  # -- whether the server pod mounts a service account API token. the server does not call the kubernetes api, so this can be set to false
+  automountServiceAccountToken: true
+
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   # -- priority class name to use for the server pods; if the priority class is empty or doesn't exist, the server pods are scheduled without a priority class
   priorityClassName: ""
@@ -449,6 +452,11 @@ backgroundServices:
     name: ""
     # -- additional service account annotations (evaluated as a template)
     annotations: {}
+    # -- whether the created service account allows automounting of its API token
+    automountServiceAccountToken: true
+
+  # -- whether the background services pod mounts a service account API token. background services do not call the kubernetes api, so this can be set to false
+  automountServiceAccountToken: true
 
   # Configuration for background service messaging using Redis
   messaging:
@@ -519,6 +527,8 @@ serviceAccount:
   name: ""
   # -- additional service account annotations (evaluated as a template)
   annotations: {}
+  # -- whether the created service account allows automounting of its API token
+  automountServiceAccountToken: true
 
 ## Service configuration
 service:


### PR DESCRIPTION
### Summary

  The `prefect-server` chart always mounts a service account API token into the
  server, background-services and pre-upgrade-hook pods, and there is no value to
  turn it off. Prefect Server does not call the Kubernetes API — only the worker
  does, to create flow run jobs — so the token is a credential sitting in a pod
  that has no use for it. Clusters that enforce CIS Kubernetes Benchmark 5.1.6
  ("ensure that Service Account Tokens are only mounted where necessary") flag
  this, and today the only workaround is patching the `default` ServiceAccount
  outside of Helm.

  This adds `automountServiceAccountToken` to:

  - `server` and `backgroundServices` pod specs (`deployment.yaml`,
    `background-services/deployment.yaml`, `pre-upgrade-hook.yaml`)
  - both ServiceAccount templates (`serviceaccount.yaml`,
    `background-services/serviceaccount.yaml`)

  Both pod-level and ServiceAccount-level knobs are needed: the SA-level one has
  no effect when `serviceAccount.create: false` and the deployment runs under an
  externally managed service account.

  All four values default to `true`, so rendered output is unchanged unless a user
  opts in. The bundled `postgresql` and `redis` subcharts already expose the same
  setting, so this brings the chart's own resources in line.

  Verified locally: `helm unittest` (220 tests, incl. 2 new ones covering the
  default and the disabled case), `ct lint`, `helm-docs` regeneration (README diff
  is exactly the four new value rows), and `yamllint --strict`.

  ### Requirements

  - [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
  - [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
  - [ ] Body includes `Closes <issue>`, if available
  - [x] Added/modified configuration includes a descriptive comment for documentation generation
  - [x] Unit tests are added/updated
  - [ ] Deprecation/removal checks are added in `templates/NOTES.txt`
  - [ ] Relevant labels are added
  - [ ] `Draft` status is used until ready for review